### PR TITLE
Update rest parameter translation

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -886,7 +886,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
                 auto name = parser.resolveConstant(prismName);
                 sorbetName = gs.enterNameUTF8(name);
             } else { // An anonymous rest parameter, like `def foo(*)`
-                sorbetName = gs.freshNameUnique(core::UniqueNameKind::Parser, core::Names::star(), ++uniqueCounter);
+                sorbetName = core::Names::star();
                 nameLoc = loc;
             }
 

--- a/test/prism_regression/array.parse-tree.exp
+++ b/test/prism_regression/array.parse-tree.exp
@@ -105,7 +105,7 @@ Begin {
       args = Args {
         args = [
           Restarg {
-            name = <P <U *> $2>
+            name = <U *>
           }
         ]
       }

--- a/test/prism_regression/call_rest_params.parse-tree.exp
+++ b/test/prism_regression/call_rest_params.parse-tree.exp
@@ -26,7 +26,7 @@ Begin {
       args = Args {
         args = [
           Restarg {
-            name = <P <U *> $2>
+            name = <U *>
           }
         ]
       }

--- a/test/prism_regression/def_all_params.parse-tree.exp
+++ b/test/prism_regression/def_all_params.parse-tree.exp
@@ -40,13 +40,13 @@ Begin {
       args = Args {
         args = [
           Restarg {
-            name = <P <U *> $2>
+            name = <U *>
           }
           Kwrestarg {
-            name = <P <U **> $3>
+            name = <P <U **> $2>
           }
           Blockarg {
-            name = <P <U &> $4>
+            name = <P <U &> $3>
           }
         ]
       }

--- a/test/prism_regression/def_rest_params.parse-tree.exp
+++ b/test/prism_regression/def_rest_params.parse-tree.exp
@@ -16,7 +16,7 @@ Begin {
       args = Args {
         args = [
           Restarg {
-            name = <P <U *> $2>
+            name = <U *>
           }
         ]
       }


### PR DESCRIPTION
I noticed that `prism` branch's CI is failing around rest parameters after merging the latest `sorbet` master. And when I regenerated the parse trees, I can indeed see them being outdated. So in this PR I updated the parse trees and the related translation logic, as well as adding a task to generate prism parse trees.

I do have a question though: why were the tests failing if both parse trees and translation were outdated? Do we also compare the committed parse trees with Sorbet's current parse trees in tests too?