### PR TITLE
Extract ensure/rescue clause from method body if no begin block is present

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -473,7 +473,12 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
                 if (kwbeginNode != nullptr && kwbeginNode->stmts[0] != nullptr &&
                     (dynamic_cast<parser::Rescue *>(kwbeginNode->stmts[0].get()) != nullptr ||
                      dynamic_cast<parser::Ensure *>(kwbeginNode->stmts[0].get()) != nullptr)) {
-                    body = move(kwbeginNode->stmts[0]);
+
+                    if (kwbeginNode->stmts.size() == 1) {
+                        body = move(kwbeginNode->stmts[0]);
+                    } else {
+                        unreachable("With ensure or rescue, the body of a method definition will be either a rescue or ensure node.");
+                    }
                 }
             }
 

--- a/test/prism_regression/def.parse-tree.exp
+++ b/test/prism_regression/def.parse-tree.exp
@@ -10,17 +10,11 @@ Begin {
       args = NULL
       body = Begin {
         stmts = [
-          Send {
-            receiver = NULL
-            method = <U method_1>
-            args = [
-            ]
+          String {
+            val = <U string1>
           }
-          Send {
-            receiver = NULL
-            method = <U method_2>
-            args = [
-            ]
+          String {
+            val = <U string2>
           }
         ]
       }
@@ -30,17 +24,11 @@ Begin {
       args = NULL
       body = Kwbegin {
         stmts = [
-          Send {
-            receiver = NULL
-            method = <U method_1>
-            args = [
-            ]
+          String {
+            val = <U string1>
           }
-          Send {
-            receiver = NULL
-            method = <U method_2>
-            args = [
-            ]
+          String {
+            val = <U string2>
           }
         ]
       }

--- a/test/prism_regression/def.parse-tree.exp
+++ b/test/prism_regression/def.parse-tree.exp
@@ -1,5 +1,49 @@
-DefMethod {
-  name = <U foo>
-  args = NULL
-  body = NULL
+Begin {
+  stmts = [
+    DefMethod {
+      name = <U foo>
+      args = NULL
+      body = NULL
+    }
+    DefMethod {
+      name = <U bar>
+      args = NULL
+      body = Begin {
+        stmts = [
+          Send {
+            receiver = NULL
+            method = <U method_1>
+            args = [
+            ]
+          }
+          Send {
+            receiver = NULL
+            method = <U method_2>
+            args = [
+            ]
+          }
+        ]
+      }
+    }
+    DefMethod {
+      name = <U baz>
+      args = NULL
+      body = Kwbegin {
+        stmts = [
+          Send {
+            receiver = NULL
+            method = <U method_1>
+            args = [
+            ]
+          }
+          Send {
+            receiver = NULL
+            method = <U method_2>
+            args = [
+            ]
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/test/prism_regression/def.rb
+++ b/test/prism_regression/def.rb
@@ -1,3 +1,15 @@
 # typed: false
 
 def foo; end
+
+def bar
+  method_1
+  method_2
+end
+
+def baz
+  begin
+    method_1
+    method_2
+  end
+end

--- a/test/prism_regression/def.rb
+++ b/test/prism_regression/def.rb
@@ -3,13 +3,13 @@
 def foo; end
 
 def bar
-  method_1
-  method_2
+  "string1"
+  "string2"
 end
 
 def baz
   begin
-    method_1
-    method_2
+  "string1"
+  "string2"
   end
 end

--- a/test/prism_regression/ensure.parse-tree.exp
+++ b/test/prism_regression/ensure.parse-tree.exp
@@ -24,25 +24,16 @@ Begin {
       body = Ensure {
         body = Begin {
           stmts = [
-            Send {
-              receiver = NULL
-              method = <U method_1>
-              args = [
-              ]
+            String {
+              val = <U string1>
             }
-            Send {
-              receiver = NULL
-              method = <U method_2>
-              args = [
-              ]
+            String {
+              val = <U string2>
             }
           ]
         }
-        ensure = Send {
-          receiver = NULL
-          method = <U ensured_method>
-          args = [
-          ]
+        ensure = String {
+          val = <U ensured>
         }
       }
     }
@@ -51,11 +42,8 @@ Begin {
       args = NULL
       body = Ensure {
         body = NULL
-        ensure = Send {
-          receiver = NULL
-          method = <U ensured_method>
-          args = [
-          ]
+        ensure = String {
+          val = <U ensured>
         }
       }
     }
@@ -67,25 +55,16 @@ Begin {
           Ensure {
             body = Begin {
               stmts = [
-                Send {
-                  receiver = NULL
-                  method = <U method_1>
-                  args = [
-                  ]
+                String {
+                  val = <U string1>
                 }
-                Send {
-                  receiver = NULL
-                  method = <U method_2>
-                  args = [
-                  ]
+                String {
+                  val = <U string2>
                 }
               ]
             }
-            ensure = Send {
-              receiver = NULL
-              method = <U ensured_method_in_begin>
-              args = [
-              ]
+            ensure = String {
+              val = <U ensured>
             }
           }
         ]
@@ -96,33 +75,21 @@ Begin {
         Ensure {
           body = Begin {
             stmts = [
-              Send {
-                receiver = NULL
-                method = <U method_1>
-                args = [
-                ]
+              String {
+                val = <U string1>
               }
-              Send {
-                receiver = NULL
-                method = <U method_2>
-                args = [
-                ]
+              String {
+                val = <U string2>
               }
             ]
           }
           ensure = Begin {
             stmts = [
-              Send {
-                receiver = NULL
-                method = <U ensured_method_1>
-                args = [
-                ]
+              String {
+                val = <U ensured1>
               }
-              Send {
-                receiver = NULL
-                method = <U ensured_method_2>
-                args = [
-                ]
+              String {
+                val = <U ensured2>
               }
             ]
           }
@@ -133,10 +100,14 @@ Begin {
       stmts = [
         Ensure {
           body = Rescue {
-            body = Send {
-              receiver = NULL
-              method = <U method_for_rescue_and_ensure>
-              args = [
+            body = Begin {
+              stmts = [
+                String {
+                  val = <U string1>
+                }
+                String {
+                  val = <U string2>
+                }
               ]
             }
             rescue = [

--- a/test/prism_regression/ensure.parse-tree.exp
+++ b/test/prism_regression/ensure.parse-tree.exp
@@ -18,6 +18,79 @@ Begin {
         }
       ]
     }
+    DefMethod {
+      name = <U method_with_ensure>
+      args = NULL
+      body = Ensure {
+        body = Begin {
+          stmts = [
+            Send {
+              receiver = NULL
+              method = <U method_1>
+              args = [
+              ]
+            }
+            Send {
+              receiver = NULL
+              method = <U method_2>
+              args = [
+              ]
+            }
+          ]
+        }
+        ensure = Send {
+          receiver = NULL
+          method = <U ensured_method>
+          args = [
+          ]
+        }
+      }
+    }
+    DefMethod {
+      name = <U empty_method_with_ensure>
+      args = NULL
+      body = Ensure {
+        body = NULL
+        ensure = Send {
+          receiver = NULL
+          method = <U ensured_method>
+          args = [
+          ]
+        }
+      }
+    }
+    DefMethod {
+      name = <U method_with_begin_and_ensure>
+      args = NULL
+      body = Kwbegin {
+        stmts = [
+          Ensure {
+            body = Begin {
+              stmts = [
+                Send {
+                  receiver = NULL
+                  method = <U method_1>
+                  args = [
+                  ]
+                }
+                Send {
+                  receiver = NULL
+                  method = <U method_2>
+                  args = [
+                  ]
+                }
+              ]
+            }
+            ensure = Send {
+              receiver = NULL
+              method = <U ensured_method_in_begin>
+              args = [
+              ]
+            }
+          }
+        ]
+      }
+    }
     Kwbegin {
       stmts = [
         Ensure {

--- a/test/prism_regression/ensure.rb
+++ b/test/prism_regression/ensure.rb
@@ -7,6 +7,30 @@ ensure
   bar
 end
 
+# Testing an ensure clause in a method definition
+def method_with_ensure
+  method_1
+  method_2
+ensure
+  ensured_method
+end
+
+# Testing an ensure clause in an empty method definition
+def empty_method_with_ensure
+ensure
+  ensured_method
+end
+
+# Testing an ensure clause in a begin block in a method definition
+def method_with_begin_and_ensure
+  begin
+    method_1
+    method_2
+  ensure
+    ensured_method_in_begin
+  end
+end
+
 # Testing an ensure clause with multiple methods
 begin
   method_1

--- a/test/prism_regression/ensure.rb
+++ b/test/prism_regression/ensure.rb
@@ -9,40 +9,41 @@ end
 
 # Testing an ensure clause in a method definition
 def method_with_ensure
-  method_1
-  method_2
+  "string1"
+  "string2"
 ensure
-  ensured_method
+  "ensured"
 end
 
 # Testing an ensure clause in an empty method definition
 def empty_method_with_ensure
 ensure
-  ensured_method
+  "ensured"
 end
 
 # Testing an ensure clause in a begin block in a method definition
 def method_with_begin_and_ensure
   begin
-    method_1
-    method_2
+    "string1"
+    "string2"
   ensure
-    ensured_method_in_begin
+    "ensured"
   end
 end
 
 # Testing an ensure clause with multiple methods
 begin
-  method_1
-  method_2
+  "string1"
+  "string2"
 ensure
-  ensured_method_1
-  ensured_method_2
+  "ensured1"
+  "ensured2"
 end
 
 # Testing a rescue clause with an else and ensure clause
 begin
-  method_for_rescue_and_ensure
+  "string1"
+  "string2"
 rescue
   "rescued rescue"
 else

--- a/test/prism_regression/rescue.parse-tree.exp
+++ b/test/prism_regression/rescue.parse-tree.exp
@@ -22,6 +22,25 @@ Begin {
         }
       ]
     }
+    DefMethod {
+      name = <U method_with_rescue>
+      args = NULL
+      body = Rescue {
+        body = Integer {
+          val = "123"
+        }
+        rescue = [
+          Resbody {
+            exception = NULL
+            var = NULL
+            body = String {
+              val = <U rescued>
+            }
+          }
+        ]
+        else_ = NULL
+      }
+    }
     Kwbegin {
       stmts = [
         Rescue {

--- a/test/prism_regression/rescue.parse-tree.exp
+++ b/test/prism_regression/rescue.parse-tree.exp
@@ -46,17 +46,11 @@ Begin {
         Rescue {
           body = Begin {
             stmts = [
-              Send {
-                receiver = NULL
-                method = <U foo>
-                args = [
-                ]
+              String {
+                val = <U string1>
               }
-              Send {
-                receiver = NULL
-                method = <U bar>
-                args = [
-                ]
+              String {
+                val = <U string2>
               }
             ]
           }
@@ -76,11 +70,8 @@ Begin {
     Kwbegin {
       stmts = [
         Rescue {
-          body = Send {
-            receiver = NULL
-            method = <U foo>
-            args = [
-            ]
+          body = String {
+            val = <U string1>
           }
           rescue = [
             Resbody {
@@ -105,11 +96,8 @@ Begin {
     Kwbegin {
       stmts = [
         Rescue {
-          body = Send {
-            receiver = NULL
-            method = <U foo>
-            args = [
-            ]
+          body = String {
+            val = <U string1>
           }
           rescue = [
             Resbody {
@@ -151,11 +139,8 @@ Begin {
     Kwbegin {
       stmts = [
         Rescue {
-          body = Send {
-            receiver = NULL
-            method = <U foo>
-            args = [
-            ]
+          body = String {
+            val = <U string1>
           }
           rescue = [
             Resbody {
@@ -182,11 +167,8 @@ Begin {
     Kwbegin {
       stmts = [
         Rescue {
-          body = Send {
-            receiver = NULL
-            method = <U foo>
-            args = [
-            ]
+          body = String {
+            val = <U string1>
           }
           rescue = [
             Resbody {
@@ -271,11 +253,8 @@ Begin {
     Kwbegin {
       stmts = [
         Rescue {
-          body = Send {
-            receiver = NULL
-            method = <U foo>
-            args = [
-            ]
+          body = String {
+            val = <U string1>
           }
           rescue = [
             Resbody {
@@ -363,11 +342,8 @@ Begin {
       stmts = [
         Ensure {
           body = Rescue {
-            body = Send {
-              receiver = NULL
-              method = <U foo>
-              args = [
-              ]
+            body = String {
+              val = <U string1>
             }
             rescue = [
               Resbody {

--- a/test/prism_regression/rescue.rb
+++ b/test/prism_regression/rescue.rb
@@ -7,6 +7,13 @@ rescue
   "rescued"
 end
 
+# Testing a simple rescue clause in a method definition
+def method_with_rescue
+  123
+rescue
+  "rescued"
+end
+
 # Testing a rescue clause with multiple body statements
 begin
   foo

--- a/test/prism_regression/rescue.rb
+++ b/test/prism_regression/rescue.rb
@@ -16,29 +16,29 @@ end
 
 # Testing a rescue clause with multiple body statements
 begin
-  foo
-  bar
+  "string1"
+  "string2"
 rescue
   "rescued"
 end
 
 # Testing a rescue clause with a specific exception
 begin
-  foo
+  "string1"
 rescue RuntimeError
   "rescued Foo"
 end
 
 # Testing a rescue clause with multiple exceptions and a variable assignment
 begin
-  foo
+  "string1"
 rescue RuntimeError, NotImplementedError => e
   "rescued Foo #{e}"
 end
 
 # Testing a rescue clause with an else clause
 begin
-  foo
+  "string1"
 rescue RuntimeError
   "rescued Foo"
 else
@@ -47,7 +47,7 @@ end
 
 # Testing multiple rescue clauses with different exceptions
 begin
-  foo
+  "string1"
 rescue RuntimeError => e
   "rescued Foo #{e}"
 rescue NotImplementedError => e
@@ -58,7 +58,7 @@ end
 
 # Testing multiple rescue clauses with different exceptions and a final else clause
 begin
-  foo
+  "string1"
 rescue RuntimeError => e
   "rescued Foo #{e}"
 rescue NotImplementedError => e
@@ -71,7 +71,7 @@ end
 
 # Testing a rescue clause with an else and ensure clause
 begin
-  foo
+  "string1"
 rescue
   "rescued rescue"
 else


### PR DESCRIPTION
### Motivation

If the method body is a `PM_BEGIN_NODE` instead of a `PM_STATEMENTS_NODE`, it means the method definition doesn't have an explicit begin block. If that's the case, we need to check if the body contains an ensure or rescue clause, and if so, we need to elevate that node to the top level of the method definition, without the `Kwbegin` node to match the behavior of Sorbet's legacy parser.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
