### PR TITLE
Fix bracket method call's location translation

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -310,6 +310,8 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
 
             if (name == "[]=") {
                 messageLoc.endLoc += 2; // The message includes the closing bracket and equals sign
+            } else if (name == "[]") {
+                messageLoc.endLoc = messageLoc.beginLoc;
             } else if (name.back() == '=') {
                 messageLoc.endLoc = args.front()->loc.beginPos() - 1; // The message ends right before the equals sign
             }

--- a/test/prism_regression/call.parse-tree.exp
+++ b/test/prism_regression/call.parse-tree.exp
@@ -12,5 +12,36 @@ Begin {
       args = [
       ]
     }
+    Send {
+      receiver = Send {
+        receiver = NULL
+        method = <U foo>
+        args = [
+        ]
+      }
+      method = <U []>
+      args = [
+        Symbol {
+          val = <U bar>
+        }
+      ]
+    }
+    Send {
+      receiver = Send {
+        receiver = NULL
+        method = <U foo>
+        args = [
+        ]
+      }
+      method = <U []=>
+      args = [
+        Symbol {
+          val = <U baz>
+        }
+        Integer {
+          val = "1"
+        }
+      ]
+    }
   ]
 }

--- a/test/prism_regression/call.rb
+++ b/test/prism_regression/call.rb
@@ -1,4 +1,6 @@
 # typed: false
 
- foo
- foo()
+foo
+foo()
+foo[:bar]
+foo[:baz] = 1


### PR DESCRIPTION
### Motivation

Was peeking into failed tests down the pipeline and found that there are several test failures caused by locations around `[]` method calls. For some reason, Sorbet's parser expects the message location to both begin and end at the position of `[`, instead of `[...]`. This PR matches that behaviour.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
