### PR TITLE
Some improvements around error tolerance

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -69,6 +69,22 @@
                 "reveal": "always"
             }
         },
+        {
+            "label": "Display Prism parse tree & errors for Ruby file",
+            "type": "shell",
+            "command": "tools/scripts/inspect_parsing_errors.rb ${file}",
+            "presentation": {
+                "reveal": "always"
+            },
+            "options": {
+                // Makes sure the shell can find the correct Ruby version
+                "shell": {
+                    "executable": "${env:SHELL}",
+                    "args": ["-c"]
+                }
+            },
+            "problemMatcher": []
+        }
     ],
     "inputs": [
         {

--- a/parser/prism/Parser.cc
+++ b/parser/prism/Parser.cc
@@ -37,8 +37,8 @@ void Parser::collectErrors() {
         auto *error = reinterpret_cast<pm_diagnostic_t *>(node);
         auto level = static_cast<pm_error_level_t>(error->level);
 
-        ParseError parseError(pm_diagnostic_id_human(error->diag_id),
-                              std::string(reinterpret_cast<const char *>(error->message)), error->location, level);
+        ParseError parseError(error->diag_id, std::string(reinterpret_cast<const char *>(error->message)),
+                              error->location, level);
 
         parseErrors.push_back(parseError);
     }

--- a/parser/prism/Parser.h
+++ b/parser/prism/Parser.h
@@ -17,10 +17,10 @@ class Node;
 
 class ParseError {
 public:
-    ParseError(const char *id, const std::string &message, pm_location_t location, pm_error_level_t level)
+    ParseError(pm_diagnostic_id_t id, const std::string &message, pm_location_t location, pm_error_level_t level)
         : id(id), message(message), location(location), level(level) {}
 
-    const char *id;
+    pm_diagnostic_id_t id;
     std::string message;
     pm_location_t location;
     pm_error_level_t level;

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1212,7 +1212,11 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             // constant assignment errors
             // TODO: We will improve this in the future when we handle more errored cases
             for (auto &error : parser.parseErrors) {
-                reportError(translateLoc(error.location), error.message);
+                // EOF error is always pointed to the very last line of the file, which can't be expressed in Sorbet's
+                // error comments
+                if (error.id != PM_ERR_UNEXPECTED_TOKEN_CLOSE_CONTEXT) {
+                    reportError(translateLoc(error.location), error.message);
+                }
             }
             return make_unique<parser::Const>(location, nullptr, core::Names::Constants::ErrorNode());
     }

--- a/test/prism_regression/error_recovery/assign.rb
+++ b/test/prism_regression/error_recovery/assign.rb
@@ -3,4 +3,4 @@
 def test_bad_assign(x)
   x =
   # ^ error: expected an expression after `=`
-end # error: unexpected 'end', assuming it is closing the parent method definition
+end

--- a/tools/scripts/inspect_parsing_errors.rb
+++ b/tools/scripts/inspect_parsing_errors.rb
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+
+require "prism"
+
+file_path = ARGV[0]
+
+parsed = Prism.parse_file(file_path)
+
+pp parsed.value
+
+if parsed.errors.empty?
+  puts "No parse errors found"
+  exit
+end
+
+puts
+puts "======================= Parse errors ======================="
+puts
+
+parsed.errors.each do |error|
+  pp error
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
1. Because neither Ruby LSP's `Show syntax tree` command nor websites like [Ruby Playground](https://ruby.github.io/play-ruby/) displays Prism's error messages, I added a new task to display a file's parse tree and Prism errors. This will make it easier to work with syntax-incorrect Ruby files.
2. [Keep Prism error id's type for easy comparison](https://github.com/Shopify/sorbet/commit/b4440c85e8c39a998fe13990f3e701618572d253) 

    We currently don't use the converted value and keeping the `pm_diagnostic_id_t` type makes it easy to compare the value with `PM_ERR_*` constants directly.

3. [Stop surfacing Prism's EOF error](https://github.com/Shopify/sorbet/commit/ce141666804074b369b2f63670aae072081b6629) 

    It usually appears when there's an unclosed statements/assignments, where the root error will also be surfaced. So it's not exactly important to surface this error.
    
    But more importantly, because Prism puts this error at the very last line of the file when there's a missing `end`, it can't be represented in Sorbet's error comments.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
