### PR TITLE
Implement Prism -> Sorbet translation for constant references

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -17,6 +17,13 @@ std::unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
 
             return make_unique<parser::Blockarg>(parser.translateLocation(loc), gs.enterNameUTF8(name));
         }
+        case PM_CONSTANT_READ_NODE: { // A single, unnested, non-fully qualified constant like "Foo"
+            auto constantReadNode = reinterpret_cast<pm_constant_read_node *>(node);
+            pm_location_t *loc = &constantReadNode->base.location;
+            std::string_view name = parser.resolveConstant(constantReadNode->name);
+
+            return make_unique<parser::Const>(parser.translateLocation(loc), nullptr, gs.enterNameConstant(name));
+        }
         case PM_DEF_NODE: {
             auto defNode = reinterpret_cast<pm_def_node *>(node);
             pm_location_t *loc = &defNode->base.location;
@@ -286,7 +293,6 @@ std::unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
         case PM_CONSTANT_PATH_OR_WRITE_NODE:
         case PM_CONSTANT_PATH_TARGET_NODE:
         case PM_CONSTANT_PATH_WRITE_NODE:
-        case PM_CONSTANT_READ_NODE:
         case PM_CONSTANT_TARGET_NODE:
         case PM_CONSTANT_WRITE_NODE:
         case PM_DEFINED_NODE:

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -26,7 +26,12 @@ std::unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
 
             std::unique_ptr<parser::Node> parent;
             if (constantPathNode->parent) {
+                // This constant reference is chained onto another constant reference.
+                // E.g. if `node` is pointing to `B`, then then `A` is the `parent` in `A::B::C`.
                 parent = translate(reinterpret_cast<pm_node *>(constantPathNode->parent));
+            } else { // This is a fully qualified constant reference, like `::A`.
+                pm_location_t *delimiterLoc = &constantPathNode->delimiter_loc; // The location of the `::`
+                parent = make_unique<parser::Cbase>(parser.translateLocation(delimiterLoc));
             }
 
             return make_unique<parser::Const>(parser.translateLocation(loc), std::move(parent),

--- a/test/prism_regression/constants.parse-tree.exp
+++ b/test/prism_regression/constants.parse-tree.exp
@@ -1,4 +1,15 @@
-Const {
-  scope = NULL
-  name = <C <U SimpleConstant>>
+Begin {
+  stmts = [
+    Const {
+      scope = NULL
+      name = <C <U SimpleConstant>>
+    }
+    Const {
+      scope = Const {
+        scope = NULL
+        name = <C <U Nested>>
+      }
+      name = <C <U Constant>>
+    }
+  ]
 }

--- a/test/prism_regression/constants.parse-tree.exp
+++ b/test/prism_regression/constants.parse-tree.exp
@@ -1,0 +1,4 @@
+Const {
+  scope = NULL
+  name = <C <U SimpleConstant>>
+}

--- a/test/prism_regression/constants.parse-tree.exp
+++ b/test/prism_regression/constants.parse-tree.exp
@@ -11,5 +11,18 @@ Begin {
       }
       name = <C <U Constant>>
     }
+    Const {
+      scope = Cbase {
+      }
+      name = <C <U FullyQualifiedConstant>>
+    }
+    Const {
+      scope = Const {
+        scope = Cbase {
+        }
+        name = <C <U FullyQualified>>
+      }
+      name = <C <U NestedConstant>>
+    }
   ]
 }

--- a/test/prism_regression/constants.rb
+++ b/test/prism_regression/constants.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+ SimpleConstant
+#^^^^^^^^^^^^^^ error: Unable to resolve constant `SimpleConstant`

--- a/test/prism_regression/constants.rb
+++ b/test/prism_regression/constants.rb
@@ -5,3 +5,9 @@
 
  Nested::Constant
 #^^^^^^ error: Unable to resolve constant `Nested`
+
+ ::FullyQualifiedConstant
+#^^^^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve constant `FullyQualifiedConstant`
+
+ ::FullyQualified::NestedConstant
+#^^^^^^^^^^^^^^^^ error: Unable to resolve constant `FullyQualified`

--- a/test/prism_regression/constants.rb
+++ b/test/prism_regression/constants.rb
@@ -2,3 +2,6 @@
 
  SimpleConstant
 #^^^^^^^^^^^^^^ error: Unable to resolve constant `SimpleConstant`
+
+ Nested::Constant
+#^^^^^^ error: Unable to resolve constant `Nested`


### PR DESCRIPTION
### Motivation

Closes #73, Closes #78.

Needed for #62, to support `class` blocks with a superclass
