### PR TITLE
Fix accidental fall-through into cases for `it` keyword

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -407,8 +407,7 @@ std::unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             return make_unique<parser::DString>(parser.translateLocation(loc), std::move(sorbetParts));
         }
         case PM_IT_LOCAL_VARIABLE_READ_NODE: {
-            // See Prism::ParserStorage::ParsedRubyVersion
-            unreachable("The `it` keyword was introduced in Ruby 3.4, which isn't supported by Sorbet yet.");
+            [[fallthrough]];
         }
         case PM_IT_PARAMETERS_NODE: {
             // See Prism::ParserStorage::ParsedRubyVersion

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -406,6 +406,14 @@ std::unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
 
             return make_unique<parser::DString>(parser.translateLocation(loc), std::move(sorbetParts));
         }
+        case PM_IT_LOCAL_VARIABLE_READ_NODE: {
+            // See Prism::ParserStorage::ParsedRubyVersion
+            unreachable("The `it` keyword was introduced in Ruby 3.4, which isn't supported by Sorbet yet.");
+        }
+        case PM_IT_PARAMETERS_NODE: {
+            // See Prism::ParserStorage::ParsedRubyVersion
+            unreachable("The `it` keyword was introduced in Ruby 3.4, which isn't supported by Sorbet yet.");
+        }
         case PM_KEYWORD_HASH_NODE: {
             auto usedForKeywordArgs = true;
             return translateHash(node, reinterpret_cast<pm_keyword_hash_node *>(node)->elements, usedForKeywordArgs);
@@ -861,14 +869,6 @@ std::unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
         case PM_INTERPOLATED_REGULAR_EXPRESSION_NODE:
         case PM_INTERPOLATED_SYMBOL_NODE:
         case PM_INTERPOLATED_X_STRING_NODE:
-        case PM_IT_LOCAL_VARIABLE_READ_NODE: {
-            // See Prism::ParserStorage::ParsedRubyVersion
-            unreachable("The `it` keyword was introduced in Ruby 3.4, which isn't supported by Sorbet yet.");
-        }
-        case PM_IT_PARAMETERS_NODE: {
-            // See Prism::ParserStorage::ParsedRubyVersion
-            unreachable("The `it` keyword was introduced in Ruby 3.4, which isn't supported by Sorbet yet.");
-        }
         case PM_LAMBDA_NODE:
         case PM_MATCH_LAST_LINE_NODE:
         case PM_MATCH_PREDICATE_NODE:


### PR DESCRIPTION
### Motivation

When I implemented #228, I forgot to move these now-handled cases. They work correctly, but have the unintended consequence of causing all cases on lines 832 to 870 too fall through into it, instead of the default handling on line 890

### Test plan

This PR only changes the behaviour of yet-unhandled cases, which will be tested once they're properly implemented in the future.
