### PR TITLE
Add Prism handling for packager tests too

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -258,6 +258,8 @@ pipeline_tests(
 pipeline_tests(
     "test_corpus_prism",
     glob([
+        # Replace [parser] with other phases to test Prism at that level
+        # Phases: https://github.com/Shopify/sorbet/blob/prism/docs/internals.md#phases
         "testdata/parser/**/*.rb",
         "testdata/parser/**/*.exp",
     ]),

--- a/test/pipeline_test.bzl
+++ b/test/pipeline_test.bzl
@@ -142,6 +142,14 @@ def pipeline_tests(suite_name, all_paths, test_name_prefix, extra_files = [], ta
                         "disabled": "disabled" in test_name,
                         "isPackage": True,
                     }
+
+                    # Tests that run with Prism parser need to have "_prism" appended to their name
+                    # to differentiate them from the tests that run with Sorbet parser.
+                    # The condition here is only for the packager tests
+                    # Other tests are handled below.
+                    if parser == "prism":
+                        test_name = test_name + "_prism"
+
                     tests[test_name] = data
                 continue
 


### PR DESCRIPTION
### Motivation

Because pipeline_tests handles packager tests differently, we need to add Prism handling for them too. Otherwise, we'll get test conflict errors when `test_corpus_prism`'s pattern covers packager tests.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
