### PR TITLE
Extract `up_cast` helper.

### DIFF
--- a/parser/prism/BUILD
+++ b/parser/prism/BUILD
@@ -7,6 +7,7 @@ cc_library(
     hdrs = [
         "Parser.h",
         "Translator.h",
+        "Helpers.h",
     ],
     linkstatic = select({
         "//tools/config:linkshared": 0,

--- a/parser/prism/Helpers.h
+++ b/parser/prism/Helpers.h
@@ -1,0 +1,28 @@
+#ifndef SORBET_PARSER_PRISM_HELPERS_H
+#define SORBET_PARSER_PRISM_HELPERS_H
+
+#include <type_traits>
+extern "C" {
+#include "prism.h"
+}
+
+namespace sorbet::parser::Prism {
+
+using std::is_same_v;
+
+// Returns true if the given `T` is a Prism node types. All Prism node types start with a `pm_node_t base` member.
+template <typename T> constexpr bool isPrismNode = is_same_v<decltype(T::base), pm_node_t>;
+
+// Take a pointer to a Prism node "subclass" (a thing with an embedded `pm_node_t base` as its first member),
+// and up-casts it back to a general `pm_node_t` pointer.
+template <typename PrismNode> pm_node_t *up_cast(PrismNode *node) {
+    static_assert(!is_same_v<PrismNode, pm_node_t>,
+                  "There's no need to call `up_cast` here, because this is already a `pm_node_t`.");
+    static_assert(isPrismNode<PrismNode>,
+                  "The `up_cast` function should only be called on Prism node pointers.");
+    return reinterpret_cast<pm_node_t *>(node);
+}
+
+} // namespace sorbet::parser::Prism
+
+#endif // SORBET_PARSER_PRISM_HELPERS_H

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1,4 +1,5 @@
 #include "Translator.h"
+#include "Helpers.h"
 
 template class std::unique_ptr<sorbet::parser::Node>;
 
@@ -180,7 +181,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             if (beginNode->rescue_clause != nullptr) {
                 // Extract rescue and else nodes from the begin node
                 auto bodyNode = translateStatements(beginNode->statements, true);
-                auto elseNode = translate(reinterpret_cast<pm_node_t *>(beginNode->else_clause));
+                auto elseNode = translate(up_cast(beginNode->else_clause));
                 // We need to pass the rescue node to the Ensure node if it exists instead of adding it to the
                 // statements
                 translatedRescue = translateRescue(reinterpret_cast<pm_rescue_node *>(beginNode->rescue_clause),
@@ -249,7 +250,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             // Sorbet's legacy parser inserts locals (Shadowargs) into the block's Args node, along with its other
             // parameters. So we need to extract the args vector from the Args node, and insert the locals at the end of
             // it.
-            auto sorbetArgsNode = translate(reinterpret_cast<pm_node *>(paramsNode->parameters));
+            auto sorbetArgsNode = translate(up_cast(paramsNode->parameters));
             auto argsNode = dynamic_cast<parser::Args *>(sorbetArgsNode.get());
             auto sorbetShadowArgs = translateMulti(paramsNode->locals);
             // Sorbet's legacy parser inserts locals (Shadowargs) at the end of the the block's Args node
@@ -348,7 +349,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
 
             auto predicate = translate(caseMatchNode->predicate);
             auto sorbetConditions = patternTranslateMulti(caseMatchNode->conditions);
-            auto elseClause = translate(reinterpret_cast<pm_node_t *>(caseMatchNode->else_clause));
+            auto elseClause = translate(up_cast(caseMatchNode->else_clause));
 
             return make_unique<parser::CaseMatch>(location, move(predicate), move(sorbetConditions), move(elseClause));
         }
@@ -357,7 +358,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
 
             auto predicate = translate(caseNode->predicate);
             auto sorbetConditions = translateMulti(caseNode->conditions);
-            auto elseClause = translate(reinterpret_cast<pm_node_t *>(caseNode->else_clause));
+            auto elseClause = translate(up_cast(caseNode->else_clause));
 
             return make_unique<Case>(location, move(predicate), move(sorbetConditions), move(elseClause));
         }
@@ -459,7 +460,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             }
 
             auto name = parser.resolveConstant(defNode->name);
-            auto params = translate(reinterpret_cast<pm_node *>(defNode->parameters));
+            auto params = translate(up_cast(defNode->parameters));
             auto body = translate(defNode->body);
 
             if (defNode->body != nullptr && PM_NODE_TYPE_P(defNode->body, PM_BEGIN_NODE)) {
@@ -473,11 +474,11 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
                 if (kwbeginNode != nullptr && kwbeginNode->stmts[0] != nullptr &&
                     (dynamic_cast<parser::Rescue *>(kwbeginNode->stmts[0].get()) != nullptr ||
                      dynamic_cast<parser::Ensure *>(kwbeginNode->stmts[0].get()) != nullptr)) {
-
                     if (kwbeginNode->stmts.size() == 1) {
                         body = move(kwbeginNode->stmts[0]);
                     } else {
-                        unreachable("With ensure or rescue, the body of a method definition will be either a rescue or ensure node.");
+                        unreachable("With ensure or rescue, the body of a method definition will be either a rescue or "
+                                    "ensure node.");
                     }
                 }
             }
@@ -493,7 +494,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
         }
         case PM_ELSE_NODE: { // An `else` clauses, which can pertain to an `if`, `begin`, `case`, etc.
             auto elseNode = reinterpret_cast<pm_else_node *>(node);
-            return translate(reinterpret_cast<pm_node *>(elseNode->statements));
+            return translate(up_cast(elseNode->statements));
         }
         case PM_EMBEDDED_STATEMENTS_NODE: { // Statements interpolated into a string.
             // e.g. the `#{bar}` in `"foo #{bar} baz"`
@@ -573,7 +574,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             auto ifNode = reinterpret_cast<pm_if_node *>(node);
 
             auto predicate = translate(ifNode->predicate);
-            auto ifTrue = translate(reinterpret_cast<pm_node *>(ifNode->statements));
+            auto ifTrue = translate(up_cast(ifNode->statements));
             auto ifFalse = translate(ifNode->subsequent);
 
             return make_unique<parser::If>(location, move(predicate), move(ifTrue), move(ifFalse));
@@ -914,7 +915,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             }
 
             if (paramsNode->block != nullptr)
-                params.emplace_back(translate(reinterpret_cast<pm_node *>(paramsNode->block)));
+                params.emplace_back(translate(up_cast(paramsNode->block)));
 
             return make_unique<parser::Args>(location, move(params));
         }
@@ -937,7 +938,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
         case PM_PROGRAM_NODE: { // The root node of the parse tree, representing the entire program
             pm_program_node *programNode = reinterpret_cast<pm_program_node *>(node);
 
-            return translate(reinterpret_cast<pm_node *>(programNode->statements));
+            return translate(up_cast(programNode->statements));
         }
         case PM_POST_EXECUTION_NODE: {
             auto postExecutionNode = reinterpret_cast<pm_post_execution_node *>(node);
@@ -996,8 +997,8 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
         }
         case PM_RESCUE_MODIFIER_NODE: {
             auto rescueModifierNode = reinterpret_cast<pm_rescue_modifier_node *>(node);
-            auto body = translate(reinterpret_cast<pm_node *>(rescueModifierNode->expression));
-            auto rescue = translate(reinterpret_cast<pm_node *>(rescueModifierNode->rescue_expression));
+            auto body = translate(up_cast(rescueModifierNode->expression));
+            auto rescue = translate(up_cast(rescueModifierNode->rescue_expression));
             NodeVec cases;
             // In rescue modifiers, users can't specify exceptions and the variable name so they're null
             cases.emplace_back(make_unique<parser::Resbody>(location, nullptr, nullptr, move(rescue)));
@@ -1116,8 +1117,8 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
 
             auto predicate = translate(unlessNode->predicate);
             // These are flipped relative to `PM_IF_NODE`
-            auto ifFalse = translate(reinterpret_cast<pm_node *>(unlessNode->statements));
-            auto ifTrue = translate(reinterpret_cast<pm_node *>(unlessNode->else_clause));
+            auto ifFalse = translate(up_cast(unlessNode->statements));
+            auto ifTrue = translate(up_cast(unlessNode->else_clause));
 
             return make_unique<parser::If>(location, move(predicate), move(ifTrue), move(ifFalse));
         }
@@ -1125,7 +1126,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             auto untilNode = reinterpret_cast<pm_until_node *>(node);
 
             auto predicate = translate(untilNode->predicate);
-            auto body = translate(reinterpret_cast<pm_node *>(untilNode->statements));
+            auto body = translate(up_cast(untilNode->statements));
 
             return make_unique<parser::Until>(location, move(predicate), move(body));
         }

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -997,8 +997,8 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
         }
         case PM_RESCUE_MODIFIER_NODE: {
             auto rescueModifierNode = reinterpret_cast<pm_rescue_modifier_node *>(node);
-            auto body = translate(up_cast(rescueModifierNode->expression));
-            auto rescue = translate(up_cast(rescueModifierNode->rescue_expression));
+            auto body = translate(rescueModifierNode->expression);
+            auto rescue = translate(rescueModifierNode->rescue_expression);
             NodeVec cases;
             // In rescue modifiers, users can't specify exceptions and the variable name so they're null
             cases.emplace_back(make_unique<parser::Resbody>(location, nullptr, nullptr, move(rescue)));


### PR DESCRIPTION
### Motivation

`reinterpret_cast` is a sharp blade, and we use it a lot. This is the first of several PRs that aims to tame our use of reinterpret casts, by wrapping them into helpers that add static and/or runtime checks to help ensure they're being used correctly.

This PR adds `up_cast`, which takes a pointer to any Prism node type, and casts it back to a `pm_node_t *`. This replaces usages of `reinterpret_cast<pm_node_t *>`, which is more dangerous because it could be given any type of pointer, not necessarily a Prism node.

One nice feature is that if the input type is _already_ `pm_node_t`, then this helper will raise a compiler error, telling you that you didn't need it.

```
In file included from parser/prism/Translator.cc:2:
parser/prism/Helpers.h:166:5: error: static assertion failed due to requirement '!std::is_same_v<pm_node, pm_node>':
There's no need to call `up_cast` here, because this is already a `pm_node_t`.
    static_assert(!std::is_same_v<PrismNode, pm_node_t>,
    ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
parser/prism/Translator.cc:999:35: note: in instantiation of function template specialization 'sorbet::parser::Prism::up_cast<pm_node>' requested here
            auto body = translate(up_cast(rescueModifierNode->expression));
                                  ^
```

I considered other names like `erase_type`, but that didn't fit as nicely with its counterpart, `down_cast` (coming soon™️).

### Test plan

This is covered by the existing tests.