### PR TITLE
Use `setup-bazel` to cache Bazel in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,5 +16,14 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.3.0
+      - name: Set up Bazel
+        uses: bazel-contrib/setup-bazel@0.9.0
+        with:
+          # Avoid downloading Bazel every time.
+          bazelisk-cache: true
+          # Store build cache per workflow.
+          disk-cache: ${{ github.workflow }}
+          # Share repository cache between workflows.
+          repository-cache: true
       - name: Run tests
         run: ./bazel test //test:prism --config=dbg --define RUBY_PATH='/opt/hostedtoolcache/Ruby/3.3.0/x64' --test_output=all


### PR DESCRIPTION
### Motivation
Closes https://github.com/Shopify/team-ruby-dx/issues/1187

This PR adds [setup-bazel](https://github.com/bazel-contrib/setup-bazel) to our CI workflow, which will cache Bazel between runs, significantly shortening the build time for our automated tests.

### Testing
Our tests run and pass a lot faster now! They used to take about 20 minutes, and [the build on this branch took 2.5](https://github.com/Shopify/sorbet/actions/runs/11223676474/job/31198802255?pr=262) :)