### PR TITLE
Add `translateMulti` helper to clean up some loops

### DIFF
--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -35,6 +35,7 @@ private:
 
     parser::NodeVec translateMulti(pm_node_list prismNodes);
     parser::NodeVec translateMulti(absl::Span<pm_node_t *> prismNodes);
+    void translateMultiInto(NodeVec &sorbetNodes, absl::Span<pm_node_t *> prismNodes);
 
     NodeVec translateArguments(pm_arguments_node *node, size_t extraCapacity = 0);
     std::unique_ptr<parser::Hash> translateHash(pm_node_t *node, pm_node_list_t elements,

--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -32,9 +32,7 @@ public:
     std::unique_ptr<parser::Node> translate(const Node &node);
 
 private:
-
     parser::NodeVec translateMulti(pm_node_list prismNodes);
-    parser::NodeVec translateMulti(absl::Span<pm_node_t *> prismNodes);
     void translateMultiInto(NodeVec &sorbetNodes, absl::Span<pm_node_t *> prismNodes);
 
     NodeVec translateArguments(pm_arguments_node *node, size_t extraCapacity = 0);

--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -32,6 +32,9 @@ public:
     std::unique_ptr<parser::Node> translate(const Node &node);
 
 private:
+
+    parser::NodeVec translateMulti(absl::Span<pm_node_t *> prismNodes);
+
     NodeVec translateArguments(pm_arguments_node *node, size_t extraCapacity = 0);
     std::unique_ptr<parser::Hash> translateHash(pm_node_t *node, pm_node_list_t elements,
                                                 bool isUsedForKeywordArguments);

--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -33,6 +33,7 @@ public:
 
 private:
 
+    parser::NodeVec translateMulti(pm_node_list prismNodes);
     parser::NodeVec translateMulti(absl::Span<pm_node_t *> prismNodes);
 
     NodeVec translateArguments(pm_arguments_node *node, size_t extraCapacity = 0);


### PR DESCRIPTION
### Motivation

Another stab at #193. We don't really need a general `map` function, because the transformation is always the same (`[this](auto &node) { return translate(node); }`).

This PR adds 3 related functions, which serve to produce a `NodeVec` from multiple Prism nodes.