### PR TITLE
Fix usage of `setup` for `Minitest::Test` subclasses

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -293,6 +293,10 @@ NameDef names[] = {
     {"ActiveSupport", "ActiveSupport", true},
     {"Concern", "Concern", true},
 
+    {"Minitest", "Minitest", true},
+
+    {"name"},
+
     {"instance"},
     {"normal"},
     {"genericPropGetter"},

--- a/rewriter/Minitest.h
+++ b/rewriter/Minitest.h
@@ -33,6 +33,7 @@ namespace sorbet::rewriter {
 class Minitest final {
 public:
     static std::vector<ast::ExpressionPtr> run(core::MutableContext ctx, bool isClass, ast::Send *send);
+    static void run(core::MutableContext ctx, ast::ClassDef *klass);
 
     Minitest() = delete;
 };

--- a/rewriter/rewriter.cc
+++ b/rewriter/rewriter.cc
@@ -54,6 +54,7 @@ public:
         Singleton::run(ctx, classDef);
         Concern::run(ctx, classDef);
         TestCase::run(ctx, classDef);
+        Minitest::run(ctx, classDef);
 
         for (auto &extension : ctx.state.semanticExtensions) {
             extension->run(ctx, classDef);

--- a/test/testdata/rewriter/minitest.rb
+++ b/test/testdata/rewriter/minitest.rb
@@ -88,3 +88,45 @@ module Mod
   class C
   end
 end
+
+module Minitest
+  class Test
+  end
+end
+
+class BestCaseTestClass < Minitest::Test
+  extend T::Sig
+
+  sig { params(a: T.untyped, b: T.untyped).void }
+  def assert_equal(a, b); end
+
+  def setup
+    @x = T.let(1, Integer)
+  end
+
+  test "it works" do
+    assert_equal 1, @x
+  end
+end
+
+class SetupWithInitializerTest < Minitest::Test
+  extend T::Sig
+
+  sig { params(a: T.untyped, b: T.untyped).void }
+  def assert_equal(a, b); end
+
+  sig { params(name: T.untyped).void }
+  def initialize(name)
+    super(name)
+    @a = T.let(3, Integer)
+  end
+
+  def setup
+    @b = T.let(4, Integer)
+  end
+
+  test "it works" do
+    assert_equal 3, @a
+    assert_equal 4, @b
+  end
+end

--- a/test/testdata/rewriter/minitest.rb
+++ b/test/testdata/rewriter/minitest.rb
@@ -1,83 +1,83 @@
 # typed: true
 class MyTest
-    def outside_method
+  def outside_method
+  end
+
+  it "works outside" do
+    outside_method
+  end
+
+  it "allows constants inside of IT" do
+    CONST = 10
+  end
+
+  it "allows let-ed constants inside of IT" do
+    C2 = T.let(10, Integer)
+  end
+
+  it "allows path constants inside of IT" do
+    C3 = Mod::C
+    C3.new
+  end
+
+  it "finds errors in the test name: #{bad_variable}" do # error: Method `bad_variable` does not exist on `T.class_of(MyTest)`
+  end
+
+  describe "some inner tests" do
+    def inside_method
     end
 
-    it "works outside" do
-        outside_method
+    it "works inside" do
+      outside_method
+      inside_method
     end
+  end
 
-    it "allows constants inside of IT" do
-      CONST = 10
+  def instance_helper; end
+
+  before do
+    @foo = T.let(3, Integer)
+    instance_helper
+  end
+
+  after do
+    @foo = nil # error: Expected `Integer` but found `NilClass` for field
+    instance_helper
+  end
+
+  it 'can read foo' do
+    T.assert_type!(@foo, Integer)
+    instance_helper
+  end
+
+  def self.random_method
+  end
+
+  random_method do
+    @random_method_ivar = T.let(3, Integer) # error: The instance variable `@random_method_ivar` must be declared inside `initialize`
+  end
+
+  describe Object do
+    it Object do
     end
-
-    it "allows let-ed constants inside of IT" do
-      C2 = T.let(10, Integer)
+    it Object do
     end
+  end
 
-    it "allows path constants inside of IT" do
-      C3 = Mod::C
-      C3.new
-    end
+  def self.it(*args)
+  end
+  it "ignores methods without a block"
 
-    it "finds errors in the test name: #{bad_variable}" do # error: Method `bad_variable` does not exist on `T.class_of(MyTest)`
-    end
+  junk.it "ignores non-self calls" do
+    junk
+  end
 
-    describe "some inner tests" do
-        def inside_method
-        end
-
-        it "works inside" do
-            outside_method
-            inside_method
-        end
-    end
-
-    def instance_helper; end
-
-    before do
-        @foo = T.let(3, Integer)
-        instance_helper
-    end
-
-    after do
-        @foo = nil # error: Expected `Integer` but found `NilClass` for field
-        instance_helper
-    end
-
-    it 'can read foo' do
-        T.assert_type!(@foo, Integer)
-        instance_helper
-    end
-
-    def self.random_method
-    end
-
-    random_method do
-        @random_method_ivar = T.let(3, Integer) # error: The instance variable `@random_method_ivar` must be declared inside `initialize`
-    end
-
-    describe Object do
-        it Object do
-        end
-        it Object do
-        end
-    end
-
-    def self.it(*args)
-    end
-    it "ignores methods without a block"
-
-    junk.it "ignores non-self calls" do
-        junk
-    end
-
-    describe "a non-ideal situation" do
-      it "contains nested describes" do
-        describe "nobody should write this but we should still parse it" do
-        end
+  describe "a non-ideal situation" do
+    it "contains nested describes" do
+      describe "nobody should write this but we should still parse it" do
       end
     end
+  end
 end
 
 def junk

--- a/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
@@ -234,4 +234,93 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     class <emptyTree>::<C C><<C <todo sym>>> < (::<todo sym>)
     end
   end
+
+  module <emptyTree>::<C Minitest><<C <todo sym>>> < ()
+    class <emptyTree>::<C Test><<C <todo sym>>> < (::<todo sym>)
+    end
+  end
+
+  class <emptyTree>::<C BestCaseTestClass><<C <todo sym>>> < (<emptyTree>::<C Minitest>::<C Test>)
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.params(:a, <emptyTree>::<C T>.untyped(), :b, <emptyTree>::<C T>.untyped()).void()
+    end
+
+    def assert_equal<<todo method>>(a, b, &<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:name, ::T.untyped()).void()
+    end
+
+    def initialize<<todo method>>(name, &<blk>)
+      @x = <cast:let>(1, <todo sym>, <emptyTree>::<C Integer>)
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.void()
+    end
+
+    def test_it_works<<todo method>>(&<blk>)
+      <self>.assert_equal(1, @x)
+    end
+
+    <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+    <runtime method definition of assert_equal>
+
+    <runtime method definition of initialize>
+
+    <runtime method definition of test_it_works>
+  end
+
+  class <emptyTree>::<C SetupWithInitializerTest><<C <todo sym>>> < (<emptyTree>::<C Minitest>::<C Test>)
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.params(:a, <emptyTree>::<C T>.untyped(), :b, <emptyTree>::<C T>.untyped()).void()
+    end
+
+    def assert_equal<<todo method>>(a, b, &<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.params(:name, <emptyTree>::<C T>.untyped()).void()
+    end
+
+    def initialize<<todo method>>(name, &<blk>)
+      begin
+        <self>.<super>(name)
+        @a = <cast:let>(3, <todo sym>, <emptyTree>::<C Integer>)
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:name, ::T.untyped()).void()
+    end
+
+    def initialize<<todo method>>(name, &<blk>)
+      @b = <cast:let>(4, <todo sym>, <emptyTree>::<C Integer>)
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.void()
+    end
+
+    def test_it_works<<todo method>>(&<blk>)
+      begin
+        <self>.assert_equal(3, @a)
+        <self>.assert_equal(4, @b)
+      end
+    end
+
+    <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+    <runtime method definition of assert_equal>
+
+    <runtime method definition of initialize>
+
+    <runtime method definition of initialize>
+
+    <runtime method definition of test_it_works>
+  end
 end


### PR DESCRIPTION
_(Opening in Shopify/sorbet to collect some team feedback, but will not merge it here)_

This PR adds a rewriter that moves the content of the `setup` method inside a synthetic initializer for immediate sublcasses of `Minitest::Test`;  we do something very similar for `ActiveSupport::TestCase`.

One limitation is that this only works on **immediate** subclasses of `Minitest::Test`, given that at this stage we don't really have more information about the class hierarchy.

Note for reviewers: the first commit is the only one that matters; the second is only fixing indentation in one of the test files.

### Motivation

Currently, Sorbet doesn't allow non-nilable instance variables to be declared inside the `setup` method:

```rb
class Bar < Minitest::Test
  def setup
    @foo = T.let(42, Integer) # Error: The instance variable `@foo` must be declared inside `initialize` or declared `nilable`
  end
end
```

[[sorbet.run](https://sorbet.run/#%23%20typed%3A%20true%0A%0Amodule%20Minitest%0A%20%20class%20Test%0A%20%20%20%20def%20setup%3B%20end%0A%20%20end%0Aend%0A%0Aclass%20Bar%20%3C%20Minitest%3A%3ATest%0A%20%20def%20setup%0A%20%20%20%20%40foo%20%3D%20T.let%2842%2C%20Integer%29%0A%20%20end%0Aend)]

The current limitation on `setup` methods forces us to use some workarounds that are not the right way to use Minitest:

https://github.com/Shopify/rbi-central/blob/b5ccbb05ce75753b032679b42b005ee8004a8727/gem/test/test_helper.rb#L142

### Test plan
See included automated tests.
