### PR TITLE
Translate conditionals in `in` statements

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1359,6 +1359,18 @@ unique_ptr<parser::Node> Translator::patternTranslate(pm_node_t *node) {
                 auto sorbetGuard = make_unique<parser::IfGuard>(location, translate(ifNode->predicate));
 
                 return make_unique<parser::InPattern>(location, move(sorbetPattern), move(sorbetGuard), move(statements));
+            } else if (prismPattern != nullptr && PM_NODE_TYPE_P(prismPattern, PM_UNLESS_NODE)) {
+                auto unlessNode = reinterpret_cast<pm_unless_node *>(prismPattern);
+                auto prismStatements = reinterpret_cast<pm_statements_node *>(unlessNode->statements);
+
+                if (prismStatements->body.size != 1) {
+                    unreachable("In pattern-matching's `in` clause, an `unless` guard must have a single statement.");
+                }
+
+                auto sorbetPattern = patternTranslate(prismStatements->body.nodes[0]);
+                auto sorbetGuard = make_unique<parser::UnlessGuard>(location, translate(unlessNode->predicate));
+
+                return make_unique<parser::InPattern>(location, move(sorbetPattern), move(sorbetGuard), move(statements));
             } else {
                 auto sorbetPattern = patternTranslate(prismPattern);
 

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1343,39 +1343,36 @@ unique_ptr<parser::Node> Translator::patternTranslate(pm_node_t *node) {
         case PM_IN_NODE: { // An `in` pattern such as in a `case` statement, or as a standalone expression.
             auto inNode = down_cast<pm_in_node>(node);
 
-            auto prismPattern = move(inNode->pattern);
+            auto prismPattern = inNode->pattern;
+            unique_ptr<parser::Node> sorbetPattern;
+            unique_ptr<parser::Node> sorbetGuard;
             auto inlineIfSingle = true;
             auto statements = translateStatements(inNode->statements, inlineIfSingle);
 
-            if (prismPattern != nullptr && PM_NODE_TYPE_P(prismPattern, PM_IF_NODE)) {
-                auto ifNode = reinterpret_cast<pm_if_node *>(prismPattern);
-                auto prismStatements = reinterpret_cast<pm_statements_node *>(ifNode->statements);
+            if (prismPattern != nullptr &&
+                (PM_NODE_TYPE_P(prismPattern, PM_IF_NODE) || PM_NODE_TYPE_P(prismPattern, PM_UNLESS_NODE))) {
+                pm_statements_node *conditionalStatements = nullptr;
 
-                if (prismStatements->body.size != 1) {
-                    unreachable("In pattern-matching's `in` clause, an `if` guard must have a single statement.");
+                if (PM_NODE_TYPE_P(prismPattern, PM_IF_NODE)) {
+                    auto ifNode = down_cast<pm_if_node>(prismPattern);
+                    conditionalStatements = ifNode->statements;
+                    sorbetGuard = make_unique<parser::IfGuard>(location, translate(ifNode->predicate));
+                } else { // PM_UNLESS_NODE
+                    auto unlessNode = down_cast<pm_unless_node>(prismPattern);
+                    conditionalStatements = unlessNode->statements;
+                    sorbetGuard = make_unique<parser::UnlessGuard>(location, translate(unlessNode->predicate));
                 }
 
-                auto sorbetPattern = patternTranslate(prismStatements->body.nodes[0]);
-                auto sorbetGuard = make_unique<parser::IfGuard>(location, translate(ifNode->predicate));
+                ENFORCE(
+                    conditionalStatements->body.size == 1,
+                    "In pattern-matching's `in` clause, a conditional (if/unless) guard must have a single statement.");
 
-                return make_unique<parser::InPattern>(location, move(sorbetPattern), move(sorbetGuard), move(statements));
-            } else if (prismPattern != nullptr && PM_NODE_TYPE_P(prismPattern, PM_UNLESS_NODE)) {
-                auto unlessNode = reinterpret_cast<pm_unless_node *>(prismPattern);
-                auto prismStatements = reinterpret_cast<pm_statements_node *>(unlessNode->statements);
-
-                if (prismStatements->body.size != 1) {
-                    unreachable("In pattern-matching's `in` clause, an `unless` guard must have a single statement.");
-                }
-
-                auto sorbetPattern = patternTranslate(prismStatements->body.nodes[0]);
-                auto sorbetGuard = make_unique<parser::UnlessGuard>(location, translate(unlessNode->predicate));
-
-                return make_unique<parser::InPattern>(location, move(sorbetPattern), move(sorbetGuard), move(statements));
+                sorbetPattern = patternTranslate(conditionalStatements->body.nodes[0]);
             } else {
-                auto sorbetPattern = patternTranslate(prismPattern);
-
-                return make_unique<parser::InPattern>(location, move(sorbetPattern), nullptr, move(statements));
+                sorbetPattern = patternTranslate(prismPattern);
             }
+
+            return make_unique<parser::InPattern>(location, move(sorbetPattern), move(sorbetGuard), move(statements));
         }
         case PM_LOCAL_VARIABLE_TARGET_NODE: { // A variable binding in a pattern, like the `head` in `[head, *tail]`
             auto localVarTargetNode = down_cast<pm_local_variable_target_node>(node);

--- a/test/prism_regression/case_match.parse-tree.exp
+++ b/test/prism_regression/case_match.parse-tree.exp
@@ -354,5 +354,102 @@ Begin {
       ]
       elseBody = NULL
     }
+    CaseMatch {
+      expr = Send {
+        receiver = NULL
+        method = <U bar>
+        args = [
+        ]
+      }
+      inBodies = [
+        InPattern {
+          pattern = MatchVar {
+            name = <U x>
+          }
+          guard = IfGuard {
+            condition = Send {
+              receiver = LVar {
+                name = <U x>
+              }
+              method = <U ==>
+              args = [
+                Integer {
+                  val = "1"
+                }
+              ]
+            }
+          }
+          body = String {
+            val = <U in with if>
+          }
+        }
+        InPattern {
+          pattern = ArrayPattern {
+            elts = [
+              MatchVar {
+                name = <U a>
+              }
+              MatchVar {
+                name = <U b>
+              }
+            ]
+          }
+          guard = IfGuard {
+            condition = Send {
+              receiver = LVar {
+                name = <U b>
+              }
+              method = <U ==>
+              args = [
+                Integer {
+                  val = "2"
+                }
+              ]
+            }
+          }
+          body = String {
+            val = <U in with 2 args and if>
+          }
+        }
+        InPattern {
+          pattern = ArrayPattern {
+            elts = [
+              MatchVar {
+                name = <U c>
+              }
+              MatchVar {
+                name = <U d>
+              }
+            ]
+          }
+          guard = NULL
+          body = Begin {
+            stmts = [
+              If {
+                condition = Send {
+                  receiver = LVar {
+                    name = <U c>
+                  }
+                  method = <U ==>
+                  args = [
+                    Integer {
+                      val = "3"
+                    }
+                  ]
+                }
+                then_ = LVar {
+                  name = <U c>
+                }
+                else_ = NULL
+              }
+              String {
+                val = <U in with 2 args, semicolon, and if>
+              }
+            ]
+          }
+        }
+      ]
+      elseBody = NULL
+    }
   ]
 }

--- a/test/prism_regression/case_match.parse-tree.exp
+++ b/test/prism_regression/case_match.parse-tree.exp
@@ -451,5 +451,102 @@ Begin {
       ]
       elseBody = NULL
     }
+    CaseMatch {
+      expr = Send {
+        receiver = NULL
+        method = <U baz>
+        args = [
+        ]
+      }
+      inBodies = [
+        InPattern {
+          pattern = MatchVar {
+            name = <U x>
+          }
+          guard = UnlessGuard {
+            condition = Send {
+              receiver = LVar {
+                name = <U x>
+              }
+              method = <U ==>
+              args = [
+                Integer {
+                  val = "1"
+                }
+              ]
+            }
+          }
+          body = String {
+            val = <U in with unless>
+          }
+        }
+        InPattern {
+          pattern = ArrayPattern {
+            elts = [
+              MatchVar {
+                name = <U a>
+              }
+              MatchVar {
+                name = <U b>
+              }
+            ]
+          }
+          guard = UnlessGuard {
+            condition = Send {
+              receiver = LVar {
+                name = <U b>
+              }
+              method = <U ==>
+              args = [
+                Integer {
+                  val = "2"
+                }
+              ]
+            }
+          }
+          body = String {
+            val = <U in with 2 args and unless>
+          }
+        }
+        InPattern {
+          pattern = ArrayPattern {
+            elts = [
+              MatchVar {
+                name = <U c>
+              }
+              MatchVar {
+                name = <U d>
+              }
+            ]
+          }
+          guard = NULL
+          body = Begin {
+            stmts = [
+              If {
+                condition = Send {
+                  receiver = LVar {
+                    name = <U c>
+                  }
+                  method = <U ==>
+                  args = [
+                    Integer {
+                      val = "3"
+                    }
+                  ]
+                }
+                then_ = NULL
+                else_ = LVar {
+                  name = <U c>
+                }
+              }
+              String {
+                val = <U in with 2 args, semicolon, and unless>
+              }
+            ]
+          }
+        }
+      ]
+      elseBody = NULL
+    }
   ]
 }

--- a/test/prism_regression/case_match.rb
+++ b/test/prism_regression/case_match.rb
@@ -43,3 +43,12 @@ in 1
   "one!"
   puts "surprise, multi-line!"
 end
+
+case bar
+in x if x == 1
+  "in with if"
+in a, b if b == 2
+  "in with 2 args and if"
+in c, d; c if c == 3
+  "in with 2 args, semicolon, and if"
+end

--- a/test/prism_regression/case_match.rb
+++ b/test/prism_regression/case_match.rb
@@ -44,6 +44,7 @@ in 1
   puts "surprise, multi-line!"
 end
 
+# pattern matching with if guards
 case bar
 in x if x == 1
   "in with if"
@@ -51,4 +52,14 @@ in a, b if b == 2
   "in with 2 args and if"
 in c, d; c if c == 3
   "in with 2 args, semicolon, and if"
+end
+
+# pattern matching with unless guards
+case baz
+in x unless x == 1
+  "in with unless"
+in a, b unless b == 2
+  "in with 2 args and unless"
+in c, d; c unless c == 3
+  "in with 2 args, semicolon, and unless"
 end

--- a/test/prism_regression/if.parse-tree.exp
+++ b/test/prism_regression/if.parse-tree.exp
@@ -1,6 +1,26 @@
-If {
-  condition = True {
-  }
-  then_ = NULL
-  else_ = NULL
+Begin {
+  stmts = [
+    If {
+      condition = Send {
+        receiver = NULL
+        method = <U condition>
+        args = [
+        ]
+      }
+      then_ = NULL
+      else_ = NULL
+    }
+    If {
+      condition = Send {
+        receiver = NULL
+        method = <U condition>
+        args = [
+        ]
+      }
+      then_ = String {
+        val = <U value>
+      }
+      else_ = NULL
+    }
+  ]
 }

--- a/test/prism_regression/if.rb
+++ b/test/prism_regression/if.rb
@@ -1,3 +1,5 @@
 # typed: false
 
-if true; end
+if condition; end
+
+"value" if condition

--- a/test/prism_regression/unless.parse-tree.exp
+++ b/test/prism_regression/unless.parse-tree.exp
@@ -1,8 +1,24 @@
-If {
-  condition = True {
-  }
-  then_ = NULL
-  else_ = String {
-    val = <U body>
-  }
+Begin {
+  stmts = [
+    If {
+      condition = True {
+      }
+      then_ = NULL
+      else_ = String {
+        val = <U body>
+      }
+    }
+    If {
+      condition = Send {
+        receiver = NULL
+        method = <U condition>
+        args = [
+        ]
+      }
+      then_ = NULL
+      else_ = String {
+        val = <U value>
+      }
+    }
+  ]
 }

--- a/test/prism_regression/unless.rb
+++ b/test/prism_regression/unless.rb
@@ -3,3 +3,5 @@
 unless true
   "body"
 end
+
+"value" unless condition


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation

Closes #204

When investigating #204 I found that Parser's `IfGuard` and `UnlessGuard` are associated with these comments:

<img width="50%" alt="Screenshot 2024-10-24 at 18 56 46" src="https://github.com/user-attachments/assets/acc335ac-4ced-4860-8051-dfdee4ee88d1">

And I found that they're not handled by the current pattern translation yet. For example:

```rb
# pattern matching with if guards
case bar
in x if x == 1
  "in with if"
in a, b if b == 2
  "in with 2 args and if"
in c, d; c if c == 3
  "in with 2 args, semicolon, and if"
end

# pattern matching with unless guards
case baz
in x unless x == 1
  "in with unless"
in a, b unless b == 2
  "in with 2 args and unless"
in c, d; c unless c == 3
  "in with 2 args, semicolon, and unless"
end
```

So this PR adds support for those cases.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
