### PR TITLE
Implement translation for `PM_BEGIN_NODE`

### DIFF
--- a/test/prism_regression/begin.parse-tree.exp
+++ b/test/prism_regression/begin.parse-tree.exp
@@ -1,0 +1,21 @@
+Begin {
+  stmts = [
+    Kwbegin {
+      stmts = [
+        Integer {
+          val = "1"
+        }
+        Integer {
+          val = "2"
+        }
+        Integer {
+          val = "3"
+        }
+      ]
+    }
+    Kwbegin {
+      stmts = [
+      ]
+    }
+  ]
+}

--- a/test/prism_regression/begin.rb
+++ b/test/prism_regression/begin.rb
@@ -1,0 +1,10 @@
+# typed: true
+
+begin
+  1
+  2
+  3
+end
+
+begin
+end


### PR DESCRIPTION
Closes #47 

### Motivation
Translates `PM_BEGIN_NODE`s from Prism to Sorbet.

These represent begin blocks, e.g.

```ruby
begin
  # ...
rescue
  # ...
end
```

Note that I haven't implemented support for `rescue` (#160), `ensure` (#86) or `else` because they're not needed for parsing the RBI gem.

### Test plan
See included automated tests.
