### PR TITLE
Fix bugs in translation of `PM_RESCUE_NODE`

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -80,7 +80,8 @@ unique_ptr<SorbetAssignmentNode> Translator::translateOpAssignment(pm_node_t *un
                          is_same_v<PrismAssignmentNode, pm_constant_path_and_write_node> ||
                          is_same_v<PrismAssignmentNode, pm_constant_path_or_write_node>) {
         // Handle operator assignment to a constant path, like `A::B::C += 1` or `::C += 1`
-        lhs = translateConst<pm_constant_path_node, parser::ConstLhs>(node->target);
+        bool skipDynamicConstantWorkaround = true;
+        lhs = translateConst<pm_constant_path_node, parser::ConstLhs>(node->target, skipDynamicConstantWorkaround);
     } else if constexpr (is_same_v<SorbetLHSNode, parser::Send>) {
         // Handle operator assignment to the result of a method call, like `a.b += 1`
         auto name = parser.resolveConstant(node->read_name);
@@ -1631,10 +1632,20 @@ unique_ptr<parser::Node> Translator::translateStatements(pm_statements_node *stm
 
 // Handles any one of the Prism nodes that models any kind of assignment to a constant or constant path.
 //
+// Dynamic constant assignment inside of a method definition will raise a SyntaxError at runtime. In the
+// Sorbet validator, there is a check that will crash Sorbet if this is detected statically.
+// To work around this, we substitute dynamic constant assignments with a write to a fake local variable
+// called `dynamicConstAssign`.
+//
+// The only exception is that dynamic constant path *operator* assignments inside of a method definition
+// do not raise a SyntaxError at runtime, so we want to skip the workaround in that case.
+// However, within this method, both regular constant path assignments and constant path operator assignments
+// are passed in as `pm_constant_path_node` types, so we need an extra boolean flag to know when to skip the workaround.
+//
 // Usually returns the `SorbetLHSNode`, but for constant writes and targets,
 // it can can return an `LVarLhs` as a workaround in the case of a dynamic constant assignment.
 template <typename PrismLhsNode, typename SorbetLHSNode>
-unique_ptr<parser::Node> Translator::translateConst(PrismLhsNode *node) {
+unique_ptr<parser::Node> Translator::translateConst(PrismLhsNode *node, bool skipDynamicConstantWorkaround) {
     static_assert(is_same_v<SorbetLHSNode, parser::Const> || is_same_v<SorbetLHSNode, parser::ConstLhs>,
                   "Invalid LHS type. Must be one of `parser::Const` or `parser::ConstLhs`.");
 
@@ -1673,7 +1684,8 @@ unique_ptr<parser::Node> Translator::translateConst(PrismLhsNode *node) {
                   is_same_v<PrismLhsNode, pm_constant_operator_write_node> ||
                   is_same_v<PrismLhsNode, pm_constant_or_write_node> ||
                   is_same_v<PrismLhsNode, pm_constant_and_write_node>) {
-        if (isInMethodDef) { // Check if this is a dynamic constant assignment (SyntaxError at runtime)
+        if (isInMethodDef &&
+            !skipDynamicConstantWorkaround) { // Check if this is a dynamic constant assignment (SyntaxError at runtime)
             // This is a copy of a workaround from `Desugar.cc`, which substitues in a fake assignment,
             // so the parsing can continue. See other usages of `dynamicConstAssign` for more details.
 
@@ -1774,5 +1786,4 @@ void Translator::reportError(core::LocOffsets loc, const std::string &message) {
         e.setHeader("{}", message);
     }
 }
-
 }; // namespace sorbet::parser::Prism

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1585,6 +1585,7 @@ unique_ptr<parser::Node> Translator::translateCallWithBlock(pm_node_t *prismBloc
 // (and its linked `subsequent` nodes) and assembling the corresponding `Rescue` and `Resbody` nodes in Sorbet's AST.
 unique_ptr<parser::Node> Translator::translateRescue(pm_rescue_node *prismRescueNode, unique_ptr<parser::Node> bodyNode,
                                                      unique_ptr<parser::Node> elseNode) {
+    auto rescueLoc = translateLoc(prismRescueNode->base.location);
     NodeVec rescueBodies;
 
     // Each `rescue` clause generates a `Resbody` node, which is a child of the `Rescue` node.
@@ -1608,7 +1609,7 @@ unique_ptr<parser::Node> Translator::translateRescue(pm_rescue_node *prismRescue
     }
 
     // The `Rescue` node combines the main body, the rescue clauses, and the else clause.
-    return make_unique<parser::Rescue>(bodyNode->loc, move(bodyNode), move(rescueBodies), move(elseNode));
+    return make_unique<parser::Rescue>(rescueLoc, move(bodyNode), move(rescueBodies), move(elseNode));
 }
 
 // Translates the given Prism Statements Node into a `parser::Begin` node or an inlined `parser::Node`.

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1669,7 +1669,10 @@ unique_ptr<parser::Node> Translator::translateConst(PrismLhsNode *node) {
     auto location = translateLoc(node->base.location);
     auto name = parser.resolveConstant(node->name);
 
-    if constexpr (is_same_v<PrismLhsNode, pm_constant_write_node> || is_same_v<PrismLhsNode, pm_constant_path_node>) {
+    if constexpr (is_same_v<PrismLhsNode, pm_constant_write_node> || is_same_v<PrismLhsNode, pm_constant_path_node> ||
+                  is_same_v<PrismLhsNode, pm_constant_operator_write_node> ||
+                  is_same_v<PrismLhsNode, pm_constant_or_write_node> ||
+                  is_same_v<PrismLhsNode, pm_constant_and_write_node>) {
         if (isInMethodDef) { // Check if this is a dynamic constant assignment (SyntaxError at runtime)
             // This is a copy of a workaround from `Desugar.cc`, which substitues in a fake assignment,
             // so the parsing can continue. See other usages of `dynamicConstAssign` for more details.

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1669,14 +1669,16 @@ unique_ptr<parser::Node> Translator::translateConst(PrismLhsNode *node) {
     auto location = translateLoc(node->base.location);
     auto name = parser.resolveConstant(node->name);
 
-    if (isInMethodDef) { // Check if this is a dynamic constant assignment (SyntaxError at runtime)
-        // This is a copy of a workaround from `Desugar.cc`, which substitues in a fake assignment,
-        // so the parsing can continue. See other usages of `dynamicConstAssign` for more details.
+    if constexpr (is_same_v<PrismLhsNode, pm_constant_write_node> || is_same_v<PrismLhsNode, pm_constant_path_node>) {
+        if (isInMethodDef) { // Check if this is a dynamic constant assignment (SyntaxError at runtime)
+            // This is a copy of a workaround from `Desugar.cc`, which substitues in a fake assignment,
+            // so the parsing can continue. See other usages of `dynamicConstAssign` for more details.
 
-        // Enter the name of the constant so that it's available for the rest of the pipeline
-        gs.enterNameConstant(name);
+            // Enter the name of the constant so that it's available for the rest of the pipeline
+            gs.enterNameConstant(name);
 
-        return make_unique<LVarLhs>(location, core::Names::dynamicConstAssign());
+            return make_unique<LVarLhs>(location, core::Names::dynamicConstAssign());
+        }
     }
 
     return make_unique<SorbetLHSNode>(location, move(parent), gs.enterNameConstant(name));

--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -74,7 +74,7 @@ private:
     std::unique_ptr<SorbetAssignmentNode> translateOpAssignment(pm_node_t *node);
 
     template <typename PrismLhsNode, typename SorbetLHSNode>
-    std::unique_ptr<parser::Node> translateConst(PrismLhsNode *node);
+    std::unique_ptr<parser::Node> translateConst(PrismLhsNode *node, bool skipDynamicConstantWorkaround = false);
 
     // Pattern-matching
     // ... variations of the main translation functions for pattern-matching related nodes.

--- a/test/prism_regression/assign_to_constant.parse-tree.exp
+++ b/test/prism_regression/assign_to_constant.parse-tree.exp
@@ -520,13 +520,171 @@ Begin {
     DefMethod {
       name = <U method2>
       args = NULL
-      body = Assign {
-        lhs = LVarLhs {
-          name = <U <dynamic-const-assign>>
-        }
-        rhs = String {
-          val = <U This should raise SyntaxError at runtime>
-        }
+      body = Begin {
+        stmts = [
+          Assign {
+            lhs = LVarLhs {
+              name = <U <dynamic-const-assign>>
+            }
+            rhs = String {
+              val = <U This should raise a SyntaxError at runtime>
+            }
+          }
+          OpAsgn {
+            left = ConstLhs {
+              scope = Const {
+                scope = NULL
+                name = <C <U ConstantPath>>
+              }
+              name = <C <U DynamicConstantBitwiseAnd>>
+            }
+            op = <U &>
+            right = Integer {
+              val = "2"
+            }
+          }
+          OpAsgn {
+            left = ConstLhs {
+              scope = Const {
+                scope = NULL
+                name = <C <U ConstantPath>>
+              }
+              name = <C <U DynamicConstantBitwiseXor>>
+            }
+            op = <U ^>
+            right = Integer {
+              val = "4"
+            }
+          }
+          OpAsgn {
+            left = ConstLhs {
+              scope = Const {
+                scope = NULL
+                name = <C <U ConstantPath>>
+              }
+              name = <C <U DynamicConstantShiftRight>>
+            }
+            op = <U >>>
+            right = Integer {
+              val = "5"
+            }
+          }
+          OpAsgn {
+            left = ConstLhs {
+              scope = Const {
+                scope = NULL
+                name = <C <U ConstantPath>>
+              }
+              name = <C <U DynamicConstantShiftLeft>>
+            }
+            op = <U <<>
+            right = Integer {
+              val = "6"
+            }
+          }
+          OpAsgn {
+            left = ConstLhs {
+              scope = Const {
+                scope = NULL
+                name = <C <U ConstantPath>>
+              }
+              name = <C <U DynamicConstantSubtractAssign>>
+            }
+            op = <U ->
+            right = Integer {
+              val = "7"
+            }
+          }
+          OpAsgn {
+            left = ConstLhs {
+              scope = Const {
+                scope = NULL
+                name = <C <U ConstantPath>>
+              }
+              name = <C <U DynamicConstantModuleAssign>>
+            }
+            op = <U %>
+            right = Integer {
+              val = "8"
+            }
+          }
+          OpAsgn {
+            left = ConstLhs {
+              scope = Const {
+                scope = NULL
+                name = <C <U ConstantPath>>
+              }
+              name = <C <U DynamicConstantBitwiseOr>>
+            }
+            op = <U |>
+            right = Integer {
+              val = "9"
+            }
+          }
+          OpAsgn {
+            left = ConstLhs {
+              scope = Const {
+                scope = NULL
+                name = <C <U ConstantPath>>
+              }
+              name = <C <U DynamicConstantDivideAssign>>
+            }
+            op = <U />
+            right = Integer {
+              val = "10"
+            }
+          }
+          OpAsgn {
+            left = ConstLhs {
+              scope = Const {
+                scope = NULL
+                name = <C <U ConstantPath>>
+              }
+              name = <C <U DynamicConstantMultiplyAssign>>
+            }
+            op = <U *>
+            right = Integer {
+              val = "11"
+            }
+          }
+          OpAsgn {
+            left = ConstLhs {
+              scope = Const {
+                scope = NULL
+                name = <C <U ConstantPath>>
+              }
+              name = <C <U DynamicConstantExponentiateAssign>>
+            }
+            op = <U **>
+            right = Integer {
+              val = "12"
+            }
+          }
+          AndAsgn {
+            left = ConstLhs {
+              scope = Const {
+                scope = NULL
+                name = <C <U ConstantPath>>
+              }
+              name = <C <U DynamicConstantLazyAndAssign>>
+            }
+            right = Integer {
+              val = "13"
+            }
+          }
+          OrAsgn {
+            left = ConstLhs {
+              scope = Const {
+                scope = NULL
+                name = <C <U ConstantPath>>
+              }
+              name = <C <U DynamicConstantLazyOrAssgin>>
+            }
+            right = Integer {
+              val = "14"
+            }
+          }
+        ]
       }
     }
   ]

--- a/test/prism_regression/assign_to_constant.parse-tree.exp
+++ b/test/prism_regression/assign_to_constant.parse-tree.exp
@@ -398,13 +398,123 @@ Begin {
     DefMethod {
       name = <U method1>
       args = NULL
-      body = Assign {
-        lhs = LVarLhs {
-          name = <U <dynamic-const-assign>>
-        }
-        rhs = String {
-          val = <U This should raise SyntaxError at runtime>
-        }
+      body = Begin {
+        stmts = [
+          Assign {
+            lhs = LVarLhs {
+              name = <U <dynamic-const-assign>>
+            }
+            rhs = String {
+              val = <U These should all raise SyntaxErrors at runtime>
+            }
+          }
+          OpAsgn {
+            left = LVarLhs {
+              name = <U <dynamic-const-assign>>
+            }
+            op = <U &>
+            right = Integer {
+              val = "2"
+            }
+          }
+          OpAsgn {
+            left = LVarLhs {
+              name = <U <dynamic-const-assign>>
+            }
+            op = <U ^>
+            right = Integer {
+              val = "4"
+            }
+          }
+          OpAsgn {
+            left = LVarLhs {
+              name = <U <dynamic-const-assign>>
+            }
+            op = <U >>>
+            right = Integer {
+              val = "5"
+            }
+          }
+          OpAsgn {
+            left = LVarLhs {
+              name = <U <dynamic-const-assign>>
+            }
+            op = <U <<>
+            right = Integer {
+              val = "6"
+            }
+          }
+          OpAsgn {
+            left = LVarLhs {
+              name = <U <dynamic-const-assign>>
+            }
+            op = <U ->
+            right = Integer {
+              val = "7"
+            }
+          }
+          OpAsgn {
+            left = LVarLhs {
+              name = <U <dynamic-const-assign>>
+            }
+            op = <U %>
+            right = Integer {
+              val = "8"
+            }
+          }
+          OpAsgn {
+            left = LVarLhs {
+              name = <U <dynamic-const-assign>>
+            }
+            op = <U |>
+            right = Integer {
+              val = "9"
+            }
+          }
+          OpAsgn {
+            left = LVarLhs {
+              name = <U <dynamic-const-assign>>
+            }
+            op = <U />
+            right = Integer {
+              val = "10"
+            }
+          }
+          OpAsgn {
+            left = LVarLhs {
+              name = <U <dynamic-const-assign>>
+            }
+            op = <U *>
+            right = Integer {
+              val = "11"
+            }
+          }
+          OpAsgn {
+            left = LVarLhs {
+              name = <U <dynamic-const-assign>>
+            }
+            op = <U **>
+            right = Integer {
+              val = "12"
+            }
+          }
+          AndAsgn {
+            left = LVarLhs {
+              name = <U <dynamic-const-assign>>
+            }
+            right = Integer {
+              val = "13"
+            }
+          }
+          OrAsgn {
+            left = LVarLhs {
+              name = <U <dynamic-const-assign>>
+            }
+            right = Integer {
+              val = "14"
+            }
+          }
+        ]
       }
     }
     DefMethod {

--- a/test/prism_regression/assign_to_constant.rb
+++ b/test/prism_regression/assign_to_constant.rb
@@ -73,5 +73,24 @@ def method1
 end
 
 def method2
-  ConstantPath::DynamicConstant2 = "This should raise SyntaxError at runtime"
+  ConstantPath::DynamicConstant2 = "This should raise a SyntaxError at runtime"
+
+  # These should *NOT* raise a SyntaxError at runtime
+  ConstantPath::DynamicConstantBitwiseAnd &= 2
+  ConstantPath::DynamicConstantBitwiseXor ^= 4
+  ConstantPath::DynamicConstantShiftRight >>= 5
+  ConstantPath::DynamicConstantShiftLeft <<= 6
+  ConstantPath::DynamicConstantSubtractAssign -= 7
+  ConstantPath::DynamicConstantModuleAssign %= 8
+  ConstantPath::DynamicConstantBitwiseOr |= 9
+  ConstantPath::DynamicConstantDivideAssign /= 10
+  ConstantPath::DynamicConstantMultiplyAssign *= 11
+  ConstantPath::DynamicConstantExponentiateAssign **= 12
+
+  # And / Or assignment; still should not raise a syntax error
+  ConstantPath::DynamicConstantLazyAndAssign &&= 13
+  ConstantPath::DynamicConstantLazyOrAssgin ||= 14
+
+  # Sorbet doesn't do the dynamic constant workaround for multi-target assignments
+  # ConstantPath::DynamicConstantTarget1, ConstantPath::DynamicConstantTarget2 = 35, 36
 end

--- a/test/prism_regression/assign_to_constant.rb
+++ b/test/prism_regression/assign_to_constant.rb
@@ -51,7 +51,25 @@ ConstantPath::TARGET1, ConstantPath::TARGET2 = 31, 32
 # Dynamic constant assignments
 
 def method1
-  DynamicConstant = "This should raise SyntaxError at runtime"
+  DynamicConstant = "These should all raise SyntaxErrors at runtime"
+
+  DynamicConstantBitwiseAnd &= 2
+  DynamicConstantBitwiseXor ^= 4
+  DynamicConstantShiftRight >>= 5
+  DynamicConstantShiftLeft <<= 6
+  DynamicConstantSubtractAssign -= 7
+  DynamicConstantModuleAssign %= 8
+  DynamicConstantBitwiseOr |= 9
+  DynamicConstantDivideAssign /= 10
+  DynamicConstantMultiplyAssign *= 11
+  DynamicConstantExponentiateAssign **= 12
+
+  # Special cases
+  DynamicConstantLazyAndAssign &&= 13
+  DynamicConstantLazyOrAssgin ||= 14
+
+  # Sorbet doesn't do the dynamic constant workaround for multi-target assignments
+  # DynamicConstantTarget1, DynamicConstantTarget2 = 35, 36
 end
 
 def method2

--- a/test/prism_regression/rescue.parse-tree.exp
+++ b/test/prism_regression/rescue.parse-tree.exp
@@ -390,6 +390,32 @@ Begin {
         }
       ]
     }
+    DefMethod {
+      name = <U index>
+      args = NULL
+      body = Rescue {
+        body = NULL
+        rescue = [
+          Resbody {
+            exception = Array {
+              elts = [
+                Const {
+                  scope = NULL
+                  name = <C <U StandardError>>
+                }
+              ]
+            }
+            var = LVarLhs {
+              name = <U e>
+            }
+            body = String {
+              val = <U rescued>
+            }
+          }
+        ]
+        else_ = NULL
+      }
+    }
     Rescue {
       body = Send {
         receiver = NULL

--- a/test/prism_regression/rescue.parse-tree.exp
+++ b/test/prism_regression/rescue.parse-tree.exp
@@ -390,6 +390,56 @@ Begin {
         }
       ]
     }
+    Kwbegin {
+      stmts = [
+        Rescue {
+          body = NULL
+          rescue = [
+            Resbody {
+              exception = Array {
+                elts = [
+                  Const {
+                    scope = NULL
+                    name = <C <U StandardError>>
+                  }
+                ]
+              }
+              var = LVarLhs {
+                name = <U e>
+              }
+              body = NULL
+            }
+          ]
+          else_ = NULL
+        }
+      ]
+    }
+    Kwbegin {
+      stmts = [
+        Rescue {
+          body = String {
+            val = <U something>
+          }
+          rescue = [
+            Resbody {
+              exception = Array {
+                elts = [
+                  Const {
+                    scope = NULL
+                    name = <C <U StandardError>>
+                  }
+                ]
+              }
+              var = LVarLhs {
+                name = <U e>
+              }
+              body = NULL
+            }
+          ]
+          else_ = NULL
+        }
+      ]
+    }
     DefMethod {
       name = <U index>
       args = NULL

--- a/test/prism_regression/rescue.parse-tree.exp
+++ b/test/prism_regression/rescue.parse-tree.exp
@@ -364,6 +364,32 @@ Begin {
         }
       ]
     }
+    Kwbegin {
+      stmts = [
+        Rescue {
+          body = NULL
+          rescue = [
+            Resbody {
+              exception = Array {
+                elts = [
+                  Const {
+                    scope = NULL
+                    name = <C <U StandardError>>
+                  }
+                ]
+              }
+              var = LVarLhs {
+                name = <U e>
+              }
+              body = String {
+                val = <U rescued>
+              }
+            }
+          ]
+          else_ = NULL
+        }
+      ]
+    }
     Rescue {
       body = Send {
         receiver = NULL

--- a/test/prism_regression/rescue.rb
+++ b/test/prism_regression/rescue.rb
@@ -86,6 +86,17 @@ rescue StandardError => e
   "rescued"
 end
 
+# Testing a rescue clause with a begin, an empty body, and an empty rescue body
+begin
+rescue StandardError => e
+end
+
+# Testing a rescue clause with a begin and an empty rescue body
+begin
+  "something"
+rescue StandardError => e
+end
+
 # Testing a rescue clause with no begin and an empty body
 def index
 rescue StandardError => e

--- a/test/prism_regression/rescue.rb
+++ b/test/prism_regression/rescue.rb
@@ -80,6 +80,12 @@ ensure
   "ensure"
 end
 
+# Testing a rescue clause with a begin and an empty body
+begin
+rescue StandardError => e
+  "rescued"
+end
+
 # Testing rescue modifiers
 problematic_code rescue puts "rescued"
 problematic_code rescue nil

--- a/test/prism_regression/rescue.rb
+++ b/test/prism_regression/rescue.rb
@@ -86,6 +86,12 @@ rescue StandardError => e
   "rescued"
 end
 
+# Testing a rescue clause with no begin and an empty body
+def index
+rescue StandardError => e
+  "rescued"
+end
+
 # Testing rescue modifiers
 problematic_code rescue puts "rescued"
 problematic_code rescue nil


### PR DESCRIPTION
Related to #316 

### Motivation
Easiest to read each commit separately.

This PR addresses some issues with `PM_RESCUE_NODE`:
1. First, we were relying on the body of the begin node within the rescue to determine the location. It is entirely possible that the rescue will not have a body.
2. We were doing the dynamic constant assignment workaround for *all* the node types that passed through `translateConst`, rather than just the ones that actually handle constant assignment.
3. We weren't testing the dynamic constant assignment workaround with all the different types of constant assignment.

### Test plan
See included automated tests.
