### PR TITLE
Implement translation for `**nil` in method def

### DIFF
--- a/test/prism_regression/def_kw_rest_params.parse-tree.exp
+++ b/test/prism_regression/def_kw_rest_params.parse-tree.exp
@@ -22,5 +22,15 @@ Begin {
       }
       body = NULL
     }
+    DefMethod {
+      name = <U foo>
+      args = Args {
+        args = [
+          Kwnilarg {
+          }
+        ]
+      }
+      body = NULL
+    }
   ]
 }

--- a/test/prism_regression/def_kw_rest_params.rb
+++ b/test/prism_regression/def_kw_rest_params.rb
@@ -3,3 +3,5 @@
 def foo(**a); end
 
 def foo(**); end
+
+def foo(**nil); end # Disallows keyword params, which is now the default in Ruby 3. Ruby 2 could might still have this.


### PR DESCRIPTION
#254 implemented handling for `**nil` in Hash patterns, but it turns out that the same node `PM_NO_KEYWORDS_PARAMETER_NODE` node type is also used in method definitions, which are translated differently.

This PR fixes the translation so it's correct in both contexts.

Closes #142