### PR TITLE
Fix desguar tests related to dynamic constant assignment

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -438,7 +438,9 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             // See`PM_CONSTANT_READ_NODE`, which handles the `::C` part
             auto constantPathNode = down_cast<pm_constant_path_node>(node);
 
-            return translateConst<pm_constant_path_node, parser::Const>(constantPathNode);
+            auto skipDynamicConstantWorkaround = true;
+            return translateConst<pm_constant_path_node, parser::Const>(constantPathNode,
+                                                                        skipDynamicConstantWorkaround);
         }
         case PM_CONSTANT_PATH_OPERATOR_WRITE_NODE: { // Compound assignment to a constant path, e.g. `A::B += 1`
             return translateOpAssignment<pm_constant_path_operator_write_node, parser::OpAsgn, parser::ConstLhs>(node);

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -33,10 +33,12 @@ unique_ptr<parser::Assign> Translator::translateAssignment(pm_node_t *untypedNod
     unique_ptr<parser::Node> lhs;
     if constexpr (is_same_v<PrismAssignmentNode, pm_constant_write_node>) {
         // Handle regular assignment to a "plain" constant, like `A = 1`
-        lhs = translateConst<pm_constant_write_node, parser::ConstLhs>(node);
+        auto replaceWithDynamicConstAssign = true;
+        lhs = translateConst<pm_constant_write_node, parser::ConstLhs>(node, replaceWithDynamicConstAssign);
     } else if constexpr (is_same_v<PrismAssignmentNode, pm_constant_path_write_node>) {
         // Handle regular assignment to a constant path, like `A::B::C = 1` or `::C = 1`
-        lhs = translateConst<pm_constant_path_node, parser::ConstLhs>(node->target);
+        auto replaceWithDynamicConstAssign = true;
+        lhs = translateConst<pm_constant_path_node, parser::ConstLhs>(node->target, replaceWithDynamicConstAssign);
     } else {
         // Handle regular assignment to any other kind of LHS.
         auto name = parser.resolveConstant(node->name);
@@ -75,13 +77,13 @@ unique_ptr<SorbetAssignmentNode> Translator::translateOpAssignment(pm_node_t *un
                          is_same_v<PrismAssignmentNode, pm_constant_and_write_node> ||
                          is_same_v<PrismAssignmentNode, pm_constant_or_write_node>) {
         // Handle operator assignment to a "plain" constant, like `A += 1`
-        lhs = translateConst<PrismAssignmentNode, parser::ConstLhs>(node);
+        auto replaceWithDynamicConstAssign = true;
+        lhs = translateConst<PrismAssignmentNode, parser::ConstLhs>(node, replaceWithDynamicConstAssign);
     } else if constexpr (is_same_v<PrismAssignmentNode, pm_constant_path_operator_write_node> ||
                          is_same_v<PrismAssignmentNode, pm_constant_path_and_write_node> ||
                          is_same_v<PrismAssignmentNode, pm_constant_path_or_write_node>) {
         // Handle operator assignment to a constant path, like `A::B::C += 1` or `::C += 1`
-        bool skipDynamicConstantWorkaround = true;
-        lhs = translateConst<pm_constant_path_node, parser::ConstLhs>(node->target, skipDynamicConstantWorkaround);
+        lhs = translateConst<pm_constant_path_node, parser::ConstLhs>(node->target);
     } else if constexpr (is_same_v<SorbetLHSNode, parser::Send> || is_same_v<SorbetLHSNode, parser::CSend>) {
         // Handle operator assignment to the result of a method call, like `a.b += 1`
         auto name = parser.resolveConstant(node->read_name);
@@ -438,9 +440,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             // See`PM_CONSTANT_READ_NODE`, which handles the `::C` part
             auto constantPathNode = down_cast<pm_constant_path_node>(node);
 
-            auto skipDynamicConstantWorkaround = true;
-            return translateConst<pm_constant_path_node, parser::Const>(constantPathNode,
-                                                                        skipDynamicConstantWorkaround);
+            return translateConst<pm_constant_path_node, parser::Const>(constantPathNode);
         }
         case PM_CONSTANT_PATH_OPERATOR_WRITE_NODE: { // Compound assignment to a constant path, e.g. `A::B += 1`
             return translateOpAssignment<pm_constant_path_operator_write_node, parser::OpAsgn, parser::ConstLhs>(node);
@@ -1767,7 +1767,7 @@ unique_ptr<parser::Node> Translator::translateStatements(pm_statements_node *stm
     return make_unique<parser::Begin>(translateLoc(stmtsNode->base.location), move(sorbetStmts));
 }
 
-// Handles any one of the Prism nodes that models any kind of assignment to a constant or constant path.
+// Handles any one of the Prism nodes that models any kind of constant or constant path.
 //
 // Dynamic constant assignment inside of a method definition will raise a SyntaxError at runtime. In the
 // Sorbet validator, there is a check that will crash Sorbet if this is detected statically.
@@ -1782,9 +1782,23 @@ unique_ptr<parser::Node> Translator::translateStatements(pm_statements_node *stm
 // Usually returns the `SorbetLHSNode`, but for constant writes and targets,
 // it can can return an `LVarLhs` as a workaround in the case of a dynamic constant assignment.
 template <typename PrismLhsNode, typename SorbetLHSNode>
-unique_ptr<parser::Node> Translator::translateConst(PrismLhsNode *node, bool skipDynamicConstantWorkaround) {
+unique_ptr<parser::Node> Translator::translateConst(PrismLhsNode *node, bool replaceWithDynamicConstAssign) {
     static_assert(is_same_v<SorbetLHSNode, parser::Const> || is_same_v<SorbetLHSNode, parser::ConstLhs>,
                   "Invalid LHS type. Must be one of `parser::Const` or `parser::ConstLhs`.");
+
+    auto location = translateLoc(node->base.location);
+    auto name = parser.resolveConstant(node->name);
+
+    if (isInMethodDef && replaceWithDynamicConstAssign) {
+        // Check if this is a dynamic constant assignment (SyntaxError at runtime)
+        // This is a copy of a workaround from `Desugar.cc`, which substitues in a fake assignment,
+        // so the parsing can continue. See other usages of `dynamicConstAssign` for more details.
+
+        // Enter the name of the constant so that it's available for the rest of the pipeline
+        gs.enterNameConstant(name);
+
+        return make_unique<LVarLhs>(location, core::Names::dynamicConstAssign());
+    }
 
     auto constexpr isConstantPath = is_same_v<PrismLhsNode, pm_constant_path_target_node> ||
                                     is_same_v<PrismLhsNode, pm_constant_path_write_node> ||
@@ -1812,25 +1826,6 @@ unique_ptr<parser::Node> Translator::translateConst(PrismLhsNode *node, bool ski
             is_same_v<PrismLhsNode, pm_constant_target_node> || is_same_v<PrismLhsNode, pm_constant_read_node> ||
             is_same_v<PrismLhsNode, pm_constant_write_node>);
         parent = nullptr;
-    }
-
-    auto location = translateLoc(node->base.location);
-    auto name = parser.resolveConstant(node->name);
-
-    if constexpr (is_same_v<PrismLhsNode, pm_constant_write_node> || is_same_v<PrismLhsNode, pm_constant_path_node> ||
-                  is_same_v<PrismLhsNode, pm_constant_operator_write_node> ||
-                  is_same_v<PrismLhsNode, pm_constant_or_write_node> ||
-                  is_same_v<PrismLhsNode, pm_constant_and_write_node>) {
-        if (isInMethodDef &&
-            !skipDynamicConstantWorkaround) { // Check if this is a dynamic constant assignment (SyntaxError at runtime)
-            // This is a copy of a workaround from `Desugar.cc`, which substitues in a fake assignment,
-            // so the parsing can continue. See other usages of `dynamicConstAssign` for more details.
-
-            // Enter the name of the constant so that it's available for the rest of the pipeline
-            gs.enterNameConstant(name);
-
-            return make_unique<LVarLhs>(location, core::Names::dynamicConstAssign());
-        }
     }
 
     return make_unique<SorbetLHSNode>(location, move(parent), gs.enterNameConstant(name));

--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -87,7 +87,7 @@ private:
     std::unique_ptr<SorbetAssignmentNode> translateOpAssignment(pm_node_t *node);
 
     template <typename PrismLhsNode, typename SorbetLHSNode>
-    std::unique_ptr<parser::Node> translateConst(PrismLhsNode *node, bool skipDynamicConstantWorkaround = false);
+    std::unique_ptr<parser::Node> translateConst(PrismLhsNode *node, bool replaceWithDynamicConstAssign = false);
 
     // Pattern-matching
     // ... variations of the main translation functions for pattern-matching related nodes.

--- a/test/BUILD
+++ b/test/BUILD
@@ -283,7 +283,6 @@ pipeline_tests(
             "testdata/desugar/oror_classvar.rb",
             "testdata/desugar/oror_ivar.rb",
             "testdata/desugar/pattern_matching_hash.rb",
-            "testdata/desugar/range.rb",
             "testdata/desugar/regexp.rb",
             "testdata/desugar/sclass.rb",
         ],

--- a/test/BUILD
+++ b/test/BUILD
@@ -283,7 +283,6 @@ pipeline_tests(
             "testdata/desugar/oror_classvar.rb",
             "testdata/desugar/oror_ivar.rb",
             "testdata/desugar/pattern_matching_hash.rb",
-            "testdata/desugar/regexp.rb",
             "testdata/desugar/sclass.rb",
         ],
     ),

--- a/test/BUILD
+++ b/test/BUILD
@@ -280,8 +280,6 @@ pipeline_tests(
             # Desugar tests having to do with tree differences; will address later
             "testdata/desugar/constant_error.rb",
             "testdata/desugar/for.rb",
-            "testdata/desugar/oror_classvar.rb",
-            "testdata/desugar/oror_ivar.rb",
             "testdata/desugar/pattern_matching_hash.rb",
             "testdata/desugar/sclass.rb",
         ],

--- a/test/prism_regression/range.parse-tree.exp
+++ b/test/prism_regression/range.parse-tree.exp
@@ -1,0 +1,67 @@
+Begin {
+  stmts = [
+    Module {
+      name = Const {
+        scope = NULL
+        name = <C <U T>>
+      }
+      body = Begin {
+        stmts = [
+          Class {
+            name = Const {
+              scope = NULL
+              name = <C <U Bar>>
+            }
+            superclass = NULL
+            body = NULL
+          }
+          Class {
+            name = Const {
+              scope = NULL
+              name = <C <U Foo>>
+            }
+            superclass = NULL
+            body = NULL
+          }
+        ]
+      }
+    }
+    DefMethod {
+      name = <U foo>
+      args = NULL
+      body = Assign {
+        lhs = LVarLhs {
+          name = <U tr1>
+        }
+        rhs = Send {
+          receiver = Const {
+            scope = Const {
+              scope = NULL
+              name = <C <U T>>
+            }
+            name = <C <U Foo>>
+          }
+          method = <U new>
+          args = [
+          ]
+        }
+      }
+    }
+    DefMethod {
+      name = <U bar>
+      args = NULL
+      body = Send {
+        receiver = Const {
+          scope = Const {
+            scope = NULL
+            name = <C <U T>>
+          }
+          name = <C <U Bar>>
+        }
+        method = <U new>
+        args = [
+        ]
+      }
+    }
+  ]
+}

--- a/test/prism_regression/range.rb
+++ b/test/prism_regression/range.rb
@@ -1,0 +1,11 @@
+# typed: false
+
+module T; class Bar; end; class Foo; end; end
+
+def foo
+  tr1 = T::Foo.new
+end
+
+def bar
+  T::Bar.new
+end


### PR DESCRIPTION
Close #363 
Close #364
Close #368 
Close #369

### Motivation

`desguar/range` and `desguar/regex` revealed that we were missing some cases where we needed to do the dynamic constant assignment workaround. In the process of fixing this, Stan and I refactored the `translateConst` method to be a bit more straightforward.

### Test plan
See included automated tests.
