### PR TITLE
Implement Prism -> Sorbet translation for basic pattern matching

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -128,6 +128,19 @@ std::unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
 
             return make_unique<parser::Array>(parser.translateLocation(loc), std::move(sorbetElements));
         }
+        case PM_ARRAY_PATTERN_NODE: { // An array pattern such as the `[head, *tail]` in the `a in [head, *tail]`
+            auto arrayPatternNode = reinterpret_cast<pm_array_pattern_node *>(node);
+            pm_location_t *loc = &arrayPatternNode->base.location;
+
+            auto prismPrefixNodes = absl::MakeSpan(arrayPatternNode->requireds.nodes, arrayPatternNode->requireds.size);
+
+            NodeVec sorbetElements{};
+            sorbetElements.reserve(prismPrefixNodes.size());
+
+            translateMultiInto(sorbetElements, prismPrefixNodes);
+
+            return make_unique<parser::ArrayPattern>(parser.translateLocation(loc), std::move(sorbetElements));
+        }
         case PM_ASSOC_NODE: { // A key-value pair in a Hash literal, e.g. the `a: 1` in `{ a: 1 }
             auto assocNode = reinterpret_cast<pm_assoc_node *>(node);
             pm_location_t *loc = &assocNode->base.location;
@@ -906,7 +919,6 @@ std::unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
         case PM_ALIAS_GLOBAL_VARIABLE_NODE:
         case PM_ALIAS_METHOD_NODE:
         case PM_ALTERNATION_PATTERN_NODE:
-        case PM_ARRAY_PATTERN_NODE:
         case PM_BACK_REFERENCE_READ_NODE:
         case PM_BLOCK_LOCAL_VARIABLE_NODE:
         case PM_CALL_TARGET_NODE:

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -134,9 +134,11 @@ std::unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
 
             auto prismPrefixNodes = absl::MakeSpan(arrayPatternNode->requireds.nodes, arrayPatternNode->requireds.size);
             auto prismSplatNode = reinterpret_cast<pm_splat_node *>(arrayPatternNode->rest);
+            auto prismSuffixNodes = absl::MakeSpan(arrayPatternNode->posts.nodes, arrayPatternNode->posts.size);
 
             NodeVec sorbetElements{};
-            sorbetElements.reserve(prismPrefixNodes.size() + (prismSplatNode != nullptr ? 1 : 0));
+            sorbetElements.reserve(prismPrefixNodes.size() + (prismSplatNode != nullptr ? 1 : 0) +
+                                   prismSuffixNodes.size());
 
             translateMultiInto(sorbetElements, prismPrefixNodes);
 
@@ -146,6 +148,8 @@ std::unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
                 sorbetElements.emplace_back(
                     make_unique<MatchRest>(parser.translateLocation(splatLoc), std::move(expr)));
             }
+
+            translateMultiInto(sorbetElements, prismSuffixNodes);
 
             return make_unique<parser::ArrayPattern>(parser.translateLocation(loc), std::move(sorbetElements));
         }

--- a/test/prism_regression/case.parse-tree.exp
+++ b/test/prism_regression/case.parse-tree.exp
@@ -1,10 +1,5 @@
 Begin {
   stmts = [
-    DefMethod {
-      name = <U foo>
-      args = NULL
-      body = NULL
-    }
     Case {
       condition = Send {
         receiver = NULL

--- a/test/prism_regression/case.rb
+++ b/test/prism_regression/case.rb
@@ -1,7 +1,5 @@
 # typed: false
 
-def foo; end
-
 case foo
 when 1
   puts "one!"

--- a/test/prism_regression/case_match.parse-tree.exp
+++ b/test/prism_regression/case_match.parse-tree.exp
@@ -139,6 +139,28 @@ Begin {
             ]
           }
         }
+        InPattern {
+          pattern = ArrayPattern {
+            elts = [
+              MatchRest {
+                var = NULL
+              }
+              Integer {
+                val = "6"
+              }
+            ]
+          }
+          guard = NULL
+          body = Send {
+            receiver = NULL
+            method = <U puts>
+            args = [
+              String {
+                val = <U ends with six!>
+              }
+            ]
+          }
+        }
       ]
       elseBody = NULL
     }

--- a/test/prism_regression/case_match.parse-tree.exp
+++ b/test/prism_regression/case_match.parse-tree.exp
@@ -117,6 +117,28 @@ Begin {
             ]
           }
         }
+        InPattern {
+          pattern = ArrayPattern {
+            elts = [
+              Integer {
+                val = "5"
+              }
+              MatchRest {
+                var = NULL
+              }
+            ]
+          }
+          guard = NULL
+          body = Send {
+            receiver = NULL
+            method = <U puts>
+            args = [
+              String {
+                val = <U starts with five!>
+              }
+            ]
+          }
+        }
       ]
       elseBody = NULL
     }

--- a/test/prism_regression/case_match.parse-tree.exp
+++ b/test/prism_regression/case_match.parse-tree.exp
@@ -1,0 +1,86 @@
+Begin {
+  stmts = [
+    CaseMatch {
+      expr = Send {
+        receiver = NULL
+        method = <U foo>
+        args = [
+        ]
+      }
+      inBodies = [
+        InPattern {
+          pattern = Integer {
+            val = "1"
+          }
+          guard = NULL
+          body = Send {
+            receiver = NULL
+            method = <U puts>
+            args = [
+              String {
+                val = <U one!>
+              }
+            ]
+          }
+        }
+        InPattern {
+          pattern = Integer {
+            val = "2"
+          }
+          guard = NULL
+          body = Send {
+            receiver = NULL
+            method = <U puts>
+            args = [
+              String {
+                val = <U two!>
+              }
+            ]
+          }
+        }
+      ]
+      elseBody = Send {
+        receiver = NULL
+        method = <U puts>
+        args = [
+          String {
+            val = <U Who knows!>
+          }
+        ]
+      }
+    }
+    CaseMatch {
+      expr = Send {
+        receiver = NULL
+        method = <U foo>
+        args = [
+        ]
+      }
+      inBodies = [
+        InPattern {
+          pattern = Integer {
+            val = "1"
+          }
+          guard = NULL
+          body = Begin {
+            stmts = [
+              String {
+                val = <U one!>
+              }
+              Send {
+                receiver = NULL
+                method = <U puts>
+                args = [
+                  String {
+                    val = <U surprise, multi-line!>
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+      elseBody = NULL
+    }
+  ]
+}

--- a/test/prism_regression/case_match.parse-tree.exp
+++ b/test/prism_regression/case_match.parse-tree.exp
@@ -161,6 +161,31 @@ Begin {
             ]
           }
         }
+        InPattern {
+          pattern = FindPattern {
+            elements = [
+              MatchRest {
+                var = NULL
+              }
+              Integer {
+                val = "7"
+              }
+              MatchRest {
+                var = NULL
+              }
+            ]
+          }
+          guard = NULL
+          body = Send {
+            receiver = NULL
+            method = <U puts>
+            args = [
+              String {
+                val = <U contains a seven!>
+              }
+            ]
+          }
+        }
       ]
       elseBody = NULL
     }

--- a/test/prism_regression/case_match.parse-tree.exp
+++ b/test/prism_regression/case_match.parse-tree.exp
@@ -52,6 +52,77 @@ Begin {
     CaseMatch {
       expr = Send {
         receiver = NULL
+        method = <U array_like_thing>
+        args = [
+        ]
+      }
+      inBodies = [
+        InPattern {
+          pattern = ArrayPattern {
+            elts = [
+            ]
+          }
+          guard = NULL
+          body = Send {
+            receiver = NULL
+            method = <U puts>
+            args = [
+              String {
+                val = <U empty!>
+              }
+            ]
+          }
+        }
+        InPattern {
+          pattern = ArrayPattern {
+            elts = [
+              Integer {
+                val = "1"
+              }
+              Integer {
+                val = "2"
+              }
+            ]
+          }
+          guard = NULL
+          body = Send {
+            receiver = NULL
+            method = <U puts>
+            args = [
+              String {
+                val = <U one and two!>
+              }
+            ]
+          }
+        }
+        InPattern {
+          pattern = ArrayPattern {
+            elts = [
+              Integer {
+                val = "3"
+              }
+              Integer {
+                val = "4"
+              }
+            ]
+          }
+          guard = NULL
+          body = Send {
+            receiver = NULL
+            method = <U puts>
+            args = [
+              String {
+                val = <U three and four!>
+              }
+            ]
+          }
+        }
+      ]
+      elseBody = NULL
+    }
+    CaseMatch {
+      expr = Send {
+        receiver = NULL
         method = <U foo>
         args = [
         ]

--- a/test/prism_regression/case_match.rb
+++ b/test/prism_regression/case_match.rb
@@ -20,6 +20,8 @@ in [5, *]
   puts "starts with five!"
 in [*, 6]
   puts "ends with six!"
+in [*, 7, *] # A "find pattern"
+  puts "contains a seven!"
 end
 
 # no else

--- a/test/prism_regression/case_match.rb
+++ b/test/prism_regression/case_match.rb
@@ -16,6 +16,8 @@ in [1, 2]
   puts "one and two!"
 in 3, 4 # An array pattern without [], but otherwise similar to the one above
   puts "three and four!"
+in [5, *]
+  puts "starts with five!"
 end
 
 # no else

--- a/test/prism_regression/case_match.rb
+++ b/test/prism_regression/case_match.rb
@@ -9,6 +9,15 @@ else
   puts "Who knows!"
 end
 
+case array_like_thing
+in []
+  puts "empty!"
+in [1, 2]
+  puts "one and two!"
+in 3, 4 # An array pattern without [], but otherwise similar to the one above
+  puts "three and four!"
+end
+
 # no else
 case foo
 in 1

--- a/test/prism_regression/case_match.rb
+++ b/test/prism_regression/case_match.rb
@@ -18,6 +18,8 @@ in 3, 4 # An array pattern without [], but otherwise similar to the one above
   puts "three and four!"
 in [5, *]
   puts "starts with five!"
+in [*, 6]
+  puts "ends with six!"
 end
 
 # no else

--- a/test/prism_regression/case_match.rb
+++ b/test/prism_regression/case_match.rb
@@ -1,0 +1,17 @@
+# typed: false
+
+case foo
+in 1
+  puts "one!"
+in 2
+  puts "two!"
+else
+  puts "Who knows!"
+end
+
+# no else
+case foo
+in 1
+  "one!"
+  puts "surprise, multi-line!"
+end


### PR DESCRIPTION
This PR implements pattern matching in `case` statements.

* Handles exact matches like `in 1`
* Handles all kinds of Array patterns like `in [1, 2]`, but doesn't implement qualifying them with a constant (e.g. `Array[1, 2]`)
* Handles "find" patterns, like `[*, 1, 2, *]`

Doesn't implement:

* anything related to Hash patterns
* variable binding (`in [1, x]`)
* variable pinning (`in ^existing_value`)
* guard clauses (`in Integer if predicate`)
* probably other stuff. there's a lot of pattern matching syntax :)

Closes #43
Closes #60
Closes #88
Closes #106