### PR TITLE
Generate empty Args node for method definitions with empty parentheses

### DIFF
--- a/test/prism_regression/def.parse-tree.exp
+++ b/test/prism_regression/def.parse-tree.exp
@@ -33,5 +33,13 @@ Begin {
         ]
       }
     }
+    DefMethod {
+      name = <U qux>
+      args = Args {
+        args = [
+        ]
+      }
+      body = NULL
+    }
   ]
 }

--- a/test/prism_regression/def.rb
+++ b/test/prism_regression/def.rb
@@ -13,3 +13,5 @@ def baz
   "string2"
   end
 end
+
+def qux(); end


### PR DESCRIPTION
### Motivation

When the method has empty parenthesis, like `def foo(); end`, Sorbet's parser still generates an empty `Args` node instead of `NULL`.

Fixes #383 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
