### PR TITLE
Translate Prism `PM_DEF_NODE` with receivers as `DefS` nodes in Sorbet

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -516,6 +516,12 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
                 }
             }
 
+            if (auto receiver = defNode->receiver; receiver != nullptr) {
+                auto sorbetReceiver = translate(receiver);
+                return make_unique<parser::DefS>(location, declLoc, move(sorbetReceiver), gs.enterNameUTF8(name),
+                                                 move(params), move(body));
+            }
+
             return make_unique<parser::DefMethod>(location, declLoc, gs.enterNameUTF8(name), move(params), move(body));
         }
         case PM_DEFINED_NODE: {

--- a/test/BUILD
+++ b/test/BUILD
@@ -290,7 +290,6 @@ pipeline_tests(
             # Legitimately failing desugar tests
             "testdata/desugar/blockpass.rb",
             "testdata/desugar/constant_error.rb",
-            "testdata/desugar/defs_not_self.rb",
             "testdata/desugar/defs_not_self_in_class.rb",
             "testdata/desugar/for.rb",
             "testdata/desugar/oror_classvar.rb",

--- a/test/BUILD
+++ b/test/BUILD
@@ -290,7 +290,6 @@ pipeline_tests(
             # Legitimately failing desugar tests
             "testdata/desugar/blockpass.rb",
             "testdata/desugar/constant_error.rb",
-            "testdata/desugar/defs_not_self_in_class.rb",
             "testdata/desugar/for.rb",
             "testdata/desugar/oror_classvar.rb",
             "testdata/desugar/oror_ivar.rb",
@@ -299,7 +298,6 @@ pipeline_tests(
             "testdata/desugar/pattern_matching_hash.rb",
             "testdata/desugar/range.rb",
             "testdata/desugar/regexp.rb",
-            "testdata/desugar/sclass_inheritance.rb",
             "testdata/desugar/sclass.rb",
             "testdata/desugar/star_in_block_arg.rb",
 

--- a/test/prism_regression/def_singleton.parse-tree.exp
+++ b/test/prism_regression/def_singleton.parse-tree.exp
@@ -1,0 +1,22 @@
+Begin {
+  stmts = [
+    DefS {
+      singleton = Self {
+      }
+      name = <U foo>
+      args = NULL
+      body = NULL
+    }
+    DefS {
+      singleton = Send {
+        receiver = NULL
+        method = <U x>
+        args = [
+        ]
+      }
+      name = <U foo>
+      args = NULL
+      body = NULL
+    }
+  ]
+}

--- a/test/prism_regression/def_singleton.rb
+++ b/test/prism_regression/def_singleton.rb
@@ -1,0 +1,4 @@
+# typed: false
+
+def self.foo; end
+def x.foo; end # This is invalid


### PR DESCRIPTION
Closes #349
Closes #352
Closes #353

### Motivation
The `desugar/defs_not_self` test revealed that we are not correctly handling method definitions with receivers.

### Test plan
See included automated tests.
