### PR TITLE
Remove the exception from the `extractString` method

### DIFF
--- a/parser/prism/Parser.cc
+++ b/parser/prism/Parser.cc
@@ -25,11 +25,6 @@ std::string_view Parser::resolveConstant(pm_constant_id_t constant_id) {
 }
 
 std::string_view Parser::extractString(pm_string_t *string) {
-    if (string->type != pm_string_t::PM_STRING_CONSTANT && string->type != pm_string_t::PM_STRING_SHARED) {
-        Exception::raise(
-            "This string needs to be freed eventually with `pm_string_free`, but that isn't implemented yet");
-    }
-
     return std::string_view(reinterpret_cast<const char *>(pm_string_source(string)), pm_string_length(string));
 }
 


### PR DESCRIPTION
### Motivation
We assumed that the `pm_string_t` objects being passed as arguments to this method would need to be freed from memory, but because they are all referenced by nodes in the Prism AST, they will be freed once the tree is destroyed.

### Test plan
Automated tests should continue to pass.
