### PR TITLE
Implement missed translations for anonymous `*`, `**` and `&` params

### DIFF
--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -19,6 +19,7 @@ class Translator final {
     // but don't have explicit ownership over it. We take a temporary reference to it, but we can't
     // escape that scope, which is why Translator objects can't be copied, or even moved.
     core::GlobalState &gs;
+    uint16_t uniqueCounter = 1;
 
     Translator(Translator &&) = delete;                 // Move constructor
     Translator(const Translator &) = delete;            // Copy constructor

--- a/test/prism_regression/def_all_params.parse-tree.exp
+++ b/test/prism_regression/def_all_params.parse-tree.exp
@@ -1,35 +1,56 @@
-DefMethod {
-  name = <U foo>
-  args = Args {
-    args = [
-      Arg {
-        name = <U a>
+Begin {
+  stmts = [
+    DefMethod {
+      name = <U foo>
+      args = Args {
+        args = [
+          Arg {
+            name = <U a>
+          }
+          Optarg {
+            name = <U b>
+            default_ = Integer {
+              val = "2"
+            }
+          }
+          Restarg {
+            name = <U c>
+          }
+          Kwarg {
+            name = <U d>
+          }
+          Kwoptarg {
+            name = <U e>
+            default_ = Integer {
+              val = "5"
+            }
+          }
+          Kwrestarg {
+            name = <U f>
+          }
+          Blockarg {
+            name = <U blk>
+          }
+        ]
       }
-      Optarg {
-        name = <U b>
-        default_ = Integer {
-          val = "2"
-        }
+      body = NULL
+    }
+    DefMethod {
+      name = <U foo>
+      args = Args {
+        args = [
+          Restarg {
+            name = <P <U *> $2>
+          }
+          Kwrestarg {
+            name = <P <U **> $3>
+          }
+          Blockarg {
+            name = <P <U &> $4>
+          }
+        ]
       }
-      Restarg {
-        name = <U c>
-      }
-      Kwarg {
-        name = <U d>
-      }
-      Kwoptarg {
-        name = <U e>
-        default_ = Integer {
-          val = "5"
-        }
-      }
-      Kwrestarg {
-        name = <U f>
-      }
-      Blockarg {
-        name = <U blk>
-      }
-    ]
-  }
-  body = NULL
+      body = NULL
+    }
+  ]
 }

--- a/test/prism_regression/def_all_params.rb
+++ b/test/prism_regression/def_all_params.rb
@@ -1,3 +1,5 @@
-# typed: true
+# typed: false
 
 def foo(a, b = 2, *c, d:, e: 5, **f, &blk); end
+
+def foo(*, **, &); end

--- a/test/prism_regression/def_block_param.parse-tree.exp
+++ b/test/prism_regression/def_block_param.parse-tree.exp
@@ -1,11 +1,26 @@
-DefMethod {
-  name = <U foo>
-  args = Args {
-    args = [
-      Blockarg {
-        name = <U blk>
+Begin {
+  stmts = [
+    DefMethod {
+      name = <U foo>
+      args = Args {
+        args = [
+          Blockarg {
+            name = <U blk>
+          }
+        ]
       }
-    ]
-  }
-  body = NULL
+      body = NULL
+    }
+    DefMethod {
+      name = <U foo>
+      args = Args {
+        args = [
+          Blockarg {
+            name = <P <U &> $2>
+          }
+        ]
+      }
+      body = NULL
+    }
+  ]
 }

--- a/test/prism_regression/def_block_param.rb
+++ b/test/prism_regression/def_block_param.rb
@@ -1,3 +1,5 @@
 # typed: true
 
 def foo(&blk); end
+
+def foo(&); end

--- a/test/prism_regression/def_kw_rest_params.parse-tree.exp
+++ b/test/prism_regression/def_kw_rest_params.parse-tree.exp
@@ -1,11 +1,26 @@
-DefMethod {
-  name = <U foo>
-  args = Args {
-    args = [
-      Kwrestarg {
-        name = <U a>
+Begin {
+  stmts = [
+    DefMethod {
+      name = <U foo>
+      args = Args {
+        args = [
+          Kwrestarg {
+            name = <U a>
+          }
+        ]
       }
-    ]
-  }
-  body = NULL
+      body = NULL
+    }
+    DefMethod {
+      name = <U foo>
+      args = Args {
+        args = [
+          Kwrestarg {
+            name = <P <U **> $2>
+          }
+        ]
+      }
+      body = NULL
+    }
+  ]
 }

--- a/test/prism_regression/def_kw_rest_params.rb
+++ b/test/prism_regression/def_kw_rest_params.rb
@@ -1,3 +1,5 @@
 # typed: true
 
 def foo(**a); end
+
+def foo(**); end

--- a/test/prism_regression/def_rest_params.parse-tree.exp
+++ b/test/prism_regression/def_rest_params.parse-tree.exp
@@ -1,11 +1,26 @@
-DefMethod {
-  name = <U foo>
-  args = Args {
-    args = [
-      Restarg {
-        name = <U a>
+Begin {
+  stmts = [
+    DefMethod {
+      name = <U foo>
+      args = Args {
+        args = [
+          Restarg {
+            name = <U a>
+          }
+        ]
       }
-    ]
-  }
-  body = NULL
+      body = NULL
+    }
+    DefMethod {
+      name = <U foo>
+      args = Args {
+        args = [
+          Restarg {
+            name = <P <U *> $2>
+          }
+        ]
+      }
+      body = NULL
+    }
+  ]
 }

--- a/test/prism_regression/def_rest_params.rb
+++ b/test/prism_regression/def_rest_params.rb
@@ -1,3 +1,5 @@
 # typed: true
 
 def foo(*a); end
+
+def foo(*); end


### PR DESCRIPTION
### Motivation

Further additions to #51, #124, #161.