### PR TITLE
Fix usage of unique counter in Prism -> Sorbet translation

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -479,6 +479,8 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             auto params = childContext.translate(up_cast(defNode->parameters));
             auto body = childContext.translate(defNode->body);
 
+            uniqueCounter = childContext.uniqueCounter;
+
             if (defNode->body != nullptr && PM_NODE_TYPE_P(defNode->body, PM_BEGIN_NODE)) {
                 // If the body is a PM_BEGIN_NODE instead of a PM_STATEMENTS_NODE, it means the method definition
                 // doesn't have an explicit begin block.
@@ -1862,7 +1864,7 @@ template <typename PrismNode> std::unique_ptr<parser::Mlhs> Translator::translat
 // Context management methods
 Translator Translator::enterMethodDef() {
     auto isInMethodDef = true;
-    return Translator(parser, gs, file, isInMethodDef);
+    return Translator(parser, gs, file, isInMethodDef, uniqueCounter);
 }
 
 void Translator::reportError(core::LocOffsets loc, const std::string &message) {

--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -40,8 +40,8 @@ public:
     std::unique_ptr<parser::Node> translate(const Node &node);
 
 private:
-    Translator(Parser parser, core::GlobalState &gs, core::FileRef file, bool isInMethodDef)
-        : parser(parser), gs(gs), file(file), isInMethodDef(isInMethodDef) {}
+    Translator(Parser parser, core::GlobalState &gs, core::FileRef file, bool isInMethodDef, int uniqueCounter)
+        : parser(parser), gs(gs), file(file), uniqueCounter(uniqueCounter), isInMethodDef(isInMethodDef) {}
     void reportError(core::LocOffsets loc, const std::string &message);
 
     core::LocOffsets translateLoc(pm_location_t loc);

--- a/test/BUILD
+++ b/test/BUILD
@@ -263,9 +263,11 @@ pipeline_tests(
             # Phases: https://github.com/Shopify/sorbet/blob/prism/docs/internals.md#phases
             "testdata/parser/**/*.rb",
             "testdata/parser/**/*.exp",
+            "testdata/desugar/**/*.rb",
+            "testdata/desugar/**/*.exp",
         ],
         exclude = [
-            # Tests having to do with error recovery; will address later
+            # Parser tests having to do with error recovery; will address later
             "testdata/parser/error_recovery/**",
             "testdata/parser/bad_argument_crash.rb",
             "testdata/parser/compare_overload_parse_error.rb",
@@ -284,6 +286,34 @@ pipeline_tests(
             "testdata/parser/misc.rb",
             "testdata/parser/offset0.rb",
             "testdata/parser/ruby_25.rb",
+
+            # Legitimately failing desugar tests
+            "testdata/desugar/blockpass.rb",
+            "testdata/desugar/constant_error.rb",
+            "testdata/desugar/csend.rb",
+            "testdata/desugar/defs_not_self.rb",
+            "testdata/desugar/defs_not_self_in_class.rb",
+            "testdata/desugar/for.rb",
+            "testdata/desugar/oror_classvar.rb",
+            "testdata/desugar/oror_ivar.rb",
+            "testdata/desugar/pattern_matching_array.rb",
+            "testdata/desugar/pattern_matching_const.rb",
+            "testdata/desugar/pattern_matching_hash.rb",
+            "testdata/desugar/range.rb",
+            "testdata/desugar/regexp.rb",
+            "testdata/desugar/sclass_inheritance.rb",
+            "testdata/desugar/sclass.rb",
+            "testdata/desugar/star_in_block_arg.rb",
+
+            # Desugar tests having to do with error recovery; will address later
+            "testdata/desugar/complex.rb",
+            "testdata/desugar/duplicated_hash_keys.rb",
+            "testdata/desugar/forwarded_rest_args_array.rb",
+            "testdata/desugar/forwarded_restarg_and_kwrestarg.rb",
+            "testdata/desugar/fuzz_block_pass.rb",
+            "testdata/desugar/fuzz_break_do_end.rb",
+            "testdata/desugar/integers.rb",
+            "testdata/desugar/keyword_args.rb",
         ],
     ),
     "PosTests",


### PR DESCRIPTION
Closes #340 

### Motivation
We were not correctly maintaining the value of `uniqueCounter` when creating and then exiting a new translator instance. This was causing one of the desugar tests to fail because the parse tree was different between Prism and Sorbet, as the anonymous block params were being assigned different unique index numbers.

This PR also adds the desugar tests to our test corpus runs!

### Test plan
See included automated tests.
