### PR TITLE
Fix splat arg translation

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -298,7 +298,6 @@ pipeline_tests(
             "testdata/desugar/range.rb",
             "testdata/desugar/regexp.rb",
             "testdata/desugar/sclass.rb",
-            "testdata/desugar/star_in_block_arg.rb",
 
             # Desugar tests having to do with error recovery; will address later
             "testdata/desugar/complex.rb",

--- a/test/prism_regression/call_block_param.parse-tree.exp
+++ b/test/prism_regression/call_block_param.parse-tree.exp
@@ -227,5 +227,45 @@ Begin {
       args = NULL
       body = NULL
     }
+    Block {
+      send = Send {
+        receiver = NULL
+        method = <U foo>
+        args = [
+        ]
+      }
+      args = Args {
+        args = [
+          Mlhs {
+            exprs = [
+              Restarg {
+                name = <U args>
+              }
+            ]
+          }
+        ]
+      }
+      body = String {
+        val = <U block with multi-target rest args>
+      }
+    }
+    Block {
+      send = Send {
+        receiver = NULL
+        method = <U foo>
+        args = [
+        ]
+      }
+      args = Args {
+        args = [
+          Restarg {
+            name = <U args>
+          }
+        ]
+      }
+      body = String {
+        val = <U block with rest args>
+      }
+    }
   ]
 }

--- a/test/prism_regression/call_block_param.rb
+++ b/test/prism_regression/call_block_param.rb
@@ -33,3 +33,11 @@ foo { |bar; baz, qux| }
 foo(&forwarded_block)
 
 foo&.bar {}
+
+foo do |(*args)|
+  "block with multi-target rest args"
+end
+
+foo do |*args|
+  "block with rest args"
+end


### PR DESCRIPTION
### Motivation

When the splat arg's expression is an `Arg`, we need to translate it to a `Restarg` instead of a `SplatLhs`.

Closes #357


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
