### PR TITLE
Implement Prism -> Sorbet translation for `unless` blocks

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -445,6 +445,18 @@ std::unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
 
             return make_unique<parser::True>(parser.translateLocation(loc));
         }
+        case PM_UNLESS_NODE: { // An `unless` branch, either in a statement or modifier form.
+            auto unlessNode = reinterpret_cast<pm_if_node *>(node);
+            auto *loc = &unlessNode->base.location;
+
+            auto predicate = translate(unlessNode->predicate);
+            // These are flipped relative to `PM_IF_NODE`
+            auto ifFalse = translate(reinterpret_cast<pm_node *>(unlessNode->statements));
+            auto ifTrue = translate(unlessNode->consequent);
+
+            return make_unique<parser::If>(parser.translateLocation(loc), std::move(predicate), std::move(ifTrue),
+                                           std::move(ifFalse));
+        }
         case PM_YIELD_NODE: {
             auto yieldNode = reinterpret_cast<pm_yield_node *>(node);
             pm_location_t *loc = &yieldNode->base.location;
@@ -557,7 +569,6 @@ std::unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
         case PM_SOURCE_LINE_NODE:
         case PM_SPLAT_NODE:
         case PM_UNDEF_NODE:
-        case PM_UNLESS_NODE:
         case PM_UNTIL_NODE:
         case PM_WHEN_NODE:
         case PM_WHILE_NODE:

--- a/test/prism_regression/if_with_stmt.rb
+++ b/test/prism_regression/if_with_stmt.rb
@@ -1,4 +1,4 @@
-# typed: static
+# typed: false
 
 if false
   5

--- a/test/prism_regression/unless.parse-tree.exp
+++ b/test/prism_regression/unless.parse-tree.exp
@@ -1,0 +1,8 @@
+If {
+  condition = True {
+  }
+  then_ = NULL
+  else_ = String {
+    val = <U body>
+  }
+}

--- a/test/prism_regression/unless.rb
+++ b/test/prism_regression/unless.rb
@@ -1,0 +1,5 @@
+# typed: false
+
+unless true
+  "body"
+end

--- a/test/prism_regression/unless_else.parse-tree.exp
+++ b/test/prism_regression/unless_else.parse-tree.exp
@@ -1,0 +1,10 @@
+If {
+  condition = True {
+  }
+  then_ = String {
+    val = <U else body>
+  }
+  else_ = String {
+    val = <U unless body>
+  }
+}

--- a/test/prism_regression/unless_else.rb
+++ b/test/prism_regression/unless_else.rb
@@ -1,0 +1,7 @@
+# typed: false
+
+unless true
+  "unless body"
+else
+  "else body"
+end


### PR DESCRIPTION
### Motivation

Closes #176.

### Scope

This implementation aways produces `parser::If` nodes (which interestingly enough, whitequark uses to model `unless`, too), and never `parser::UnlessGuard`, because we haven't implemented `parser::IfGuard`, either. Tracked in #204.