### PR TITLE
Start running Sorbet corpus tests with Prism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,6 @@ jobs:
       - name: Verify parse trees
         run: ./tools/scripts/verify_prism_regression_tests.sh
       - name: Run tests
-        run: ./bazel test //test:prism --config=dbg --test_output=errors
+        run: ./bazel test //test:prism_regression --config=dbg --test_output=errors
       - name: Run location tests
         run: ./bazel test //test:prism_location_tests --config=dbg --test_output=errors

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -18,7 +18,7 @@
         {
             "label": "Run all Prism tests",
             "type": "shell",
-            "command": "./bazel test //test:prism //test:prism_location_tests --config=dbg  --test_output=all",
+            "command": "./bazel test //test:prism_regression //test:prism_location_tests --config=dbg  --test_output=all",
             "group": {
                 "kind": "test",
                 "isDefault": true

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -16,7 +16,7 @@
             }
         },
         {
-            "label": "Run all Prism tests",
+            "label": "Run all Prism regression tests",
             "type": "shell",
             "command": "./bazel test //test:prism_regression //test:prism_location_tests --config=dbg  --test_output=all",
             "group": {
@@ -28,9 +28,38 @@
             }
         },
         {
-            "label": "Run a single Prism test",
+            "label": "Run a single Prism regression test",
             "type": "shell",
             "command": "./bazel test //test:test_PosTests/prism_regression/${input:test_name} //test:prism_regression/${input:test_name}_location_test --config=dbg  --test_output=all",
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "always"
+            },
+            // With this option, when running this task with the `Tasks: Rerun Last Test` command, it'll
+            // reuse the previous run's input, rather than prompting for it again
+            "runOptions": {
+                "reevaluateOnRerun": false
+            }
+        },
+        {
+            "label": "Run all Prism corpus tests",
+            "type": "shell",
+            "command": "./bazel test //test:test_corpus_prism --config=dbg  --test_output=all",
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "always"
+            }
+        },
+        {
+            "label": "Run a single Prism corpus test",
+            "type": "shell",
+            "command": "./bazel test //test:test_PosTests/testdata/${input:test_name}_prism --config=dbg  --test_output=all",
             "group": {
                 "kind": "test",
                 "isDefault": true

--- a/test/BUILD
+++ b/test/BUILD
@@ -256,6 +256,16 @@ pipeline_tests(
 )
 
 pipeline_tests(
+    "test_corpus_prism",
+    glob([
+        "testdata/parser/**/*.rb",
+        "testdata/parser/**/*.exp",
+    ]),
+    "PosTests",
+    parser = "prism",
+)
+
+pipeline_tests(
     "whitequark_parser_corpus",
     glob([
         "whitequark/**/*.rb",
@@ -290,6 +300,11 @@ pipeline_tests(
 test_suite(
     name = "test",
     tests = ["test_corpus"],
+)
+
+test_suite(
+    name = "test_prism",
+    tests = ["test_corpus_prism"],
 )
 
 test_suite(

--- a/test/BUILD
+++ b/test/BUILD
@@ -278,7 +278,7 @@ pipeline_tests(
 )
 
 pipeline_tests(
-    "test_corpus_prism",
+    "prism_regression_corpus",
     glob([
         "prism_regression/**/*.rb",
         "prism_regression/**/*.exp",
@@ -298,8 +298,8 @@ test_suite(
 )
 
 test_suite(
-    name = "prism",
-    tests = ["test_corpus_prism"],
+    name = "prism_regression",
+    tests = ["prism_regression_corpus"],
 )
 
 sh_binary(

--- a/test/pipeline_test.bzl
+++ b/test/pipeline_test.bzl
@@ -150,6 +150,11 @@ def pipeline_tests(suite_name, all_paths, test_name_prefix, extra_files = [], ta
 
         test_name = dirname(path) + "/" + prefix
 
+        # Tests that run with Prism parser need to have "_prism" appended to their name
+        # to differentiate them from the tests that run with Sorbet parser.
+        if parser == "prism":
+            test_name = test_name + "_prism"
+
         current = tests.get(test_name)
         if None == current:
             data = {


### PR DESCRIPTION
Best read commit-by-commit.

### Motivation
So far in this project, we have been exclusively running new tests to ensure that we do not regress as we add more to our Prism -> Sorbet translation layer. We have not been running any of the existing Sorbet tests.

In order to gain more confidence in our work and upstream to Sorbet, it makes sense to start running more of the pre-existing Sorbet tests with the Prism parser.

My plan was to start with just the parser tests (many of which are currently failing), and once we're confident in those, add more and more of the Sorbet pipeline. Right now, I don't think it makes sense to run these tests in CI, but once more are passing, I think it would make sense.

This PR adds a Prism test corpus and some tasks for easily running it!

### Test plan
See included automated tests.
