### PR TITLE
Translator should not treat `~[Integer]` as a method call

### DIFF
--- a/test/prism_regression/literal_integer.parse-tree.exp
+++ b/test/prism_regression/literal_integer.parse-tree.exp
@@ -9,5 +9,8 @@ Begin {
     Integer {
       val = "-42"
     }
+    Integer {
+      val = "~42"
+    }
   ]
 }

--- a/test/prism_regression/literal_integer.rb
+++ b/test/prism_regression/literal_integer.rb
@@ -4,3 +4,6 @@
 
 +42
 -42
+
+# ~ should not be a method call
+~42


### PR DESCRIPTION
Sorbet's legacy parser treats `~[Integer]` and `-[Integer]` as integer literals, but Prism treats `~[Integer]` as a method call.

So in the translator, we need to give `~` special handling when its receiver is an integer. We don't need the same for Float or Numeric because only Integer has the `~` method.

Fixes #332

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
