### PR TITLE
Implement Prism -> Sorbet translation for `PM_SCOPE_NODE`

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1112,6 +1112,9 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             unreachable(
                 "These pattern-match related nodes are handled separately in `Translator::patternTranslate()`.");
 
+        case PM_SCOPE_NODE: // An internal node type only created by the MRI's Ruby compiler, and not Prism itself.
+            unreachable("Prism's parser never produces `PM_SCOPE_NODE` nodes.");
+
         case PM_BACK_REFERENCE_READ_NODE:
         case PM_CAPTURE_PATTERN_NODE:
         case PM_EMBEDDED_VARIABLE_NODE:
@@ -1127,7 +1130,6 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
         case PM_NUMBERED_REFERENCE_READ_NODE:
         case PM_POST_EXECUTION_NODE:
         case PM_PRE_EXECUTION_NODE:
-        case PM_SCOPE_NODE:
             auto type_id = PM_NODE_TYPE(node);
             auto type_name = pm_node_type_to_str(type_id);
 


### PR DESCRIPTION
Closes #164

Per @kddnewton:

> It's a special kind of node used for compilation
> It won't show up in the AST, you can ignore it, because Prism will never produce these nodes
> they basically are used to mark where we're compiling a new instruction sequence, like classes, modules, blocks, singleton classes, etc

### Test plan

No tests, since Prism can't cause this scenario to happen, but definition.