### PR TITLE
RFC: Automatically get `RUBY_ROOT` from user environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,6 @@ jobs:
       - name: Verify parse trees
         run: ./tools/scripts/verify_prism_regression_tests.sh
       - name: Run tests
-        run: ./bazel test //test:prism --config=dbg --define RUBY_PATH=$RUBY_ROOT --test_output=errors
+        run: ./bazel test //test:prism --config=dbg --test_output=errors
       - name: Run location tests
-        run: ./bazel test //test:prism_location_tests --config=dbg --define RUBY_PATH=$RUBY_ROOT --test_output=errors
+        run: ./bazel test //test:prism_location_tests --config=dbg --test_output=errors

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
         {
             "label": "Build with Prism",
             "type": "shell",
-            "command": "./bazel build //main:sorbet --config=dbg --define RUBY_PATH=$RUBY_ROOT --test_output=all",
+            "command": "./bazel build //main:sorbet --config=dbg",
             "group": {
                 "kind": "build",
                 "isDefault": true
@@ -18,7 +18,7 @@
         {
             "label": "Run all Prism tests",
             "type": "shell",
-            "command": "./bazel test //test:prism //test:prism_location_tests --config=dbg --define RUBY_PATH=$RUBY_ROOT --test_output=all",
+            "command": "./bazel test //test:prism //test:prism_location_tests --config=dbg  --test_output=all",
             "group": {
                 "kind": "test",
                 "isDefault": true
@@ -30,7 +30,7 @@
         {
             "label": "Run a single Prism test",
             "type": "shell",
-            "command": "./bazel test //test:test_PosTests/prism_regression/${input:test_name} //test:prism_regression_${input:test_name}_location_test --config=dbg --define RUBY_PATH=$RUBY_ROOT --test_output=all",
+            "command": "./bazel test //test:test_PosTests/prism_regression/${input:test_name} //test:prism_regression_${input:test_name}_location_test --config=dbg  --test_output=all",
             "group": {
                 "kind": "test",
                 "isDefault": true

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,8 +2,10 @@ workspace(name = "com_stripe_ruby_typer")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("//third_party:externals.bzl", "register_sorbet_dependencies")
+load("//third_party:ruby_root.bzl", "ruby_root")
 
 register_sorbet_dependencies()
+ruby_root(name = "ruby_root")
 
 load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
 

--- a/third_party/prism.BUILD
+++ b/third_party/prism.BUILD
@@ -1,3 +1,5 @@
+load("@ruby_root//:ruby_root.bzl", "RUBY_ROOT") # Get the RUBY_ROOT environment variable
+
 GENERATED_SRCS = [
   "src/diagnostic.c",
   "src/node.c",
@@ -28,12 +30,7 @@ genrule(
     # echo "PWD: $$PWD"
     # echo "RULEDIR: $(RULEDIR)"
 
-    # This is a workaround; without guidance, Bazel will try to use the system Ruby,
-    # which is too old to install gems and run this script.
-    #
-    # Pass the RUBY_PATH variable to the build using the --define flag, e.g.
-    # ./bazel build //main:sorbet --config=dbg --define RUBY_PATH=/path/to/ruby
-    export PATH="$(RUBY_PATH)/bin:$$PATH"
+    export PATH="{ruby_root}/bin:$$PATH"
 
     gemfile="$(location Gemfile)"
     script="$(location templates/template.rb)"
@@ -43,6 +40,7 @@ genrule(
     {template_render_commands}
 
   """.format(
+    ruby_root = RUBY_ROOT,
     template_render_commands = "\n    ".join([
       """
         bundle exec --gemfile="$$gemfile" ruby "$$script" {f} "$(location {f})"

--- a/third_party/ruby_root.bzl
+++ b/third_party/ruby_root.bzl
@@ -1,0 +1,20 @@
+# This rule is used to get the RUBY_ROOT environment variable from the
+# user's local environment and make it available to the build system.
+def _ruby_root_impl(repository_ctx):
+  # Retrieve the RUBY_ROOT environment variable
+  ruby_root = repository_ctx.os.environ.get("RUBY_ROOT")
+
+  if not ruby_root:
+    fail("RUBY_ROOT environment variable is not set.")
+
+  # Create a file to store the RUBY_ROOT value
+  content = 'RUBY_ROOT = "{}"\n'.format(ruby_root)
+  repository_ctx.file("ruby_root.bzl", content=content)
+
+  # Create an empty BUILD file to make the directory a valid Bazel repository
+  repository_ctx.file("BUILD", content="")
+
+ruby_root = repository_rule(
+  implementation = _ruby_root_impl,
+  attrs = {},
+)


### PR DESCRIPTION
Related to Shopify/team-ruby-dx#1234

### Motivation
Up to this point, in order to build Prism, we've needed to manually pass the path to the correct RUBY version to the build process because Bazel does not take the user's environment into account and will just usethe system's default Ruby version (which is often very old).

This is an okay workaround, but it will not be acceptable once we try to upstream these changes.

There are a few potential paths forward:

#### Build Ruby from source in Bazel
While this seems like the most "Bazel-y" way to do things, this means we/the Sorbet team at Stripe would have to maintain a whole Ruby build pipeline just to build Prism, which partially defeats the purpose of adopting Prism in order to reduce the cost of maintaining the parser.

#### Pre-build and host Prism binaries
I still think we should explore this route, but it'll take some time and collaboration, so I wanted to look at other lower-effort options first.

#### Get Bazel to automatically use the correct version of Ruby
The downside of this approach is that it ruins Bazel's "hermetic" approach to building software. The upside is that it is definitely an improvement on what we're doing now and requires very little effort for the time being.

### Resources

I originally got this idea by reading [this StackOverflow post](https://stackoverflow.com/questions/47603608/how-to-reference-environmental-variables-in-workspace), and then read more about [Bazel repository rules here](https://bazel.build/extending/repo).

### Test plan

See automated tests
