### PR TITLE
Start reporting errors from the translator 

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -30,7 +30,7 @@
         {
             "label": "Run a single Prism test",
             "type": "shell",
-            "command": "./bazel test //test:test_PosTests/prism_regression/${input:test_name} //test:prism_regression_${input:test_name}_location_test --config=dbg  --test_output=all",
+            "command": "./bazel test //test:test_PosTests/prism_regression/${input:test_name} //test:prism_regression/${input:test_name}_location_test --config=dbg  --test_output=all",
             "group": {
                 "kind": "test",
                 "isDefault": true

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -146,7 +146,7 @@ unique_ptr<parser::Node> runPrismParser(core::GlobalState &gs, core::FileRef fil
         return std::unique_ptr<parser::Node>();
     }
 
-    auto nodes = Prism::Translator(parser, gs).translate(std::move(root));
+    auto nodes = Prism::Translator(parser, gs, file).translate(std::move(root));
 
     if (print.ParseTree.enabled) {
         print.ParseTree.fmt("{}\n", nodes->toStringWithTabs(gs, 0));

--- a/test/prism_location_test.bzl
+++ b/test/prism_location_test.bzl
@@ -1,6 +1,6 @@
 def prism_test_suite(name, srcs):
     for src in srcs:
-        test_name = src.replace(".rb", "").replace("/", "_") + "_location_test"
+        test_name = src.replace(".rb", "") + "_location_test"
         native.sh_test(
             name = test_name,
             srcs = ["prism_location_test.sh"],

--- a/test/prism_regression/error_recovery/assign.parse-tree.exp
+++ b/test/prism_regression/error_recovery/assign.parse-tree.exp
@@ -1,0 +1,19 @@
+DefMethod {
+  name = <U test_bad_assign>
+  args = Args {
+    args = [
+      Arg {
+        name = <U x>
+      }
+    ]
+  }
+  body = Assign {
+    lhs = LVarLhs {
+      name = <U x>
+    }
+    rhs = Const {
+      scope = NULL
+      name = <C <U <ErrorNode>>>
+    }
+  }
+}

--- a/test/prism_regression/error_recovery/assign.rb
+++ b/test/prism_regression/error_recovery/assign.rb
@@ -1,0 +1,5 @@
+# typed: false
+# Should still see at least method def (not body)
+def test_bad_assign(x)
+  x = # error: unexpected token
+end


### PR DESCRIPTION
### Motivation

First step to #309

I'd like to approach this task with these steps:

1. Since node locations are important for autocorrection, we first make sure parse-trees still match in errored cases. So at this time we don't report errors at the same details & location as Sorbet does, as long as there are errors and they are captured in the fixtures, which we can used for comparison later.
2. Once we got all the parse-trees right, we compare all fixtures under `prism_regression/error_recovery/` with `testdata/parser/error_recovery/` and try to enrich/calibrate our error reporting.
    - This doesn't include `error: Hint:` but only real syntax errors
4. Finally, we start working on `error: Hint`

With that in mind, in this PR:

1. To make it easier to compare with Sorbet's tests, I added `error_recovery` folder to host error related fixture files as well
1. To make location tests work with 1, which means to accept `error_recovery/assign` without converting it to `error_recovery_assign` (can't easily be done in `tasks.json`), I updated `test/prism_location_test.bzl` too
1. I added a very basic `Translator::reportError` function and updated the `PM_MISSING_NODE` case to start reporting basic errors when parsing invalid Ruby code, which starts with `assign.rb`


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
