### PR TITLE
Use a string literal as the default fallback

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -403,8 +403,16 @@ std::unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
         case PM_X_STRING_NODE:
         case PM_YIELD_NODE:
         case PM_SCOPE_NODE:
-            std::unique_ptr<parser::Node> ast;
-            return ast;
+            auto type_id = PM_NODE_TYPE(node);
+            auto type_name = pm_node_type_to_str(type_id);
+
+            fmt::memory_buffer buf;
+            fmt::format_to(std::back_inserter(buf), "Unimplemented node type {} (#{}).", type_name, type_id);
+            std::string s = fmt::to_string(buf);
+
+            auto fakeLocation = core::LocOffsets{0, 1};
+
+            return make_unique<parser::String>(fakeLocation, gs.enterNameUTF8(s));
     }
 }
 


### PR DESCRIPTION
### Motivation

Currently, an unimplemented node type just returns a `nullptr` and causes a downstream crash.

This PR replaces it with a string literal, which contains the name of the type of node that was reached. This is useful for quickly knowing "what do I need to implement next?" just from looking at the test output.

E.g. given

```rb
def foo
  while true; end
end
```

I get this failure:

```diff
test/helpers/expectations.cc:209: ERROR: Mismatch on: test/prism_regression/while.parse-tree.exp

If these changes are expected, run this script and commit the results:
tools/scripts/update_testdata_exp.sh

@@ -1,2 +1,8 @@
+DefMethod {
+  name = <U foo>
+  args = NULL
+  body = String {
+    val = <U Unimplemented node type PM_WHILE_NODE (#148).>
+  }
+}
```

Making it clear that I need to implement `case PM_WHILE_NODE` next.