### PR TITLE
Fix edge case for lambda with no params

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -245,6 +245,10 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
         case PM_BLOCK_PARAMETERS_NODE: { // The parameters declared at the top of a PM_BLOCK_NODE
             auto paramsNode = down_cast<pm_block_parameters_node>(node);
 
+            if (paramsNode->parameters == nullptr) {
+                return make_unique<parser::Args>(location, NodeVec{});
+            }
+
             // Sorbet's legacy parser inserts locals (Shadowargs) into the block's Args node, along with its other
             // parameters. So we need to extract the args vector from the Args node, and insert the locals at the end of
             // it.

--- a/test/prism_regression/lambda.parse-tree.exp
+++ b/test/prism_regression/lambda.parse-tree.exp
@@ -192,5 +192,31 @@ Begin {
         }
       }
     }
+    Block {
+      send = Send {
+        receiver = Const {
+          scope = NULL
+          name = <C <U Kernel>>
+        }
+        method = <U lambda>
+        args = [
+        ]
+      }
+      args = Args {
+        args = [
+        ]
+      }
+      body = Send {
+        receiver = Integer {
+          val = "1"
+        }
+        method = <U +>
+        args = [
+          Integer {
+            val = "2"
+          }
+        ]
+      }
+    }
   ]
 }

--- a/test/prism_regression/lambda.rb
+++ b/test/prism_regression/lambda.rb
@@ -19,3 +19,6 @@ class C
     -> { 123 }
   end
 end
+
+# Empty lambda parameters
+->() { 1 + 2 }


### PR DESCRIPTION
### Motivation
We didn't have a test case for lambdas with no block parameters. Sorbet represents this case with an empty `Args` node, so we can check whether the `parameters` field inside a `PM_BLOCK_PARAMETERS_NODE` is a `nullptr`, and then return early if so.

### Test plan
See included automated tests.
