### PR TITLE
Report Prism parse errors

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -146,8 +146,9 @@ unique_ptr<parser::Node> runPrismParser(core::GlobalState &gs, core::FileRef fil
         return std::unique_ptr<parser::Node>();
     }
 
-    auto errors = parser.errors();
-    auto nodes = Prism::Translator(parser, errors, gs, file).translate(std::move(root));
+    // Needs to be called after `parse_root()` otherwise there will be no errors to collect
+    parser.collectErrors();
+    auto nodes = Prism::Translator(parser, gs, file).translate(std::move(root));
 
     if (print.ParseTree.enabled) {
         print.ParseTree.fmt("{}\n", nodes->toStringWithTabs(gs, 0));

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -146,7 +146,8 @@ unique_ptr<parser::Node> runPrismParser(core::GlobalState &gs, core::FileRef fil
         return std::unique_ptr<parser::Node>();
     }
 
-    auto nodes = Prism::Translator(parser, gs, file).translate(std::move(root));
+    auto errors = parser.errors();
+    auto nodes = Prism::Translator(parser, errors, gs, file).translate(std::move(root));
 
     if (print.ParseTree.enabled) {
         print.ParseTree.fmt("{}\n", nodes->toStringWithTabs(gs, 0));

--- a/parser/prism/Parser.cc
+++ b/parser/prism/Parser.cc
@@ -28,4 +28,22 @@ std::string_view Parser::extractString(pm_string_t *string) {
     return std::string_view(reinterpret_cast<const char *>(pm_string_source(string)), pm_string_length(string));
 }
 
+std::vector<ParseError> Parser::errors() const {
+    std::vector<ParseError> errors;
+
+    pm_list_node_t *node = storage->parser.error_list.head;
+
+    while (node != nullptr) {
+        pm_diagnostic_t *error = reinterpret_cast<pm_diagnostic_t *>(node);
+        pm_error_level_t level = static_cast<pm_error_level_t>(error->level);
+
+        ParseError parseError(pm_diagnostic_id_human(error->diag_id),
+                              std::string(reinterpret_cast<const char *>(error->message)), error->location, level);
+
+        errors.push_back(parseError);
+        node = node->next;
+    }
+
+    return errors;
+}
 }; // namespace sorbet::parser::Prism

--- a/parser/prism/Parser.h
+++ b/parser/prism/Parser.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 extern "C" {
 #include "prism.h"
@@ -13,6 +14,17 @@ extern "C" {
 namespace sorbet::parser::Prism {
 
 class Node;
+
+class ParseError {
+public:
+    ParseError(const char *id, const std::string &message, pm_location_t location, pm_error_level_t level)
+        : id(id), message(message), location(location), level(level) {}
+
+    const char *id;
+    std::string message;
+    pm_location_t location;
+    pm_error_level_t level;
+};
 
 // A backing implemenation detail of `Parser`, which stores a Prism parser and its options in a single allocation.
 struct ParserStorage {
@@ -54,6 +66,8 @@ public:
     core::LocOffsets translateLocation(pm_location_t location);
     std::string_view resolveConstant(pm_constant_id_t constant_id);
     std::string_view extractString(pm_string_t *string);
+
+    std::vector<ParseError> errors() const;
 
 private:
     pm_parser_t *get_raw_parser_pointer();

--- a/parser/prism/Parser.h
+++ b/parser/prism/Parser.h
@@ -57,6 +57,8 @@ class Parser final {
     std::shared_ptr<ParserStorage> storage;
 
 public:
+    std::vector<ParseError> parseErrors;
+
     Parser(std::string_view source_code) : storage(std::make_shared<ParserStorage>(source_code)) {}
 
     Parser(const Parser &) = default;
@@ -67,7 +69,7 @@ public:
     std::string_view resolveConstant(pm_constant_id_t constant_id);
     std::string_view extractString(pm_string_t *string);
 
-    std::vector<ParseError> errors() const;
+    void collectErrors();
 
 private:
     pm_parser_t *get_raw_parser_pointer();

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1211,7 +1211,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             // For now, we only report errors when we hit a missing node because we don't want to always report dynamic
             // constant assignment errors
             // TODO: We will improve this in the future when we handle more errored cases
-            for (auto &error : parseErrors) {
+            for (auto &error : parser.parseErrors) {
                 reportError(translateLoc(error.location), error.message);
             }
             return make_unique<parser::Const>(location, nullptr, core::Names::Constants::ErrorNode());
@@ -1782,7 +1782,7 @@ template <typename PrismNode> std::unique_ptr<parser::Mlhs> Translator::translat
 // Context management methods
 Translator Translator::enterMethodDef() {
     auto isInMethodDef = true;
-    return Translator(parser, parseErrors, gs, file, isInMethodDef);
+    return Translator(parser, gs, file, isInMethodDef);
 }
 
 void Translator::reportError(core::LocOffsets loc, const std::string &message) {

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1208,7 +1208,12 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
 
         case PM_IMPLICIT_NODE:
         case PM_MISSING_NODE:
-            reportError(location, "unexpected token");
+            // For now, we only report errors when we hit a missing node because we don't want to always report dynamic
+            // constant assignment errors
+            // TODO: We will improve this in the future when we handle more errored cases
+            for (auto &error : parseErrors) {
+                reportError(translateLoc(error.location), error.message);
+            }
             return make_unique<parser::Const>(location, nullptr, core::Names::Constants::ErrorNode());
     }
 }
@@ -1777,7 +1782,7 @@ template <typename PrismNode> std::unique_ptr<parser::Mlhs> Translator::translat
 // Context management methods
 Translator Translator::enterMethodDef() {
     auto isInMethodDef = true;
-    return Translator(parser, gs, file, isInMethodDef);
+    return Translator(parser, parseErrors, gs, file, isInMethodDef);
 }
 
 void Translator::reportError(core::LocOffsets loc, const std::string &message) {

--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -15,8 +15,6 @@ namespace sorbet::parser::Prism {
 class Translator final {
     Parser parser;
 
-    std::vector<ParseError> parseErrors;
-
     // The functions in Pipeline.cc pass around a reference to the global state as a parameter,
     // but don't have explicit ownership over it. We take a temporary reference to it, but we can't
     // escape that scope, which is why Translator objects can't be copied, or even moved.
@@ -34,17 +32,16 @@ class Translator final {
     Translator &operator=(Translator &&) = delete;      // Move assignment
     Translator &operator=(const Translator &) = delete; // Copy assignment
 public:
-    Translator(Parser parser, std::vector<ParseError> parseErrors, core::GlobalState &gs, core::FileRef file)
-        : parser(std::move(parser)), parseErrors(parseErrors), gs(gs), file(file) {}
+    Translator(Parser parser, core::GlobalState &gs, core::FileRef file)
+        : parser(std::move(parser)), gs(gs), file(file) {}
 
     // Translates the given AST from Prism's node types into the equivalent AST in Sorbet's legacy parser node types.
     std::unique_ptr<parser::Node> translate(pm_node_t *node);
     std::unique_ptr<parser::Node> translate(const Node &node);
 
 private:
-    Translator(Parser parser, std::vector<ParseError> parseErrors, core::GlobalState &gs, core::FileRef file,
-               bool isInMethodDef)
-        : parser(parser), parseErrors(parseErrors), gs(gs), file(file), isInMethodDef(isInMethodDef) {}
+    Translator(Parser parser, core::GlobalState &gs, core::FileRef file, bool isInMethodDef)
+        : parser(parser), gs(gs), file(file), isInMethodDef(isInMethodDef) {}
     void reportError(core::LocOffsets loc, const std::string &message);
 
     core::LocOffsets translateLoc(pm_location_t loc);

--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -15,6 +15,8 @@ namespace sorbet::parser::Prism {
 class Translator final {
     Parser parser;
 
+    std::vector<ParseError> parseErrors;
+
     // The functions in Pipeline.cc pass around a reference to the global state as a parameter,
     // but don't have explicit ownership over it. We take a temporary reference to it, but we can't
     // escape that scope, which is why Translator objects can't be copied, or even moved.
@@ -32,16 +34,17 @@ class Translator final {
     Translator &operator=(Translator &&) = delete;      // Move assignment
     Translator &operator=(const Translator &) = delete; // Copy assignment
 public:
-    Translator(Parser parser, core::GlobalState &gs, core::FileRef file)
-        : parser(std::move(parser)), gs(gs), file(file) {}
+    Translator(Parser parser, std::vector<ParseError> parseErrors, core::GlobalState &gs, core::FileRef file)
+        : parser(std::move(parser)), parseErrors(parseErrors), gs(gs), file(file) {}
 
     // Translates the given AST from Prism's node types into the equivalent AST in Sorbet's legacy parser node types.
     std::unique_ptr<parser::Node> translate(pm_node_t *node);
     std::unique_ptr<parser::Node> translate(const Node &node);
 
 private:
-    Translator(Parser parser, core::GlobalState &gs, core::FileRef file, bool isInMethodDef)
-        : parser(parser), gs(gs), file(file), isInMethodDef(isInMethodDef) {}
+    Translator(Parser parser, std::vector<ParseError> parseErrors, core::GlobalState &gs, core::FileRef file,
+               bool isInMethodDef)
+        : parser(parser), parseErrors(parseErrors), gs(gs), file(file), isInMethodDef(isInMethodDef) {}
     void reportError(core::LocOffsets loc, const std::string &message);
 
     core::LocOffsets translateLoc(pm_location_t loc);

--- a/test/prism_regression/error_recovery/assign.rb
+++ b/test/prism_regression/error_recovery/assign.rb
@@ -1,5 +1,6 @@
 # typed: false
 # Should still see at least method def (not body)
 def test_bad_assign(x)
-  x = # error: unexpected token
-end
+  x =
+  # ^ error: expected an expression after `=`
+end # error: unexpected 'end', assuming it is closing the parent method definition


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation

Part of #309 

After #318, I found that we should pass Prism errors translator instead of just relying on `PM_MISSING_NODE` because:

- To generate `error: Hint: ...` like Sorbet's parser does, we need to have access to more context
- In some errored cases, the current translator still generates different parse-tree than Sorbet's parser. To solve this we need a translator-level context to update the translation in those cases

So in this PR, I start to feed Prism errors to the translator and report them when we hit a `PM_MISSING_NODE`. This prevents runtime(-ish?) errors like dynamic constant assignment error being reported proactively. We will revise this in later PRs when we understand better around error translation.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
