### PR TITLE
Remove unnecessary task to set `BAZEL_EXEC_ROOT`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,11 +29,11 @@
             "name": "Debug Prism test in LLDB",
             "program": "${workspaceFolder}/bazel-bin/test/test_PosTests/prism_regression/${input:test_name}.runfiles/com_stripe_ruby_typer/test/pipeline_test_runner",
             "args": ["--single_test=${workspaceFolder}/test/prism_regression/${input:test_name}.rb", "--parser=prism"],
-            // See .vscode/tasks.json for the task that sets the `BAZEL_EXEC_ROOT` environment variable.
-            "preLaunchTask": "Prepare tests debugging",
+            // We need to run all tests to generate the pipeline_test_runner files, which are needed by the LLDB debugger to execute the tests.
+            "preLaunchTask": "Run all Prism tests",
             "stopOnEntry": false,
             "sourceMap": {
-                "${env:BAZEL_EXEC_ROOT}": "${workspaceFolder}",
+                "": "${workspaceFolder}",
             },
         },
         {
@@ -45,7 +45,7 @@
             "preLaunchTask": "Build with Prism",
             "stopOnEntry": false,
             "sourceMap": {
-                "${env:BAZEL_EXEC_ROOT}": "${workspaceFolder}",
+                "": "${workspaceFolder}",
             },
         },
     ],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -69,23 +69,6 @@
                 "reveal": "always"
             }
         },
-        // This task:
-        // - Runs tests to generate the pipeline_test_runner files, which are needed by the LLDB
-        //   debugger to execute the tests.
-        // - Sets the `BAZEL_EXEC_ROOT` environment variable, which is used by the LLDB
-        //   debugger to find the source files.
-        {
-            "label": "Prepare tests debugging",
-            "type": "shell",
-            "command": "export BAZEL_EXEC_ROOT=$(./bazel info execution_root)",
-            // We need to run tests first to get the pipeline_test_runner files generated
-            // Just building Sorbet with Prism doesn't generate them.
-            "dependsOn": ["Run all Prism tests"],
-            "hide": true,
-            "presentation": {
-                "reveal": "never",
-            }
-        }
     ],
     "inputs": [
         {


### PR DESCRIPTION
It turns out that we only need `sourceMap`'s value to be set to the workspace folder with any arbitrary key. So not setting `BAZEL_EXEC_ROOT` is fine.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation

When reviewing #312, I [found](https://github.com/Shopify/sorbet/pull/312/files#r1821555693) that having bazel's execroot being the source map key is actually unnecessary. What's required seems to just be the value being the workspace folder. So in this PR I'm removing the task that sets `BAZEL_EXEC_ROOT` and updating `launch.json` entries.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
