### PR TITLE
Implement Prism -> Sorbet translation for `super` calls

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -419,6 +419,14 @@ std::unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             // TODO: handle different string encodings
             return make_unique<parser::String>(parser.translateLocation(loc), gs.enterNameUTF8(source));
         }
+        case PM_SUPER_NODE: {
+            auto superNode = reinterpret_cast<pm_super_node *>(node);
+            pm_location_t *loc = &superNode->base.location;
+
+            auto returnValues = translateArguments(superNode->arguments);
+
+            return make_unique<parser::Super>(parser.translateLocation(loc), std::move(returnValues));
+        }
         case PM_SYMBOL_NODE: {
             auto symNode = reinterpret_cast<pm_string_node *>(node);
             pm_location_t *loc = &symNode->base.location;
@@ -548,7 +556,6 @@ std::unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
         case PM_SOURCE_FILE_NODE:
         case PM_SOURCE_LINE_NODE:
         case PM_SPLAT_NODE:
-        case PM_SUPER_NODE:
         case PM_UNDEF_NODE:
         case PM_UNLESS_NODE:
         case PM_UNTIL_NODE:

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -193,6 +193,12 @@ std::unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
 
             return make_unique<parser::Float>(parser.translateLocation(loc), std::to_string(floatNode->value));
         }
+        case PM_FORWARDING_SUPER_NODE: { // `super` with no `(...)`
+            auto forwardingSuperNode = reinterpret_cast<pm_forwarding_super_node *>(node);
+            pm_location_t *loc = &forwardingSuperNode->base.location;
+
+            return make_unique<parser::ZSuper>(parser.translateLocation(loc));
+        }
         case PM_HASH_NODE: {
             auto usedForKeywordArgs = false;
             return translateHash(node, reinterpret_cast<pm_hash_node *>(node)->elements, usedForKeywordArgs);
@@ -481,7 +487,6 @@ std::unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
         case PM_FOR_NODE:
         case PM_FORWARDING_ARGUMENTS_NODE:
         case PM_FORWARDING_PARAMETER_NODE:
-        case PM_FORWARDING_SUPER_NODE:
         case PM_GLOBAL_VARIABLE_AND_WRITE_NODE:
         case PM_GLOBAL_VARIABLE_OPERATOR_WRITE_NODE:
         case PM_GLOBAL_VARIABLE_OR_WRITE_NODE:

--- a/test/prism_regression/super.parse-tree.exp
+++ b/test/prism_regression/super.parse-tree.exp
@@ -1,6 +1,27 @@
 DefMethod {
   name = <U m>
   args = NULL
-  body = ZSuper {
+  body = Begin {
+    stmts = [
+      ZSuper {
+      }
+      Super {
+        args = [
+        ]
+      }
+      Super {
+        args = [
+          Integer {
+            val = "1"
+          }
+          Integer {
+            val = "2"
+          }
+          Integer {
+            val = "3"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/test/prism_regression/super.parse-tree.exp
+++ b/test/prism_regression/super.parse-tree.exp
@@ -1,0 +1,6 @@
+DefMethod {
+  name = <U m>
+  args = NULL
+  body = ZSuper {
+  }
+}

--- a/test/prism_regression/super.rb
+++ b/test/prism_regression/super.rb
@@ -2,4 +2,8 @@
 
 def m
   super # Invoke super, forwarding all the arguments, unmodified
+
+  super() # Invoke super, explicitly with no arguments
+
+  super(1, 2, 3)
 end

--- a/test/prism_regression/super.rb
+++ b/test/prism_regression/super.rb
@@ -1,0 +1,5 @@
+# typed: false
+
+def m
+  super # Invoke super, forwarding all the arguments, unmodified
+end


### PR DESCRIPTION
### Motivation

Closes #93
Closes #172

Depends on the `translateArguments()` helper from #197.
