### PR TITLE
Shorten build by moving prism dependency

### DIFF
--- a/common/BUILD
+++ b/common/BUILD
@@ -46,7 +46,6 @@ cc_library(
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:span",
         "@spdlog",
-        "@prism",
     ],
 )
 

--- a/parser/prism/BUILD
+++ b/parser/prism/BUILD
@@ -16,5 +16,6 @@ cc_library(
     deps = [
         "//core",
         "//parser", # Legacy parser, needed for translating to its nodes defined in `parser/Node_gen.h`
+        "@prism",
     ],
 )


### PR DESCRIPTION
### Motivation
This one-line change will reduce the time it takes to build Sorbet whenever we update Prism.

### Test plan
See included automated tests.
