### PR TITLE
Implement prepend

### DIFF
--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -331,6 +331,7 @@ public:
     using ANCESTORS_store = InlinedVector<ExpressionPtr, EXPECTED_ANCESTORS_COUNT>;
 
     ANCESTORS_store ancestors;
+    ANCESTORS_store prependers;
     ANCESTORS_store singletonAncestors;
 
     ClassDef(core::LocOffsets loc, core::LocOffsets declLoc, core::ClassOrModuleRef symbol, ExpressionPtr name,

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -140,9 +140,14 @@ public:
         return mixins_;
     }
 
+    inline const InlinedVector<ClassOrModuleRef, 4> &prepended_mixins() const {
+        ENFORCE_NO_TIMER(isClassOrModule());
+        return prepended_mixins_;
+    }
+
     // Attempts to add the given mixin to the symbol. If the mixin is invalid because it is not a module, it returns
     // `false` (but still adds the mixin for processing during linearization) and the caller should report an error.
-    [[nodiscard]] bool addMixin(const GlobalState &gs, ClassOrModuleRef sym);
+    [[nodiscard]] bool addMixin(const GlobalState &gs, ClassOrModuleRef sym, bool prepend = false);
 
     inline InlinedVector<SymbolRef, 4> &typeMembers() {
         ENFORCE(isClassOrModule());
@@ -690,6 +695,7 @@ private:
      *   Resolver::finalize(), these will be rewritten to `Object()`.
      */
     InlinedVector<ClassOrModuleRef, 4> mixins_;
+    InlinedVector<ClassOrModuleRef, 4> prepended_mixins_;
 
     /** For Class or module - ordered type members of the class,
      * for method - ordered type generic type arguments of the class

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -87,6 +87,7 @@ NameDef names[] = {
     {"argPresent", "<argPresent>"},
     // end CFG temporaries
 
+    {"prepend"},
     {"include"},
     {"extend"},
     {"currentFile", "__FILE__"},

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1499,6 +1499,8 @@ class TreeSymbolizer {
         ast::ClassDef::ANCESTORS_store *dest;
         if (send->fun == core::Names::include()) {
             dest = &klass.ancestors;
+        } else if (send->fun == core::Names::prepend()) {
+            dest = &klass.prependers;
         } else if (send->fun == core::Names::extend()) {
             dest = &klass.singletonAncestors;
         } else {

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1533,14 +1533,16 @@ class TreeSymbolizer {
                 dest->emplace_back(arg.deepCopy());
                 continue;
             }
-            if (isValidAncestor(arg)) {
-                dest->emplace_back(arg.deepCopy());
-            } else {
+
+            if (!isValidAncestor(arg)) {
                 if (auto e = ctx.beginError(arg.loc(), core::errors::Namer::AncestorNotConstant)) {
                     e.setHeader("`{}` must only contain constant literals", send->fun.show(ctx));
                 }
                 arg = ast::MK::EmptyTree();
+                continue;
             }
+
+            dest->emplace_back(arg.deepCopy());
         }
     }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This PR implements `prepend` logic. It adds a lot of copy pasted code to mirror `mixins()` and `ancestors` to get around the fact that Sorbet does not add the class itself to the ancestors list and also the first ancestor has special meaning being the superclass.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Addresses https://github.com/sorbet/sorbet/issues/259.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This should type check properly and show `No errors! Great job.`:

```ruby
module Including
  def foo a, b, c; end
  def bar a, b, c; end
  def baz a, b, c; end
end

module Prepending
  def foo a; end
end

class A
  include Including
  prepend Prepending
  
  def foo a, b; end
  def bar a, b; end
end

# foo comes from Prepending
A.new.foo 1
# bar comes from A (the class itself)
A.new.bar 1, 2
# baz somes from Including
A.new.baz 1, 2, 3
```

If the approach is ok, I'm more than willing to do add some tests and do TDT to polish the edge cases (i.e. prependers ordering).
