### PR TITLE
Fix array pattern translation

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1407,12 +1407,21 @@ unique_ptr<parser::Node> Translator::patternTranslate(pm_node_t *node) {
 
             patternTranslateMultiInto(sorbetElements, prismPrefixNodes);
 
-            if (prismRestNode != nullptr)
+            // Implicit rest nodes in array patterns don't need to be translated
+            if (prismRestNode != nullptr && !PM_NODE_TYPE_P(prismRestNode, PM_IMPLICIT_REST_NODE)) {
                 sorbetElements.emplace_back(patternTranslate(prismRestNode));
+            }
 
             patternTranslateMultiInto(sorbetElements, prismSuffixNodes);
 
-            auto arrayPattern = make_unique<parser::ArrayPattern>(location, move(sorbetElements));
+            unique_ptr<parser::Node> arrayPattern = nullptr;
+
+            // When the pattern ends with an implicit rest node, we need to return an `ArrayPatternWithTail` instead
+            if (prismRestNode != nullptr && PM_NODE_TYPE_P(prismRestNode, PM_IMPLICIT_REST_NODE)) {
+                arrayPattern = make_unique<parser::ArrayPatternWithTail>(location, move(sorbetElements));
+            } else {
+                arrayPattern = make_unique<parser::ArrayPattern>(location, move(sorbetElements));
+            }
 
             if (auto prismConstant = arrayPatternNode->constant; prismConstant != nullptr) {
                 // An array pattern can start with a constant that matches against a specific type,

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1437,7 +1437,7 @@ unique_ptr<parser::Node> Translator::patternTranslate(pm_node_t *node) {
         case PM_CAPTURE_PATTERN_NODE: { // A variable capture such as the `Integer => i` in `in Integer => i`
             auto capturePatternNode = down_cast<pm_capture_pattern_node>(node);
 
-            auto pattern = translate(capturePatternNode->value);
+            auto pattern = patternTranslate(capturePatternNode->value);
             auto target = patternTranslate(up_cast(capturePatternNode->target));
 
             return make_unique<parser::MatchAs>(location, move(pattern), move(target));

--- a/test/BUILD
+++ b/test/BUILD
@@ -292,7 +292,6 @@ pipeline_tests(
             "testdata/desugar/for.rb",
             "testdata/desugar/oror_classvar.rb",
             "testdata/desugar/oror_ivar.rb",
-            "testdata/desugar/pattern_matching_array.rb",
             "testdata/desugar/pattern_matching_const.rb",
             "testdata/desugar/pattern_matching_hash.rb",
             "testdata/desugar/range.rb",

--- a/test/BUILD
+++ b/test/BUILD
@@ -292,7 +292,6 @@ pipeline_tests(
             "testdata/desugar/for.rb",
             "testdata/desugar/oror_classvar.rb",
             "testdata/desugar/oror_ivar.rb",
-            "testdata/desugar/pattern_matching_const.rb",
             "testdata/desugar/pattern_matching_hash.rb",
             "testdata/desugar/range.rb",
             "testdata/desugar/regexp.rb",

--- a/test/prism_regression/case_match.parse-tree.exp
+++ b/test/prism_regression/case_match.parse-tree.exp
@@ -304,6 +304,25 @@ Begin {
             ]
           }
         }
+        InPattern {
+          pattern = ArrayPatternWithTail {
+            elts = [
+              MatchVar {
+                name = <U i>
+              }
+            ]
+          }
+          guard = NULL
+          body = Send {
+            receiver = NULL
+            method = <U puts>
+            args = [
+              String {
+                val = <U An array with an element and maybe other stuff>
+              }
+            ]
+          }
+        }
       ]
       elseBody = NULL
     }

--- a/test/prism_regression/case_match.parse-tree.exp
+++ b/test/prism_regression/case_match.parse-tree.exp
@@ -78,9 +78,14 @@ Begin {
       }
       inBodies = [
         InPattern {
-          pattern = ArrayPattern {
-            elts = [
-            ]
+          pattern = MatchAs {
+            value = ArrayPattern {
+              elts = [
+              ]
+            }
+            as = MatchVar {
+              name = <U a>
+            }
           }
           guard = NULL
           body = Send {

--- a/test/prism_regression/case_match.rb
+++ b/test/prism_regression/case_match.rb
@@ -28,6 +28,8 @@ in Array[first, second] # Requires the `array_like_thing` to be an `Array` speci
   puts "An Array with first: #{first} and second: #{second}"
 in Point[x, y]          # Requires the `array_like_thing` to be a `Point` specifically
   puts "A Point with x: #{x} and y: #{y}"
+in [i,]
+  puts "An array with an element and maybe other stuff"
 end
 
 case hash_like_thing

--- a/test/prism_regression/case_match.rb
+++ b/test/prism_regression/case_match.rb
@@ -12,7 +12,7 @@ else
 end
 
 case array_like_thing
-in []
+in [] => a
   puts "empty!"
 in [1, 2]
   puts "one and two!"


### PR DESCRIPTION
### Motivation

1. We don't need to translate implicit rest nodes in array patterns
2. We need to return an `ArrayPatternWithTail` instead of an `ArrayPattern` when the pattern ends with an implicit rest node
3. When translating `PM_CAPTURE_PATTERN_NODE`'s pattern, we need to use `patternTranslate` instead of `translate`.

Fixes #359 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
