### PR TITLE
Implement Prism -> Sorbet translation for numbered block parameters (`_1`, `_2`, ...)

### DIFF
--- a/test/prism_regression/numbered_params.parse-tree.exp
+++ b/test/prism_regression/numbered_params.parse-tree.exp
@@ -1,0 +1,29 @@
+NumBlock {
+  send = Send {
+    receiver = NULL
+    method = <U proc>
+    args = [
+    ]
+  }
+  args = NumParams {
+    decls = [
+      LVar {
+        name = <U _1>
+      }
+      LVar {
+        name = <U _2>
+      }
+    ]
+  }
+  body = Send {
+    receiver = LVar {
+      name = <U _1>
+    }
+    method = <U +>
+    args = [
+      LVar {
+        name = <U _2>
+      }
+    ]
+  }
+}

--- a/test/prism_regression/numbered_params.rb
+++ b/test/prism_regression/numbered_params.rb
@@ -1,0 +1,6 @@
+# typed: false
+
+proc { _1 + _2 }
+
+# TODO: uncomment once we support lambdas https://github.com/Shopify/sorbet/issues/125
+# -> { _1 + _2 }


### PR DESCRIPTION
Closes #143.

We'll need to follow up and make sure these also work when we implement #125