### PR TITLE
Properly handle complex literals with `+` or `-` prefix

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,8 +27,8 @@
             "type": "lldb",
             "request": "launch",
             "name": "Debug Prism test in LLDB",
-            "program": "${workspaceFolder}/bazel-bin/test/test_PosTests/prism_regression/${input:test_name}_prism.runfiles/com_stripe_ruby_typer/test/pipeline_test_runner",
-            "args": ["--single_test=${workspaceFolder}/test/prism_regression/${input:test_name}.rb", "--parser=prism"],
+            "program": "${workspaceFolder}/bazel-bin/test/test_PosTests/prism_regression/${input:prism_regression_test_name}_prism.runfiles/com_stripe_ruby_typer/test/pipeline_test_runner",
+            "args": ["--single_test=${workspaceFolder}/test/prism_regression/${input:prism_regression_test_name}.rb", "--parser=prism"],
             // We need to run all tests to generate the pipeline_test_runner files, which are needed by the LLDB debugger to execute the tests.
             "preLaunchTask": "Run all Prism regression tests",
             "stopOnEntry": false,
@@ -51,7 +51,7 @@
     ],
     "inputs": [
         {
-            "id": "test_name",
+            "id": "prism_regression_test_name",
             "type": "promptString",
             "description": "Enter the test name, e.g. case for running test/prism_regression/case.rb",
         },

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -16,9 +16,9 @@
             }
         },
         {
-            "label": "Run all Prism regression tests",
+            "label": "(Re)Generate Prism test",
             "type": "shell",
-            "command": "./bazel test //test:prism_regression //test:prism_location_tests --config=dbg  --test_output=all",
+            "command": "TEST_NAME=${input:prism_regression_test_name}; $EDITOR -w test/prism_regression/$TEST_NAME.rb; ./bazel-bin/main/sorbet --stop-after=parser --print=parse-tree test/prism_regression/$TEST_NAME.rb > test/prism_regression/$TEST_NAME.parse-tree.exp; $EDITOR test/prism_regression/$TEST_NAME.parse-tree.exp test/prism_regression/$TEST_NAME.rb",
             "group": {
                 "kind": "test",
                 "isDefault": true
@@ -30,7 +30,7 @@
         {
             "label": "Run a single Prism regression test",
             "type": "shell",
-            "command": "./bazel test //test:test_PosTests/prism_regression/${input:test_name}_prism //test:prism_regression/${input:test_name}_location_test --config=dbg  --test_output=all",
+            "command": "./bazel test //test:test_PosTests/prism_regression/${input:prism_regression_test_name}_prism //test:prism_regression/${input:prism_regression_test_name}_location_test --config=dbg  --test_output=all",
             "group": {
                 "kind": "test",
                 "isDefault": true
@@ -42,6 +42,18 @@
             // reuse the previous run's input, rather than prompting for it again
             "runOptions": {
                 "reevaluateOnRerun": false
+            }
+        },
+        {
+            "label": "Run all Prism regression tests",
+            "type": "shell",
+            "command": "./bazel test //test:prism_regression //test:prism_location_tests --config=dbg  --test_output=all",
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "always"
             }
         },
         {
@@ -59,7 +71,7 @@
         {
             "label": "Run a single Prism corpus test",
             "type": "shell",
-            "command": "./bazel test //test:test_PosTests/testdata/${input:test_name}_prism --config=dbg  --test_output=all",
+            "command": "./bazel test //test:test_PosTests/testdata/${input:prism_corpus_test_name}_prism --config=dbg  --test_output=all",
             "group": {
                 "kind": "test",
                 "isDefault": true
@@ -87,18 +99,6 @@
             }
         },
         {
-            "label": "(Re)Generate Prism test",
-            "type": "shell",
-            "command": "TEST_NAME=${input:test_name}; $EDITOR -w test/prism_regression/$TEST_NAME.rb; ./bazel-bin/main/sorbet --stop-after=parser --print=parse-tree test/prism_regression/$TEST_NAME.rb > test/prism_regression/$TEST_NAME.parse-tree.exp; $EDITOR test/prism_regression/$TEST_NAME.parse-tree.exp",
-            "group": {
-                "kind": "test",
-                "isDefault": true
-            },
-            "presentation": {
-                "reveal": "always"
-            }
-        },
-        {
             "label": "Display Prism parse tree & errors for Ruby file",
             "type": "shell",
             "command": "tools/scripts/inspect_parsing_errors.rb ${file}",
@@ -117,7 +117,12 @@
     ],
     "inputs": [
         {
-            "id": "test_name",
+            "id": "prism_corpus_test_name",
+            "type": "promptString",
+            "description": "Enter the test name, e.g. parser/and_and_bug for running test/testdata/parser/and_and_bug.rb",
+        },
+        {
+            "id": "prism_regression_test_name",
             "type": "promptString",
             "description": "Enter the test name, e.g. case for running test/prism_regression/case.rb",
         },

--- a/test/prism_regression/literal_complex.parse-tree.exp
+++ b/test/prism_regression/literal_complex.parse-tree.exp
@@ -1,0 +1,55 @@
+Begin {
+  stmts = [
+    Complex {
+      value = "1"
+    }
+    Send {
+      receiver = Complex {
+        value = "1"
+      }
+      method = <U +@>
+      args = [
+      ]
+    }
+    Send {
+      receiver = Complex {
+        value = "1.0"
+      }
+      method = <U +@>
+      args = [
+      ]
+    }
+    Send {
+      receiver = Complex {
+        value = "1"
+      }
+      method = <U -@>
+      args = [
+      ]
+    }
+    Send {
+      receiver = Complex {
+        value = "1.0"
+      }
+      method = <U -@>
+      args = [
+      ]
+    }
+    Send {
+      receiver = Complex {
+        value = "1"
+      }
+      method = <U ~>
+      args = [
+      ]
+    }
+    Send {
+      receiver = Complex {
+        value = "1.0"
+      }
+      method = <U ~>
+      args = [
+      ]
+    }
+  ]
+}

--- a/test/prism_regression/literal_complex.rb
+++ b/test/prism_regression/literal_complex.rb
@@ -1,0 +1,10 @@
+# typed: false
+1i
++1i
++1.0i
+-1i
+-1.0i
+
+# calling ~ on a complex number would cause NoMethodError but is valid syntax
+~1i
+~1.0i


### PR DESCRIPTION
### Motivation

Unlike Integer or Float, Complex literals with prefix `-` or `+` should be translated to method calls on the Complex literal.

Closes #339 (that test would still fail due to error messages, but the trees match now)

The first commit splits the test name input into `prism_regression_test_name` and `prism_corpus_test_name`, so when we run one type of tests, the other type's previous input doesn't get erased.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
