### PR TITLE
Skip error message checking when running Corpus tests with Prism

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -267,27 +267,17 @@ pipeline_tests(
             "testdata/desugar/**/*.exp",
         ],
         exclude = [
-            # Parser tests having to do with error recovery; will address later
+            # Parser tests having to do with tree differences in invalid Ruby code; will address later
             "testdata/parser/error_recovery/**",
-            "testdata/parser/bad_argument_crash.rb",
-            "testdata/parser/compare_overload_parse_error.rb",
-            "testdata/parser/crash_block_pass.rb",
             "testdata/parser/crash_block_pass_suggestion.rb",
-            "testdata/parser/fuzz_ivar.rb",
             "testdata/parser/invalid_fatal.rb",
             "testdata/parser/invalid_syntax_error.rb",
-            "testdata/parser/invalid_trailing_in_number.rb",
-            "testdata/parser/curly_braces_block_pass.rb",
-            "testdata/parser/forward_arg_after_restarg.rb",
             "testdata/parser/kwargs_missing_comma.rb",
-            "testdata/parser/kwargs_missing_comma_unsupported.rb",
-            "testdata/parser/kwnil_errors.rb",
-            "testdata/parser/method_def_trailing_comma.rb",
             "testdata/parser/misc.rb",
             "testdata/parser/offset0.rb",
             "testdata/parser/ruby_25.rb",
 
-            # Legitimately failing desugar tests
+            # Desugar tests having to do with tree differences; will address later
             "testdata/desugar/constant_error.rb",
             "testdata/desugar/for.rb",
             "testdata/desugar/oror_classvar.rb",
@@ -296,16 +286,6 @@ pipeline_tests(
             "testdata/desugar/range.rb",
             "testdata/desugar/regexp.rb",
             "testdata/desugar/sclass.rb",
-
-            # Desugar tests having to do with error recovery; will address later
-            "testdata/desugar/complex.rb",
-            "testdata/desugar/duplicated_hash_keys.rb",
-            "testdata/desugar/forwarded_rest_args_array.rb",
-            "testdata/desugar/forwarded_restarg_and_kwrestarg.rb",
-            "testdata/desugar/fuzz_block_pass.rb",
-            "testdata/desugar/fuzz_break_do_end.rb",
-            "testdata/desugar/integers.rb",
-            "testdata/desugar/keyword_args.rb",
         ],
     ),
     "PosTests",

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -58,6 +58,11 @@ template <typename T> bool isDuplicateDiagnostic(string_view filename, T *assert
 template <typename T>
 void reportMissingError(const string &filename, const T &assertion, string_view sourceLine, string_view errorPrefix,
                         bool missingDuplicate = false) {
+    // Skip error message checking when running with Prism.
+    if (sorbet::test::parser == realmain::options::Parser::PRISM) {
+        return;
+    }
+
     auto coreMessage = missingDuplicate ? "Error was not duplicated" : "Did not find expected error";
     auto messagePostfix = missingDuplicate ? "\nYou can fix this error by changing the assertion to `error:`." : "";
     ADD_FAIL_CHECK_AT(filename.c_str(), assertion.range->start->line + 1,
@@ -68,6 +73,11 @@ void reportMissingError(const string &filename, const T &assertion, string_view 
 
 void reportUnexpectedError(const string &filename, const Diagnostic &diagnostic, string_view sourceLine,
                            string_view errorPrefix) {
+    // Skip error message checking when running with Prism.
+    if (sorbet::test::parser == realmain::options::Parser::PRISM) {
+        return;
+    }
+
     ADD_FAIL_CHECK_AT(
         filename.c_str(), diagnostic.range->start->line + 1,
         fmt::format(
@@ -476,6 +486,10 @@ string ErrorAssertion::toString() const {
 }
 
 bool ErrorAssertion::check(const Diagnostic &diagnostic, string_view sourceLine, string_view errorPrefix) {
+    // Skip error message checking when running with Prism.
+    if (sorbet::test::parser == realmain::options::Parser::PRISM) {
+        return true;
+    }
     // The error message must contain `message`.
     if (diagnostic.message.find(message) == string::npos) {
         ADD_FAIL_CHECK_AT(filename.c_str(), range->start->line + 1,

--- a/test/helpers/position_assertions.h
+++ b/test/helpers/position_assertions.h
@@ -9,6 +9,10 @@
 namespace sorbet::test {
 using namespace sorbet::realmain::lsp;
 
+// TODO: Remove this before upstreaming
+// This is needed to skip error assertions when running under Prism
+extern realmain::options::Parser parser;
+
 class ErrorAssertion;
 class UntypedAssertion;
 


### PR DESCRIPTION
### Motivation

Currently, corpus tests may fail with Prism for a few reasons:

1. The error checking fails with Prism. This is expected.
2. There are tree mismatches.

And sometimes, a test fail because of both 1 and 2.

This means that by skipping the test altogether, we are potentially skipping legitimately failing tests.

This commit updates the test runner to skip the error message checking when running corpus tests with Prism and updates the skipped tests in the BUILD file.

So now if a test is skipped, it's only because of the second reason. And we should minimize the number of tests that are skipped in that case.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
