### PR TITLE
Fix failing local_vars test by translating post params

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1027,6 +1027,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             auto requireds = absl::MakeSpan(paramsNode->requireds.nodes, paramsNode->requireds.size);
             auto optionals = absl::MakeSpan(paramsNode->optionals.nodes, paramsNode->optionals.size);
             auto keywords = absl::MakeSpan(paramsNode->keywords.nodes, paramsNode->keywords.size);
+            auto posts = absl::MakeSpan(paramsNode->posts.nodes, paramsNode->posts.size);
 
             parser::NodeVec params;
 
@@ -1034,7 +1035,8 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             auto kwrestSize = paramsNode->keyword_rest == nullptr ? 0 : 1;
             auto blockSize = paramsNode->block == nullptr ? 0 : 1;
 
-            params.reserve(requireds.size() + optionals.size() + restSize + keywords.size() + kwrestSize + blockSize);
+            params.reserve(requireds.size() + optionals.size() + restSize + posts.size() + keywords.size() +
+                           kwrestSize + blockSize);
 
             translateMultiInto(params, requireds);
             translateMultiInto(params, optionals);
@@ -1042,6 +1044,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             if (paramsNode->rest != nullptr)
                 params.emplace_back(translate(paramsNode->rest));
 
+            translateMultiInto(params, posts);
             translateMultiInto(params, keywords);
 
             if (auto prismKwRestNode = paramsNode->keyword_rest; prismKwRestNode != nullptr) {

--- a/test/BUILD
+++ b/test/BUILD
@@ -292,9 +292,6 @@ pipeline_tests(
             "testdata/rewriter/prop.rb",
             "testdata/rewriter/struct.rb",
 
-            # Failing local_vars tests to investigate
-            "testdata/local_vars/z_super_args_splats_blocks.rb",
-
             # Sorbets' parser incorrectly accepts invalid syntax
             "testdata/desugar/pattern_matching_hash.rb", # See https://github.com/Shopify/sorbet/issues/362
         ],

--- a/test/BUILD
+++ b/test/BUILD
@@ -277,6 +277,7 @@ pipeline_tests(
             "testdata/parser/invalid_fatal.rb",
             "testdata/parser/invalid_syntax_error.rb",
             "testdata/parser/kwargs_missing_comma.rb",
+            "testdata/parser/kwnil_errors.rb", # See https://github.com/Shopify/sorbet/issues/393
             "testdata/parser/misc.rb",
             "testdata/parser/offset0.rb",
             "testdata/parser/ruby_25.rb",

--- a/test/prism_regression/def_rest_params.parse-tree.exp
+++ b/test/prism_regression/def_rest_params.parse-tree.exp
@@ -22,5 +22,22 @@ Begin {
       }
       body = NULL
     }
+    DefMethod {
+      name = <U foo>
+      args = Args {
+        args = [
+          Restarg {
+            name = <U a>
+          }
+          Arg {
+            name = <U b>
+          }
+          Arg {
+            name = <U c>
+          }
+        ]
+      }
+      body = NULL
+    }
   ]
 }

--- a/test/prism_regression/def_rest_params.rb
+++ b/test/prism_regression/def_rest_params.rb
@@ -3,3 +3,6 @@
 def foo(*a); end
 
 def foo(*); end
+
+# Rest with posts
+def foo(*a, b, c); end


### PR DESCRIPTION
Closes #381
Opens #393, having to do with the handling of `**nil` as a post param.

### Motivation
So uh... I think we (*I*) forgot that post params exist 😁 

### Test plan
See included automated tests.
