### PR TITLE
Forward `build_compilation_db.sh` args to its Bazel build command

### DIFF
--- a/tools/scripts/build_compilation_db.sh
+++ b/tools/scripts/build_compilation_db.sh
@@ -4,7 +4,7 @@ set -e
 
 cd "$(dirname "$0")/../.."
 
-./bazel build //tools:compdb --config=dbg
+./bazel build //tools:compdb --config=dbg "$@"
 
 if command -v jq &> /dev/null; then
   jq . < bazel-bin/tools/compile_commands.json > compile_commands.json


### PR DESCRIPTION
### Motivation

Temporary workaround for this limitation:

https://github.com/Shopify/sorbet/blob/15372d7937c0215181122b82b44e54ac86c53492/third_party/prism.BUILD#L17-L23

Which lets you manually define the `RUBY_VERISON`:

```sh
./tools/scripts/build_compilation_db.sh --define RUBY_PATH='/opt/rubies/3.3.4/'
```
