### PR TITLE
Fix crash when attempting to dow-cast `nullptr` in debug builds

### DIFF
--- a/parser/prism/Helpers.h
+++ b/parser/prism/Helpers.h
@@ -184,7 +184,7 @@ template <typename PrismNode> pm_node_t *up_cast(PrismNode *node) {
 template <typename PrismNode> PrismNode *down_cast(pm_node_t *anyNode) {
     static_assert(std::is_same_v<decltype(PrismNode::base), pm_node_t>,
                   "The `down_cast` function should only be called on Prism node pointers.");
-    ENFORCE(PM_NODE_TYPE_P(anyNode, PrismNodeTypeHelper<PrismNode>::TypeID),
+    ENFORCE(anyNode == nullptr || PM_NODE_TYPE_P(anyNode, PrismNodeTypeHelper<PrismNode>::TypeID),
             "Failed to cast a Prism AST Node. Expected {} (#{}), but got {} (#{}).",
             pm_node_type_to_str(PrismNodeTypeHelper<PrismNode>::TypeID), PrismNodeTypeHelper<PrismNode>::TypeID,
             pm_node_type_to_str(PM_NODE_TYPE(anyNode)), PM_NODE_TYPE(anyNode));


### PR DESCRIPTION
### Motivation

In our debug builds, our `down_cast` helper verifies that the pointed-to node actually is the kind of node we're trying to cast it to. Doing this requires us to check the `type` field, which will fail if given `nullptr`.

We modify the `ENFORCE` check to either:

1. Allow `nullptr`
2. otherwise nullptr, check for the correct type.

This is safe because of the short-circuiting behaviour of `||`.

### Test plan
Automated tests continue to pass