### PR TITLE
Implement Prism -> Sorbet translation for `PM_BACK_REFERENCE_READ_NODE`

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -165,6 +165,12 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
                         "`PM_HASH_PATTERN_NODE`, because its translation depends on whether its used in a "
                         "Hash literal, Hash pattern, or method call.");
         }
+        case PM_BACK_REFERENCE_READ_NODE: {
+            auto backReferenceReadNode = reinterpret_cast<pm_back_reference_read_node *>(node);
+            auto name = parser.resolveConstant(backReferenceReadNode->name);
+
+            return make_unique<parser::Backref>(location, gs.enterNameUTF8(name));
+        }
         case PM_BEGIN_NODE: { // A `begin ... end` block
             auto beginNode = reinterpret_cast<pm_begin_node *>(node);
 
@@ -1146,7 +1152,6 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
         case PM_SCOPE_NODE: // An internal node type only created by the MRI's Ruby compiler, and not Prism itself.
             unreachable("Prism's parser never produces `PM_SCOPE_NODE` nodes.");
 
-        case PM_BACK_REFERENCE_READ_NODE:
         case PM_CAPTURE_PATTERN_NODE:
         case PM_EMBEDDED_VARIABLE_NODE:
         case PM_FLIP_FLOP_NODE:

--- a/test/prism_regression/back_reference_read.parse-tree.exp
+++ b/test/prism_regression/back_reference_read.parse-tree.exp
@@ -1,0 +1,57 @@
+Begin {
+  stmts = [
+    Backref {
+      name = <U $&>
+    }
+    Backref {
+      name = <U $`>
+    }
+    Backref {
+      name = <U $'>
+    }
+    Backref {
+      name = <U $+>
+    }
+    If {
+      condition = Send {
+        receiver = String {
+          val = <U foobar>
+        }
+        method = <U =~>
+        args = [
+          Regexp {
+            regex = [
+              String {
+                val = <U foo(.*)>
+              }
+            ]
+            opts = Regopt {
+              opts = ""
+            }
+          }
+        ]
+      }
+      then_ = Send {
+        receiver = NULL
+        method = <U puts>
+        args = [
+          DString {
+            nodes = [
+              String {
+                val = <U The last matching word was >
+              }
+              Begin {
+                stmts = [
+                  Backref {
+                    name = <U $+>
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+      else_ = NULL
+    }
+  ]
+}

--- a/test/prism_regression/back_reference_read.rb
+++ b/test/prism_regression/back_reference_read.rb
@@ -1,0 +1,18 @@
+# typed: false
+
+# The result of the last match
+$&
+
+# The string preceding the match in the last match
+$`
+
+# The string following the match in the last match
+$'
+
+# The results of the highest-numbered group matched
+$+
+
+# In context
+if "foobar" =~ /foo(.*)/ then
+  puts "The last matching word was #{$+}"
+end


### PR DESCRIPTION
### Motivation
Closes #46 

### Test plan
See included automated tests.
