### PR TITLE
Fix tests for beginless ranges

### DIFF
--- a/test/prism_regression/range.parse-tree.exp
+++ b/test/prism_regression/range.parse-tree.exp
@@ -16,29 +16,45 @@ Begin {
         val = "4"
       }
     }
-    IRange {
-      from = String {
-        val = <U Has no end..>
-      }
-      to = NULL
+    Begin {
+      stmts = [
+        IRange {
+          from = String {
+            val = <U Has no end..>
+          }
+          to = NULL
+        }
+      ]
     }
-    ERange {
-      from = String {
-        val = <U Has no end...>
-      }
-      to = NULL
+    Begin {
+      stmts = [
+        ERange {
+          from = String {
+            val = <U Has no end...>
+          }
+          to = NULL
+        }
+      ]
     }
-    IRange {
-      from = NULL
-      to = String {
-        val = <U ..Has no begin>
-      }
+    Begin {
+      stmts = [
+        IRange {
+          from = NULL
+          to = String {
+            val = <U ..Has no begin>
+          }
+        }
+      ]
     }
-    ERange {
-      from = NULL
-      to = String {
-        val = <U ...Has no begin>
-      }
+    Begin {
+      stmts = [
+        ERange {
+          from = NULL
+          to = String {
+            val = <U ...Has no begin>
+          }
+        }
+      ]
     }
   ]
 }

--- a/test/prism_regression/range.rb
+++ b/test/prism_regression/range.rb
@@ -8,5 +8,6 @@
 ("Has no end.."..)
 ("Has no end..."...)
 
-.."..Has no begin"
-..."...Has no begin"
+# Sorbet's parser can't handle these without parentheses, so we use them for parity
+(.."..Has no begin")
+(..."...Has no begin")


### PR DESCRIPTION
### Motivation

Beginless ranges don't need to be parenthesized in MRI ruby:

```shell
$ cat demo.rb
..1
...2

$ ruby -c demo.rb
Syntax OK
```

... but Sorbet's parser doesn't support them. Prism does, but we'll use them just for parity.