### PR TITLE
Support translating interpolated xstrings

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -18,7 +18,7 @@
         {
             "label": "Run all Prism tests",
             "type": "shell",
-            "command": "./bazel test //test:prism --config=dbg --define RUBY_PATH=$RUBY_ROOT --test_output=all",
+            "command": "./bazel test //test:prism //test:prism_location_tests --config=dbg --define RUBY_PATH=$RUBY_ROOT --test_output=all",
             "group": {
                 "kind": "test",
                 "isDefault": true
@@ -30,7 +30,7 @@
         {
             "label": "Run a single Prism test",
             "type": "shell",
-            "command": "./bazel test //test:test_PosTests/prism_regression/${input:test_name} --config=dbg --define RUBY_PATH=$RUBY_ROOT --test_output=all",
+            "command": "./bazel test //test:test_PosTests/prism_regression/${input:test_name} //test:prism_regression_${input:test_name}_location_test --config=dbg --define RUBY_PATH=$RUBY_ROOT --test_output=all",
             "group": {
                 "kind": "test",
                 "isDefault": true
@@ -64,30 +64,6 @@
                 "reveal": "always"
             }
         },
-        {
-            "label": "Run all Prism location tests",
-            "type": "shell",
-            "command": "./bazel test //test:prism_location_tests --config=dbg --define RUBY_PATH=$RUBY_ROOT --test_output=all",
-            "group": {
-                "kind": "test",
-                "isDefault": true
-            },
-            "presentation": {
-                "reveal": "always"
-            }
-        },
-        {
-            "label": "Run a single Prism location test",
-            "type": "shell",
-            "command": "./bazel test //test:prism_regression_${input:test_name}_location_test --config=dbg --define RUBY_PATH=$RUBY_ROOT",
-            "group": {
-                "kind": "test",
-                "isDefault": true
-            },
-            "presentation": {
-                "reveal": "always"
-            }
-        }
     ],
     "inputs": [
         {

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -640,6 +640,15 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
 
             return make_unique<parser::DString>(parser.translateLocation(loc), move(sorbetParts));
         }
+        case PM_INTERPOLATED_X_STRING_NODE: {
+            auto interpolatedXStringNode = reinterpret_cast<pm_interpolated_x_string_node *>(node);
+
+            pm_location_t *loc = &interpolatedXStringNode->base.location;
+
+            auto sorbetParts = translateMulti(interpolatedXStringNode->parts);
+
+            return make_unique<parser::XString>(parser.translateLocation(loc), move(sorbetParts));
+        }
         case PM_IT_LOCAL_VARIABLE_READ_NODE: { // The `it` implicit parameter added in Ruby 3.4, e.g. `a.map { it + 1 }`
             [[fallthrough]];
         }
@@ -1098,7 +1107,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
                 make_unique<parser::String>(parser.translateLocation(loc), gs.enterNameUTF8(source));
 
             NodeVec nodes{};
-            nodes.emplace_back(move(string)); // When can a Sorbet XString node have multiple child nodes?
+            nodes.emplace_back(move(string)); // Multiple nodes is only possible for interpolated x strings.
 
             return make_unique<parser::XString>(parser.translateLocation(loc), move(nodes));
         }
@@ -1129,7 +1138,6 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
         case PM_INTERPOLATED_MATCH_LAST_LINE_NODE:
         case PM_INTERPOLATED_REGULAR_EXPRESSION_NODE:
         case PM_INTERPOLATED_SYMBOL_NODE:
-        case PM_INTERPOLATED_X_STRING_NODE:
         case PM_LAMBDA_NODE:
         case PM_MATCH_LAST_LINE_NODE:
         case PM_MATCH_PREDICATE_NODE:

--- a/test/prism_regression/xstring.parse-tree.exp
+++ b/test/prism_regression/xstring.parse-tree.exp
@@ -35,5 +35,77 @@ Begin {
         }
       ]
     }
+    XString {
+      nodes = [
+        String {
+          val = <U ruby -e 'puts "Hello, >
+        }
+        Begin {
+          stmts = [
+          ]
+        }
+        String {
+          val = <U "'>
+        }
+      ]
+    }
+    XString {
+      nodes = [
+        String {
+          val = <U ruby -e 'puts "Hello, >
+        }
+        Begin {
+          stmts = [
+            String {
+              val = <U interpolation>
+            }
+          ]
+        }
+        String {
+          val = <U "'>
+        }
+      ]
+    }
+    XString {
+      nodes = [
+        String {
+          val = <U ruby -e 'puts "Hello, >
+        }
+        Begin {
+          stmts = [
+            Send {
+              receiver = NULL
+              method = <U foo>
+              args = [
+              ]
+            }
+          ]
+        }
+        String {
+          val = <U "'>
+        }
+      ]
+    }
+    XString {
+      nodes = [
+        String {
+          val = <U ruby -e 'puts "Hello, >
+        }
+        Begin {
+          stmts = [
+            XString {
+              nodes = [
+                String {
+                  val = <U echo "backticks">
+                }
+              ]
+            }
+          ]
+        }
+        String {
+          val = <U "'>
+        }
+      ]
+    }
   ]
 }

--- a/test/prism_regression/xstring.rb
+++ b/test/prism_regression/xstring.rb
@@ -6,3 +6,8 @@
 %x{ruby -e 'puts "Hello, braces!"'}
 %x[ruby -e 'puts "Hello, square brackets!"']
 %x/ruby -e 'puts "Hello, slashes!"'/
+
+`ruby -e 'puts "Hello, #{}"'`
+`ruby -e 'puts "Hello, #{'interpolation'}"'`
+`ruby -e 'puts "Hello, #{foo}"'`
+`ruby -e 'puts "Hello, #{`echo "backticks"`}"'`


### PR DESCRIPTION
Closes https://github.com/Shopify/sorbet/issues/121

In the second commit, I merged single/all location tests into regression tests as I feel it's more convenient to run them together.

Example:

```
INFO: Elapsed time: 10.133s, Critical Path: 10.00s
INFO: 11 processes: 12 local.
INFO: Build completed, 2 tests FAILED, 11 total actions
//test:prism_regression_xstring_location_test                            FAILED in 2.9s
  /private/var/tmp/_bazel_hung-wulo/4a66351d4da81785705c4ebcb28c4103/execroot/com_stripe_ruby_typer/bazel-out/darwin_arm64-dbg/testlogs/test/prism_regression_xstring_location_test/test.log
//test:test_PosTests/prism_regression/xstring                            FAILED in 4.0s
  /private/var/tmp/_bazel_hung-wulo/4a66351d4da81785705c4ebcb28c4103/execroot/com_stripe_ruby_typer/bazel-out/darwin_arm64-dbg/testlogs/test/test_PosTests/prism_regression/xstring/test.log

Executed 2 out of 2 tests: 2 fail locally.
```