### PR TITLE
Fix test failures stemming from stemming from test pipeline 

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,7 +27,7 @@
             "type": "lldb",
             "request": "launch",
             "name": "Debug Prism test in LLDB",
-            "program": "${workspaceFolder}/bazel-bin/test/test_PosTests/prism_regression/${input:test_name}.runfiles/com_stripe_ruby_typer/test/pipeline_test_runner",
+            "program": "${workspaceFolder}/bazel-bin/test/test_PosTests/prism_regression/${input:test_name}_prism.runfiles/com_stripe_ruby_typer/test/pipeline_test_runner",
             "args": ["--single_test=${workspaceFolder}/test/prism_regression/${input:test_name}.rb", "--parser=prism"],
             // We need to run all tests to generate the pipeline_test_runner files, which are needed by the LLDB debugger to execute the tests.
             "preLaunchTask": "Run all Prism regression tests",

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -796,8 +796,15 @@ TEST_CASE("PerPhaseTest") { // NOLINT
         gs->replaceFile(f.file, move(newFile));
 
         // this replicates the logic of pipeline::indexOne
-        auto settings = parser::Parser::Settings{};
-        auto nodes = parser::Parser::run(*gs, f.file, settings);
+        unique_ptr<parser::Node> nodes;
+
+        if (parser == realmain::options::Parser::SORBET) {
+            auto settings = parser::Parser::Settings{};
+            nodes = parser::Parser::run(*gs, f.file, settings);
+        } else if (parser == realmain::options::Parser::PRISM) {
+            nodes = realmain::pipeline::runPrismParser(*gs, f.file, false, {});
+        }
+
         handler.addObserved(*gs, "parse-tree", [&]() { return nodes->toString(*gs); });
         handler.addObserved(*gs, "parse-tree-json", [&]() { return nodes->toJSON(*gs); });
 


### PR DESCRIPTION
Closes #331

### Motivation
Some of the Sorbet corpus tests are failing with the error `enforced condition !nameTableFrozen has failed`, but the issue was actually that we were attempting to run part of the test with old Sorbet parser, rather than with Prism. I'm assuming this was attempting to create new entries in the name table when we didn't expect any more, which was causing the error.

The Sorbet test pipeline actually has multiple entry points for the parser -- there are two calls to the `index` method ([one here](https://github.com/Shopify/sorbet/blob/prism/test/pipeline_test_runner.cc#L434), [one here](https://github.com/Shopify/sorbet/blob/prism/test/pipeline_test_runner.cc#L441)) and then another pass where the pipeline re-parses some of the files ([here](https://github.com/Shopify/sorbet/blob/prism/test/pipeline_test_runner.cc#L800)) -- why it does this, I'm not sure.

I've modified this part of the test pipeline to parse with Prism instead of the Sorbet parser, and the relevant corpus tests are now passing.

### Test plan
Existing tests should continue to pass.
