### PR TITLE
Support translating block local variables

### DIFF
--- a/test/prism_regression/call_block_param.parse-tree.exp
+++ b/test/prism_regression/call_block_param.parse-tree.exp
@@ -120,6 +120,84 @@ Begin {
         val = <U block with multi-target node in parameter list>
       }
     }
+    Block {
+      send = Send {
+        receiver = NULL
+        method = <U foo>
+        args = [
+        ]
+      }
+      args = Args {
+        args = [
+          Arg {
+            name = <U bar>
+          }
+          Shadowarg {
+            name = <U baz>
+          }
+          Shadowarg {
+            name = <U qux>
+          }
+        ]
+      }
+      body = NULL
+    }
+    Block {
+      send = Send {
+        receiver = NULL
+        method = <U foo>
+        args = [
+        ]
+      }
+      args = Args {
+        args = [
+          Arg {
+            name = <U positional>
+          }
+          Mlhs {
+            exprs = [
+              Arg {
+                name = <U multi>
+              }
+              Arg {
+                name = <U target>
+              }
+            ]
+          }
+          Shadowarg {
+            name = <U baz>
+          }
+          Shadowarg {
+            name = <U qux>
+          }
+        ]
+      }
+      body = String {
+        val = <U block with multi-target node in parameter list and block locals>
+      }
+    }
+    Block {
+      send = Send {
+        receiver = NULL
+        method = <U foo>
+        args = [
+        ]
+      }
+      args = Args {
+        args = [
+          Arg {
+            name = <U bar>
+          }
+          Shadowarg {
+            name = <U baz>
+          }
+          Shadowarg {
+            name = <U qux>
+          }
+        ]
+      }
+      body = NULL
+    }
     Send {
       receiver = NULL
       method = <U foo>

--- a/test/prism_regression/call_block_param.rb
+++ b/test/prism_regression/call_block_param.rb
@@ -1,26 +1,35 @@
 # typed: false
 
- foo {} # empty inline block
+foo {} # empty inline block
 
- foo do # empty do-end block
- end
+foo do # empty do-end block
+end
 
- foo { "inline block" }
+foo { "inline block" }
 
- foo do
-   "do-end block"
- end
+foo do
+  "do-end block"
+end
 
- foo { |positional, kwarg:, &block| "inline block with params" }
+foo { |positional, kwarg:, &block| "inline block with params" }
 
- foo do |positional, kwarg:, &block|
-   "inline block with params"
- end
+foo do |positional, kwarg:, &block|
+  "inline block with params"
+end
 
 foo do |positional, (multi, target)|
   "block with multi-target node in parameter list"
 end
 
- foo(&forwarded_block)
+# block with parameter `bar` and block locals `baz` and `qux`
+foo { |bar; baz, qux| }
 
- foo&.bar {}
+foo do |positional, (multi, target); baz, qux|
+  "block with multi-target node in parameter list and block locals"
+end
+
+foo { |bar; baz, qux| }
+
+foo(&forwarded_block)
+
+foo&.bar {}


### PR DESCRIPTION
### Motivation

Closes #49

Block local variables are "readonly" (can't have assignment) and looks like it's purpose is to shield the variables inside the block from the outer scope?

```rb
bar = 1

foo do |x|
  puts bar # 1
end

foo do |x; bar|
  puts bar # nil
end

# these are not valid
# foo { |x; bar = 1|}
# foo { |x; bar.baz|}
# foo { |x; Bar|}
```




### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
