### PR TITLE
Add VS Code tasks for common operations

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,69 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Build with Prism",
+            "type": "shell",
+            "command": "./bazel build //main:sorbet --config=dbg --define RUBY_PATH=$RUBY_ROOT",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "always"
+            }
+        },
+        {
+            "label": "Run all Prism tests",
+            "type": "shell",
+            "command": "./bazel test //test:prism --config=dbg --define RUBY_PATH=$RUBY_ROOT",
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "always"
+            }
+        },
+        {
+            "label": "Run a single Prism tests",
+            "type": "shell",
+            "command": "./bazel test //test:test_PosTests/prism_regression/${input:test_name} --config=dbg --define RUBY_PATH=$RUBY_ROOT",
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "always"
+            }
+        },
+        {
+            "label": "Typecheck with Prism",
+            "type": "shell",
+            "command": "bazel-bin/main/sorbet --parser=prism ${input:file_path}",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "dependsOn": ["Build with Prism"],
+            "presentation": {
+                "reveal": "always"
+            }
+        }
+    ],
+    "inputs": [
+        {
+            "id": "test_name",
+            "type": "promptString",
+            "description": "Enter the test name, e.g. case for running test/prism_regression/case.rb",
+        },
+        {
+            "id": "file_path",
+            "type": "promptString",
+            "default": "test.rb",
+            "description": "Enter the file path to typecheck, e.g. test.rb",
+        }
+    ]
+}


### PR DESCRIPTION
I think we can utilize VS Code's task feature to automate some common development tasks. This will make unboarding contributor easier and have a better developer experience (see the demo below).

## Demo

https://github.com/user-attachments/assets/91b5b92d-e7de-45b2-b05c-ab00195dca27

## Notes

- If we use `chruby`, it'll automatically export `$RUBY_ROOT` to point to the Ruby version folder refined in `.ruby-version`. Currently it's `3.1.2` but it's already enough for working with bazel.