### PR TITLE
Implement Prism -> Sorbet translation for variable binding in patterns

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1105,6 +1105,14 @@ unique_ptr<parser::Node> Translator::patternTranslate(pm_node_t *node) {
 
             return make_unique<parser::MatchAlt>(location, move(left), move(right));
         }
+        case PM_ASSOC_NODE: { // A key-value pair in a Hash pattern, e.g. the `k: v` in `h in { k: v }
+            auto assocNode = reinterpret_cast<pm_assoc_node *>(node);
+
+            auto key = patternTranslate(assocNode->key);
+            auto value = patternTranslate(assocNode->value);
+
+            return make_unique<parser::Pair>(location, move(key), move(value));
+        }
         case PM_ARRAY_PATTERN_NODE: { // An array pattern such as the `[head, *tail]` in the `a in [head, *tail]`
             auto arrayPatternNode = reinterpret_cast<pm_array_pattern_node *>(node);
 

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1196,6 +1196,13 @@ unique_ptr<parser::Node> Translator::patternTranslate(pm_node_t *node) {
 
             return make_unique<parser::InPattern>(location, move(sorbetPattern), nullptr, move(statements));
         }
+        case PM_LOCAL_VARIABLE_TARGET_NODE: { // A variable binding in a pattern, like the `head` in `[head, *tail]`
+            auto localVarTargetNode = reinterpret_cast<pm_local_variable_target_node *>(node);
+
+            auto name = parser.resolveConstant(localVarTargetNode->name);
+
+            return make_unique<MatchVar>(location, gs.enterNameUTF8(name));
+        }
         default: {
             return translate(node);
         }

--- a/test/prism_regression/case_match_variable_binding.parse-tree.exp
+++ b/test/prism_regression/case_match_variable_binding.parse-tree.exp
@@ -31,6 +31,35 @@ CaseMatch {
       }
     }
     InPattern {
+      pattern = HashPattern {
+        pairs = [
+          Pair {
+            key = Symbol {
+              val = <U k>
+            }
+            value = MatchVar {
+              name = <U x>
+            }
+          }
+        ]
+      }
+      guard = NULL
+      body = DString {
+        nodes = [
+          String {
+            val = <U A Hash-like whose key `:k` has value >
+          }
+          Begin {
+            stmts = [
+              LVar {
+                name = <U x>
+              }
+            ]
+          }
+        ]
+      }
+    }
+    InPattern {
       pattern = MatchVar {
         name = <U x>
       }

--- a/test/prism_regression/case_match_variable_binding.parse-tree.exp
+++ b/test/prism_regression/case_match_variable_binding.parse-tree.exp
@@ -60,6 +60,82 @@ CaseMatch {
       }
     }
     InPattern {
+      pattern = ArrayPattern {
+        elts = [
+          ArrayPattern {
+            elts = [
+              MatchVar {
+                name = <U value>
+              }
+            ]
+          }
+          MatchRest {
+            var = MatchVar {
+              name = <U tail>
+            }
+          }
+        ]
+      }
+      guard = NULL
+      body = DString {
+        nodes = [
+          String {
+            val = <U An array-like thing that starts with a one-element Array containing >
+          }
+          Begin {
+            stmts = [
+              LVar {
+                name = <U value>
+              }
+            ]
+          }
+          String {
+            val = <U , and ends with >
+          }
+          Begin {
+            stmts = [
+              LVar {
+                name = <U tail>
+              }
+            ]
+          }
+        ]
+      }
+    }
+    InPattern {
+      pattern = HashPattern {
+        pairs = [
+          Pair {
+            key = Symbol {
+              val = <U k>
+            }
+            value = ArrayPattern {
+              elts = [
+                MatchVar {
+                  name = <U value>
+                }
+              ]
+            }
+          }
+        ]
+      }
+      guard = NULL
+      body = DString {
+        nodes = [
+          String {
+            val = <U A hash-like whose key `:k` has a one-element Array value containing >
+          }
+          Begin {
+            stmts = [
+              LVar {
+                name = <U value>
+              }
+            ]
+          }
+        ]
+      }
+    }
+    InPattern {
       pattern = MatchVar {
         name = <U x>
       }

--- a/test/prism_regression/case_match_variable_binding.parse-tree.exp
+++ b/test/prism_regression/case_match_variable_binding.parse-tree.exp
@@ -7,6 +7,30 @@ CaseMatch {
   }
   inBodies = [
     InPattern {
+      pattern = ArrayPattern {
+        elts = [
+          MatchVar {
+            name = <U x>
+          }
+        ]
+      }
+      guard = NULL
+      body = DString {
+        nodes = [
+          String {
+            val = <U An Array-like thing that only contains >
+          }
+          Begin {
+            stmts = [
+              LVar {
+                name = <U x>
+              }
+            ]
+          }
+        ]
+      }
+    }
+    InPattern {
       pattern = MatchVar {
         name = <U x>
       }

--- a/test/prism_regression/case_match_variable_binding.parse-tree.exp
+++ b/test/prism_regression/case_match_variable_binding.parse-tree.exp
@@ -1,0 +1,31 @@
+CaseMatch {
+  expr = Send {
+    receiver = NULL
+    method = <U foo>
+    args = [
+    ]
+  }
+  inBodies = [
+    InPattern {
+      pattern = MatchVar {
+        name = <U x>
+      }
+      guard = NULL
+      body = DString {
+        nodes = [
+          String {
+            val = <U Some other value: >
+          }
+          Begin {
+            stmts = [
+              LVar {
+                name = <U x>
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+  elseBody = NULL
+}

--- a/test/prism_regression/case_match_variable_binding.parse-tree.exp
+++ b/test/prism_regression/case_match_variable_binding.parse-tree.exp
@@ -136,6 +136,92 @@ CaseMatch {
       }
     }
     InPattern {
+      pattern = ArrayPattern {
+        elts = [
+          HashPattern {
+            pairs = [
+              Pair {
+                key = Symbol {
+                  val = <U k>
+                }
+                value = MatchVar {
+                  name = <U value>
+                }
+              }
+            ]
+          }
+          MatchRest {
+            var = MatchVar {
+              name = <U tail>
+            }
+          }
+        ]
+      }
+      guard = NULL
+      body = DString {
+        nodes = [
+          String {
+            val = <U An array-like thing that starts with a one-element Hash containing >
+          }
+          Begin {
+            stmts = [
+              LVar {
+                name = <U value>
+              }
+            ]
+          }
+          String {
+            val = <U , and ends with >
+          }
+          Begin {
+            stmts = [
+              LVar {
+                name = <U tail>
+              }
+            ]
+          }
+        ]
+      }
+    }
+    InPattern {
+      pattern = HashPattern {
+        pairs = [
+          Pair {
+            key = Symbol {
+              val = <U k>
+            }
+            value = HashPattern {
+              pairs = [
+                Pair {
+                  key = Symbol {
+                    val = <U k2>
+                  }
+                  value = MatchVar {
+                    name = <U value>
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+      guard = NULL
+      body = DString {
+        nodes = [
+          String {
+            val = <U A hash-like whose key `:k` has a one-element Hash value containing k2: >
+          }
+          Begin {
+            stmts = [
+              LVar {
+                name = <U value>
+              }
+            ]
+          }
+        ]
+      }
+    }
+    InPattern {
       pattern = MatchVar {
         name = <U x>
       }

--- a/test/prism_regression/case_match_variable_binding.rb
+++ b/test/prism_regression/case_match_variable_binding.rb
@@ -6,6 +6,11 @@ in [x]      # Variable binding nested in an Array pattern
 in { k: x } # Variable binding nested in a Hash pattern
   "A Hash-like whose key `:k` has value #{x}"
 
+in [[value], *tail] # Array pattern inside an Array pattern
+  "An array-like thing that starts with a one-element Array containing #{value}, and ends with #{tail}"
+in { k: [value] }   # Array pattern inside a Hash pattern
+  "A hash-like whose key `:k` has a one-element Array value containing #{value}"
+
 in x
   "Some other value: #{x}"
 end

--- a/test/prism_regression/case_match_variable_binding.rb
+++ b/test/prism_regression/case_match_variable_binding.rb
@@ -1,8 +1,10 @@
 # typed: false
 
 case foo
-in [x] # Variable binding nested in an Array pattern
+in [x]      # Variable binding nested in an Array pattern
   "An Array-like thing that only contains #{x}"
+in { k: x } # Variable binding nested in a Hash pattern
+  "A Hash-like whose key `:k` has value #{x}"
 
 in x
   "Some other value: #{x}"

--- a/test/prism_regression/case_match_variable_binding.rb
+++ b/test/prism_regression/case_match_variable_binding.rb
@@ -1,0 +1,6 @@
+# typed: false
+
+case foo
+in x
+  "Some other value: #{x}"
+end

--- a/test/prism_regression/case_match_variable_binding.rb
+++ b/test/prism_regression/case_match_variable_binding.rb
@@ -11,6 +11,11 @@ in [[value], *tail] # Array pattern inside an Array pattern
 in { k: [value] }   # Array pattern inside a Hash pattern
   "A hash-like whose key `:k` has a one-element Array value containing #{value}"
 
+in [{ k: value }, *tail] # A Hash pattern inside an Array pattern
+  "An array-like thing that starts with a one-element Hash containing #{value}, and ends with #{tail}"
+in { k: { k2: value } }  # A Hash pattern inside a Hash pattern
+  "A hash-like whose key `:k` has a one-element Hash value containing k2: #{value}"
+
 in x
   "Some other value: #{x}"
 end

--- a/test/prism_regression/case_match_variable_binding.rb
+++ b/test/prism_regression/case_match_variable_binding.rb
@@ -1,6 +1,9 @@
 # typed: false
 
 case foo
+in [x] # Variable binding nested in an Array pattern
+  "An Array-like thing that only contains #{x}"
+
 in x
   "Some other value: #{x}"
 end


### PR DESCRIPTION
Closes #130
Related #43, #44, #101, #130

Stacked on top of #274

This PR implements the ability to bind variables inside patterns, including nesting bindings inside Array and Hash patterns.