### PR TITLE
Improve handling of `uniqueCounter` in Prism translator

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -237,8 +237,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
                 auto name = parser.resolveConstant(prismName);
                 sorbetName = gs.enterNameUTF8(name);
             } else { // An anonymous block parameter, like `def foo(&)`
-                sorbetName =
-                    gs.freshNameUnique(core::UniqueNameKind::Parser, core::Names::ampersand(), ++uniqueCounter);
+                sorbetName = gs.freshNameUnique(core::UniqueNameKind::Parser, core::Names::ampersand(), nextUniqueID());
             }
 
             return make_unique<parser::Blockarg>(location, sorbetName);
@@ -496,8 +495,6 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             Translator childContext = enterMethodDef();
             auto params = childContext.translate(up_cast(defNode->parameters));
             auto body = childContext.translate(defNode->body);
-
-            uniqueCounter = childContext.uniqueCounter;
 
             if (defNode->body != nullptr && PM_NODE_TYPE_P(defNode->body, PM_BEGIN_NODE)) {
                 // If the body is a PM_BEGIN_NODE instead of a PM_STATEMENTS_NODE, it means the method definition
@@ -829,7 +826,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
                 auto name = parser.resolveConstant(prismName);
                 sorbetName = gs.enterNameUTF8(name);
             } else { // An anonymous keyword rest parameter, like `def foo(**)`
-                sorbetName = gs.freshNameUnique(core::UniqueNameKind::Parser, core::Names::starStar(), ++uniqueCounter);
+                sorbetName = gs.freshNameUnique(core::UniqueNameKind::Parser, core::Names::starStar(), nextUniqueID());
             }
 
             return make_unique<parser::Kwrestarg>(location, sorbetName);


### PR DESCRIPTION
### Motivation
`uniqueCounter` is a counter that is used to give unique ids to anonymous arguments while parsing them in Sorbet. Thus far, we have coordinated the `uniqueCounter` between multiple Translators by passing the value back and forth, but this approach is brittle.

With this new approach, we can maintain the same `uniqueCounter` between multiple translators:

1. The parent translator maintains the source-of-truth counter in a variable called `uniqueCounterStorage`
2. It also maintains a pointer to that value called `uniqueCounter`
3. Child translators are created with a dummy value in `uniqueCounterStorage` that will never be used, as well as the `uniqueCounter` pointer that points to their parent translator's storage
4. Incrementing the `uniqueCounter` happens via the pointer, which will always point to the parent's `uniqueCounter` value

### Test plan
Existing tests should continue to pass.
