### PR TITLE
Handle translation of safe navigation operator

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -200,6 +200,20 @@ std::unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
                 args.emplace_back(std::move(blockPassNode));
             }
 
+            // Handle safe navigation operator
+            auto callOperatorLoc = &callNode->call_operator_loc;
+            std::string_view callOperator;
+            if (callOperatorLoc != nullptr) {
+                callOperator = std::string_view(reinterpret_cast<const char *>(callOperatorLoc->start),
+                                                callOperatorLoc->end - callOperatorLoc->start);
+            }
+
+            if (callOperator == "&.") {
+                return make_unique<parser::CSend>(parser.translateLocation(loc), std::move(receiver),
+                                                  gs.enterNameUTF8(name), parser.translateLocation(messageLoc),
+                                                  std::move(args));
+            }
+
             auto sendNode =
                 make_unique<parser::Send>(parser.translateLocation(loc), std::move(receiver), gs.enterNameUTF8(name),
                                           parser.translateLocation(messageLoc), std::move(args));

--- a/test/prism_regression/call_with_receiver.parse-tree.exp
+++ b/test/prism_regression/call_with_receiver.parse-tree.exp
@@ -22,5 +22,27 @@ Begin {
       args = [
       ]
     }
+    CSend {
+      receiver = Send {
+        receiver = NULL
+        method = <U receiver>
+        args = [
+        ]
+      }
+      method = <U foo>
+      args = [
+      ]
+    }
+    CSend {
+      receiver = Send {
+        receiver = NULL
+        method = <U receiver>
+        args = [
+        ]
+      }
+      method = <U foo>
+      args = [
+      ]
+    }
   ]
 }

--- a/test/prism_regression/call_with_receiver.rb
+++ b/test/prism_regression/call_with_receiver.rb
@@ -1,7 +1,7 @@
-# typed: true
+# typed: false
 
  receiver.foo
-#^^^^^^^^ error: Method `receiver` does not exist on `T.class_of(<root>)`
-
  receiver.foo()
-#^^^^^^^^ error: Method `receiver` does not exist on `T.class_of(<root>)`
+
+ receiver&.foo
+ receiver&.foo()


### PR DESCRIPTION
### Motivation
Parsing the RBI gem revealed that we are not correctly translating method calls with safe navigation operators, which Sorbet represents with `CSend` nodes.

This PR adds a check to the `PM_CALL_NODE` translation that handles the case of the operator being a safe navigation operator.

### Test plan
See included automated tests.
