### PR TITLE
Implement Prism -> Sorbet translation for Regexp match writes

### DIFF
--- a/test/prism_regression/match_write.parse-tree.exp
+++ b/test/prism_regression/match_write.parse-tree.exp
@@ -1,0 +1,46 @@
+Begin {
+  stmts = [
+    Send {
+      receiver = Regexp {
+        regex = [
+          String {
+            val = <U (?<new_local_var1> foo)>
+          }
+        ]
+        opts = Regopt {
+          opts = ""
+        }
+      }
+      method = <U =~>
+      args = [
+        Send {
+          receiver = NULL
+          method = <U input1>
+          args = [
+          ]
+        }
+      ]
+    }
+    Send {
+      receiver = Regexp {
+        regex = [
+          String {
+            val = <U (?<new_local_var2> bar) (?<new_local_var3> baz)>
+          }
+        ]
+        opts = Regopt {
+          opts = ""
+        }
+      }
+      method = <U =~>
+      args = [
+        Send {
+          receiver = NULL
+          method = <U input2>
+          args = [
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/prism_regression/match_write.rb
+++ b/test/prism_regression/match_write.rb
@@ -1,0 +1,12 @@
+# typed: false
+
+# "Match writes" let you bind regex capture groups directly into new variables.
+# Sorbet doesn't treat this syntax in a special way, so it doesn't know that it introduces new local variables.
+
+# Assigns the captured value to `new_local_var1`
+/(?<new_local_var1> foo)/ =~ input1
+
+# Test multiple captures
+/(?<new_local_var2> bar) (?<new_local_var3> baz)/ =~ input2
+
+# This does not work for Constants, @instance_var, @@class_var or @global_var


### PR DESCRIPTION
Closes #135.

Match writes are code like:

```ruby
/(?<new_local_var1> foo)/ =~ input1
```

Which binds the capture group's value to a new local variable called `new_local_var1`.

Sorbet doesn't know about this behaviour, and just treats this as a regular call to `Regexp#=~`.