### PR TITLE
Fix output of Prism location test errors

### DIFF
--- a/test/prism_location_test.sh
+++ b/test/prism_location_test.sh
@@ -32,7 +32,7 @@ set -e  # Re-enable exit on error
 if ! diff -q "$sorbet_output_prism" "$sorbet_output_sorbet" >/dev/null 2>&1; then
     echo "Test failed for $TEST_FILE"
     echo "Differences:"
-    diff -u "$sorbet_output_prism" "$sorbet_output_sorbet"
+    diff -u "$sorbet_output_sorbet" "$sorbet_output_prism"
     rm "$sorbet_output_prism" "$sorbet_output_sorbet"
     exit 1
 fi


### PR DESCRIPTION
### Motivation
When I implemented the Prism location test runner, I accidentally switched the diff output so the expected parse tree showed up as the test output and vice versa.

For example, if I purposely make the `alias` location tests error by removing the symbol name, this is what the output looks like:

```
       "type" : "Alias",
       "from" : {
         "type" : "Symbol",
-        "val" : ""
+        "val" : "new_method1"
       },
```

This PR just fixes the test output, making it correct and easier for us to read.

### Test plan
See included automated tests.
