### PR TITLE
Standardize handling of block arguments in Prism -> Sorbet translation

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -264,7 +264,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
         case PM_BREAK_NODE: { // A `break` statement, e.g. `break`, `break 1, 2, 3`
             auto breakNode = down_cast<pm_break_node>(node);
 
-            auto arguments = translateArguments(breakNode->arguments, nullptr);
+            auto arguments = translateArguments(breakNode->arguments);
 
             return make_unique<parser::Break>(location, move(arguments));
         }
@@ -303,7 +303,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             if (prismBlock != nullptr && PM_NODE_TYPE_P(prismBlock, PM_BLOCK_ARGUMENT_NODE)) {
                 args = translateArguments(callNode->arguments, callNode->block);
             } else {
-                args = translateArguments(callNode->arguments, nullptr);
+                args = translateArguments(callNode->arguments);
             }
 
             if (name == "[]=") {
@@ -931,7 +931,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
         case PM_NEXT_NODE: { // A `next` statement, e.g. `next`, `next 1, 2, 3`
             auto nextNode = down_cast<pm_next_node>(node);
 
-            auto arguments = translateArguments(nextNode->arguments, nullptr);
+            auto arguments = translateArguments(nextNode->arguments);
 
             return make_unique<parser::Next>(location, move(arguments));
         }
@@ -1145,7 +1145,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
         case PM_RETURN_NODE: { // A `return` statement, like `return 1, 2, 3`
             auto returnNode = down_cast<pm_return_node>(node);
 
-            auto returnValues = translateArguments(returnNode->arguments, nullptr);
+            auto returnValues = translateArguments(returnNode->arguments);
 
             return make_unique<parser::Return>(location, move(returnValues));
         }
@@ -1284,7 +1284,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
         case PM_YIELD_NODE: { // The `yield` keyword, like `yield`, `yield 1, 2, 3`
             auto yieldNode = down_cast<pm_yield_node>(node);
 
-            auto yieldArgs = translateArguments(yieldNode->arguments, nullptr);
+            auto yieldArgs = translateArguments(yieldNode->arguments);
 
             return make_unique<parser::Yield>(location, move(yieldArgs));
         }
@@ -1583,7 +1583,7 @@ void Translator::patternTranslateMultiInto(NodeVec &outSorbetNodes, absl::Span<p
 
 // The legacy Sorbet parser doesn't have a counterpart to PM_ARGUMENTS_NODE to wrap the array
 // of argument nodes. It just uses a NodeVec directly, which is what this function produces.
-NodeVec Translator::translateArguments(pm_arguments_node *argsNode, pm_node *blockNode, size_t extraCapacity) {
+NodeVec Translator::translateArguments(pm_arguments_node *argsNode, pm_node *blockNode) {
     NodeVec results;
 
     absl::Span<pm_node *> prismArgs;
@@ -1592,7 +1592,7 @@ NodeVec Translator::translateArguments(pm_arguments_node *argsNode, pm_node *blo
         prismArgs = absl::MakeSpan(argsNode->arguments.nodes, argsNode->arguments.size);
     }
 
-    results.reserve(prismArgs.size() + extraCapacity + blockNode == nullptr ? 0 : 1);
+    results.reserve(prismArgs.size() + (blockNode == nullptr ? 0 : 1));
 
     translateMultiInto(results, prismArgs);
     if (blockNode != nullptr) {

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -690,7 +690,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             auto openingLoc = translateLoc(indexedTargetNode->opening_loc);                  // The location of `[]=`
             auto lBracketLoc = core::LocOffsets{openingLoc.beginLoc, openingLoc.endLoc - 1}; // Drop the `=`
             auto receiver = translate(indexedTargetNode->receiver);
-            auto arguments = translateArguments(indexedTargetNode->arguments, nullptr);
+            auto arguments = translateArguments(indexedTargetNode->arguments, up_cast(indexedTargetNode->block));
 
             return make_unique<parser::Send>(location, move(receiver), core::Names::squareBracketsEq(), lBracketLoc,
                                              move(arguments));

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -68,7 +68,7 @@ unique_ptr<SorbetAssignmentNode> Translator::translateOpAssignment(pm_node_t *un
         auto lBracketLoc = core::LocOffsets{openingLoc.beginLoc, openingLoc.endLoc - 1};
 
         auto receiver = translate(node->receiver);
-        auto args = translateArguments(node->arguments, nullptr);
+        auto args = translateArguments(node->arguments, up_cast(node->block));
         lhs =
             make_unique<parser::Send>(location, move(receiver), core::Names::squareBrackets(), lBracketLoc, move(args));
     } else if constexpr (is_same_v<PrismAssignmentNode, pm_constant_operator_write_node> ||

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -297,15 +297,13 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             }
 
             pm_node_t *prismBlock = callNode->block;
+            NodeVec args;
             // PM_BLOCK_ARGUMENT_NODE models the `&b` in `a.map(&b)`,
             // but not an explicit block with `{ ... }` or `do ... end`
-            auto hasBlockArgument = prismBlock != nullptr && PM_NODE_TYPE_P(prismBlock, PM_BLOCK_ARGUMENT_NODE);
-
-            auto args = translateArguments(callNode->arguments, nullptr, (hasBlockArgument ? 0 : 1));
-
-            if (hasBlockArgument) {
-                auto blockPassNode = translate(prismBlock);
-                args.emplace_back(move(blockPassNode));
+            if (prismBlock != nullptr && PM_NODE_TYPE_P(prismBlock, PM_BLOCK_ARGUMENT_NODE)) {
+                args = translateArguments(callNode->arguments, callNode->block);
+            } else {
+                args = translateArguments(callNode->arguments, nullptr);
             }
 
             if (name == "[]=") {

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1209,6 +1209,11 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
 
             auto returnValues = translateArguments(superNode->arguments);
 
+            if (auto block = superNode->block; block != nullptr) {
+                auto prismBlock = translate(superNode->block);
+                returnValues.emplace_back(move(prismBlock));
+            }
+
             return make_unique<parser::Super>(location, move(returnValues));
         }
         case PM_SYMBOL_NODE: { // A symbol literal, e.g. `:foo`

--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -62,7 +62,7 @@ private:
     parser::NodeVec translateMulti(pm_node_list prismNodes);
     void translateMultiInto(NodeVec &sorbetNodes, absl::Span<pm_node_t *> prismNodes);
 
-    NodeVec translateArguments(pm_arguments_node *node, pm_node *blockNode, size_t extraCapacity = 0);
+    NodeVec translateArguments(pm_arguments_node *node, pm_node *blockNode = nullptr);
     std::unique_ptr<parser::Hash> translateHash(pm_node_t *node, pm_node_list_t elements,
                                                 bool isUsedForKeywordArguments);
     std::unique_ptr<parser::Node> translateCallWithBlock(pm_node_t *prismBlockOrLambdaNode,

--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -62,7 +62,7 @@ private:
     parser::NodeVec translateMulti(pm_node_list prismNodes);
     void translateMultiInto(NodeVec &sorbetNodes, absl::Span<pm_node_t *> prismNodes);
 
-    NodeVec translateArguments(pm_arguments_node *node, pm_block_node *blockNode, size_t extraCapacity = 0);
+    NodeVec translateArguments(pm_arguments_node *node, pm_node *blockNode, size_t extraCapacity = 0);
     std::unique_ptr<parser::Hash> translateHash(pm_node_t *node, pm_node_list_t elements,
                                                 bool isUsedForKeywordArguments);
     std::unique_ptr<parser::Node> translateCallWithBlock(pm_node_t *prismBlockOrLambdaNode,

--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -62,7 +62,7 @@ private:
     parser::NodeVec translateMulti(pm_node_list prismNodes);
     void translateMultiInto(NodeVec &sorbetNodes, absl::Span<pm_node_t *> prismNodes);
 
-    NodeVec translateArguments(pm_arguments_node *node, size_t extraCapacity = 0);
+    NodeVec translateArguments(pm_arguments_node *node, pm_block_node *blockNode, size_t extraCapacity = 0);
     std::unique_ptr<parser::Hash> translateHash(pm_node_t *node, pm_node_list_t elements,
                                                 bool isUsedForKeywordArguments);
     std::unique_ptr<parser::Node> translateCallWithBlock(pm_node_t *prismBlockOrLambdaNode,

--- a/test/BUILD
+++ b/test/BUILD
@@ -288,7 +288,6 @@ pipeline_tests(
             "testdata/parser/ruby_25.rb",
 
             # Legitimately failing desugar tests
-            "testdata/desugar/blockpass.rb",
             "testdata/desugar/constant_error.rb",
             "testdata/desugar/for.rb",
             "testdata/desugar/oror_classvar.rb",

--- a/test/prism_regression/assign_to_index.parse-tree.exp
+++ b/test/prism_regression/assign_to_index.parse-tree.exp
@@ -369,5 +369,47 @@ Begin {
         }
       ]
     }
+    Masgn {
+      lhs = Mlhs {
+        exprs = [
+          Send {
+            receiver = Send {
+              receiver = NULL
+              method = <U target>
+              args = [
+              ]
+            }
+            method = <U []=>
+            args = [
+              BlockPass {
+                block = Send {
+                  receiver = NULL
+                  method = <U blk>
+                  args = [
+                  ]
+                }
+              }
+            ]
+          }
+          Send {
+            receiver = Send {
+              receiver = NULL
+              method = <U target>
+              args = [
+              ]
+            }
+            method = <U []=>
+            args = [
+              Integer {
+                val = "1"
+              }
+            ]
+          }
+        ]
+      }
+      rhs = Integer {
+        val = "4"
+      }
+    }
   ]
 }

--- a/test/prism_regression/assign_to_index.parse-tree.exp
+++ b/test/prism_regression/assign_to_index.parse-tree.exp
@@ -369,6 +369,304 @@ Begin {
         }
       ]
     }
+    OpAsgn {
+      left = Send {
+        receiver = Send {
+          receiver = NULL
+          method = <U bitwise_and>
+          args = [
+          ]
+        }
+        method = <U []>
+        args = [
+          BlockPass {
+            block = Send {
+              receiver = NULL
+              method = <U blk>
+              args = [
+              ]
+            }
+          }
+        ]
+      }
+      op = <U &>
+      right = Integer {
+        val = "2"
+      }
+    }
+    OpAsgn {
+      left = Send {
+        receiver = Send {
+          receiver = NULL
+          method = <U bitwise_xor>
+          args = [
+          ]
+        }
+        method = <U []>
+        args = [
+          BlockPass {
+            block = Send {
+              receiver = NULL
+              method = <U blk>
+              args = [
+              ]
+            }
+          }
+        ]
+      }
+      op = <U ^>
+      right = Integer {
+        val = "4"
+      }
+    }
+    OpAsgn {
+      left = Send {
+        receiver = Send {
+          receiver = NULL
+          method = <U shift_right>
+          args = [
+          ]
+        }
+        method = <U []>
+        args = [
+          BlockPass {
+            block = Send {
+              receiver = NULL
+              method = <U blk>
+              args = [
+              ]
+            }
+          }
+        ]
+      }
+      op = <U >>>
+      right = Integer {
+        val = "5"
+      }
+    }
+    OpAsgn {
+      left = Send {
+        receiver = Send {
+          receiver = NULL
+          method = <U shift_left>
+          args = [
+          ]
+        }
+        method = <U []>
+        args = [
+          BlockPass {
+            block = Send {
+              receiver = NULL
+              method = <U blk>
+              args = [
+              ]
+            }
+          }
+        ]
+      }
+      op = <U <<>
+      right = Integer {
+        val = "6"
+      }
+    }
+    OpAsgn {
+      left = Send {
+        receiver = Send {
+          receiver = NULL
+          method = <U subtract_assign>
+          args = [
+          ]
+        }
+        method = <U []>
+        args = [
+          BlockPass {
+            block = Send {
+              receiver = NULL
+              method = <U blk>
+              args = [
+              ]
+            }
+          }
+        ]
+      }
+      op = <U ->
+      right = Integer {
+        val = "7"
+      }
+    }
+    OpAsgn {
+      left = Send {
+        receiver = Send {
+          receiver = NULL
+          method = <U module_assign>
+          args = [
+          ]
+        }
+        method = <U []>
+        args = [
+          BlockPass {
+            block = Send {
+              receiver = NULL
+              method = <U blk>
+              args = [
+              ]
+            }
+          }
+        ]
+      }
+      op = <U %>
+      right = Integer {
+        val = "8"
+      }
+    }
+    OpAsgn {
+      left = Send {
+        receiver = Send {
+          receiver = NULL
+          method = <U bitwise_or>
+          args = [
+          ]
+        }
+        method = <U []>
+        args = [
+          BlockPass {
+            block = Send {
+              receiver = NULL
+              method = <U blk>
+              args = [
+              ]
+            }
+          }
+        ]
+      }
+      op = <U |>
+      right = Integer {
+        val = "9"
+      }
+    }
+    OpAsgn {
+      left = Send {
+        receiver = Send {
+          receiver = NULL
+          method = <U divide_assign>
+          args = [
+          ]
+        }
+        method = <U []>
+        args = [
+          BlockPass {
+            block = Send {
+              receiver = NULL
+              method = <U blk>
+              args = [
+              ]
+            }
+          }
+        ]
+      }
+      op = <U />
+      right = Integer {
+        val = "10"
+      }
+    }
+    OpAsgn {
+      left = Send {
+        receiver = Send {
+          receiver = NULL
+          method = <U multiply_assign>
+          args = [
+          ]
+        }
+        method = <U []>
+        args = [
+          BlockPass {
+            block = Send {
+              receiver = NULL
+              method = <U blk>
+              args = [
+              ]
+            }
+          }
+        ]
+      }
+      op = <U *>
+      right = Integer {
+        val = "11"
+      }
+    }
+    OpAsgn {
+      left = Send {
+        receiver = Send {
+          receiver = NULL
+          method = <U exponentiate_assign>
+          args = [
+          ]
+        }
+        method = <U []>
+        args = [
+          BlockPass {
+            block = Send {
+              receiver = NULL
+              method = <U blk>
+              args = [
+              ]
+            }
+          }
+        ]
+      }
+      op = <U **>
+      right = Integer {
+        val = "12"
+      }
+    }
+    AndAsgn {
+      left = Send {
+        receiver = Send {
+          receiver = NULL
+          method = <U lazy_and_assign>
+          args = [
+          ]
+        }
+        method = <U []>
+        args = [
+          BlockPass {
+            block = Send {
+              receiver = NULL
+              method = <U blk>
+              args = [
+              ]
+            }
+          }
+        ]
+      }
+      right = Integer {
+        val = "13"
+      }
+    }
+    OrAsgn {
+      left = Send {
+        receiver = Send {
+          receiver = NULL
+          method = <U lazy_or_assign>
+          args = [
+          ]
+        }
+        method = <U []>
+        args = [
+          BlockPass {
+            block = Send {
+              receiver = NULL
+              method = <U blk>
+              args = [
+              ]
+            }
+          }
+        ]
+      }
+      right = Integer {
+        val = "14"
+      }
+    }
     Masgn {
       lhs = Mlhs {
         exprs = [

--- a/test/prism_regression/assign_to_index.rb
+++ b/test/prism_regression/assign_to_index.rb
@@ -23,3 +23,6 @@ lazy_or_assign[0] ||= 14
 target[0], target[1] = 15, 16
 target[2, 3], target[4, 5] = 17, 18, 19, 20
 target[] = 21 # Yes, this is valid. You can have `def []=(only_one_param)`.
+
+# Index target node with a block
+target[&blk], target[1] = 4

--- a/test/prism_regression/assign_to_index.rb
+++ b/test/prism_regression/assign_to_index.rb
@@ -3,7 +3,7 @@
 # Regular assignment
 regular[0] = 1
 
-# # Compound assignment operators
+# Compound assignment operators
 bitwise_and[0] &= 2
 bitwise_xor[0] ^= 4
 shift_right[0] >>= 5
@@ -15,7 +15,7 @@ divide_assign[0] /= 10
 multiply_assign[0] *= 11
 exponentiate_assign[0] **= 12
 
-# # Special cases
+# Special cases
 lazy_and_assign[0] &&= 13
 lazy_or_assign[0] ||= 14
 
@@ -24,5 +24,22 @@ target[0], target[1] = 15, 16
 target[2, 3], target[4, 5] = 17, 18, 19, 20
 target[] = 21 # Yes, this is valid. You can have `def []=(only_one_param)`.
 
-# Index target node with a block
+# Assign to index with a block
+# Note: this is technically not valid Ruby, but Prism allows it.
+
+bitwise_and[&blk] &= 2
+bitwise_xor[&blk] ^= 4
+shift_right[&blk] >>= 5
+shift_left[&blk] <<= 6
+subtract_assign[&blk] -= 7
+module_assign[&blk] %= 8
+bitwise_or[&blk] |= 9
+divide_assign[&blk] /= 10
+multiply_assign[&blk] *= 11
+exponentiate_assign[&blk] **= 12
+
+lazy_and_assign[&blk] &&= 13
+lazy_or_assign[&blk] ||= 14
+
+
 target[&blk], target[1] = 4

--- a/test/prism_regression/def_block_param.parse-tree.exp
+++ b/test/prism_regression/def_block_param.parse-tree.exp
@@ -22,5 +22,24 @@ Begin {
       }
       body = NULL
     }
+    DefMethod {
+      name = <U foo>
+      args = Args {
+        args = [
+          Blockarg {
+            name = <U blk>
+          }
+        ]
+      }
+      body = Super {
+        args = [
+          BlockPass {
+            block = LVar {
+              name = <U blk>
+            }
+          }
+        ]
+      }
+    }
   ]
 }

--- a/test/prism_regression/def_block_param.rb
+++ b/test/prism_regression/def_block_param.rb
@@ -3,3 +3,7 @@
 def foo(&blk); end
 
 def foo(&); end
+
+def foo(&blk)
+  super(&blk)
+end

--- a/test/prism_regression/def_singleton.parse-tree.exp
+++ b/test/prism_regression/def_singleton.parse-tree.exp
@@ -18,5 +18,26 @@ Begin {
       args = NULL
       body = NULL
     }
+    DefS {
+      singleton = Self {
+      }
+      name = <U foo>
+      args = Args {
+        args = [
+          Blockarg {
+            name = <U blk>
+          }
+        ]
+      }
+      body = Super {
+        args = [
+          BlockPass {
+            block = LVar {
+              name = <U blk>
+            }
+          }
+        ]
+      }
+    }
   ]
 }

--- a/test/prism_regression/def_singleton.rb
+++ b/test/prism_regression/def_singleton.rb
@@ -2,3 +2,7 @@
 
 def self.foo; end
 def x.foo; end # This is invalid
+
+def self.foo(&blk)
+  super(&blk)
+end


### PR DESCRIPTION
Closes #354

### Motivation
Best read commit-by-commit.

I started out this PR trying to get the `desguar/blockpass` test to pass. It turns out, that test was failing because we weren't properly translating calls to `super` with block arguments.

Once I had done that, I realized that our logic for handling block arguments was sprinkled throughout the translator, so I did a refactor of `translateArguments` so that it handles block arguments, unifying all that scattered logic into one method.

### Test plan
See included automated tests.
