### PR TITLE
Implement Prism -> Sorbet translation for “last line matches”

### DIFF
--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -51,6 +51,8 @@ private:
     template <typename SorbetNode> std::unique_ptr<SorbetNode> translateSimpleKeyword(pm_node_t *untypedNode);
 
     std::unique_ptr<parser::Regopt> translateRegexpOptions(pm_location_t closingLoc);
+    std::unique_ptr<parser::Regexp> translateRegexp(pm_string_t unescaped, core::LocOffsets location,
+                                                    pm_location_t closingLoc);
 
     template <typename PrismAssignmentNode, typename SorbetLHSNode>
     std::unique_ptr<parser::Assign> translateAssignment(pm_node_t *node);

--- a/test/prism_regression/match_last_line.parse-tree.exp
+++ b/test/prism_regression/match_last_line.parse-tree.exp
@@ -1,0 +1,42 @@
+Begin {
+  stmts = [
+    If {
+      condition = MatchCurLine {
+        cond = Regexp {
+          regex = [
+            String {
+              val = <U wat>
+            }
+          ]
+          opts = Regopt {
+            opts = ""
+          }
+        }
+      }
+      then_ = Begin {
+        stmts = [
+          String {
+            val = <U This is _not_ a truthiness test of a Regexp literal,>
+          }
+          String {
+            val = <U but a special syntax implicitly match against the last line read by an IO object.>
+          }
+        ]
+      }
+      else_ = NULL
+    }
+    If {
+      condition = MatchCurLine {
+        cond = Regexp {
+          regex = [
+          ]
+          opts = Regopt {
+            opts = ""
+          }
+        }
+      }
+      then_ = NULL
+      else_ = NULL
+    }
+  ]
+}

--- a/test/prism_regression/match_last_line.rb
+++ b/test/prism_regression/match_last_line.rb
@@ -1,0 +1,11 @@
+# typed: false
+
+if /wat/
+#  ^^^^^ error: Unsupported node type `MatchCurLine`
+  "This is _not_ a truthiness test of a Regexp literal,"
+  "but a special syntax implicitly match against the last line read by an IO object."
+end
+
+if // # testing an empty pattern
+#  ^^ error: Unsupported node type `MatchCurLine`
+end


### PR DESCRIPTION
Closes #132

Handles syntax like this:

```ruby
if /wat/
end
```

which is _not_ just testing the truthiness of a regex literal. It's implicitly testing if the last read line (`$_`) matches the pattern.

Sorbet doesn't support it today ([Sorbet.run](https://sorbet.run/#if%20%2Fx%2F%0Aend)), but we still need to translate it, to get that diagnostic.