### PR TITLE
Modify locations of kw arguments and params to match legacy parser

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -242,7 +242,9 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
                 sorbetName = gs.freshNameUnique(core::UniqueNameKind::Parser, core::Names::ampersand(), nextUniqueID());
             }
 
-            return make_unique<parser::Blockarg>(location, sorbetName);
+            auto blockLoc = core::LocOffsets{location.beginPos() + 1, location.endPos()};
+
+            return make_unique<parser::Blockarg>(blockLoc, sorbetName);
         }
         case PM_BLOCK_PARAMETERS_NODE: { // The parameters declared at the top of a PM_BLOCK_NODE
             auto paramsNode = down_cast<pm_block_parameters_node>(node);
@@ -863,7 +865,8 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
                 sorbetName = gs.freshNameUnique(core::UniqueNameKind::Parser, core::Names::starStar(), nextUniqueID());
             }
 
-            return make_unique<parser::Kwrestarg>(location, sorbetName);
+            auto kwrestLoc = core::LocOffsets{location.beginPos() + 2, location.endPos()};
+            return make_unique<parser::Kwrestarg>(kwrestLoc, sorbetName);
         }
         case PM_LAMBDA_NODE: { // lambda literals, like `-> { 123 }`
             auto lambdaNode = down_cast<pm_lambda_node>(node);

--- a/test/BUILD
+++ b/test/BUILD
@@ -299,7 +299,6 @@ pipeline_tests(
             "testdata/namer/alias_cross_file__01.rb",
             "testdata/namer/alias_cross_file__02.rb",
             "testdata/namer/all_constant_redefinitions.rb",
-            "testdata/namer/arguments.rb",
             "testdata/namer/class_alias_inside_method.rb",
             "testdata/namer/class_and_alias.rb",
             "testdata/namer/constant_in_block.rb",

--- a/test/BUILD
+++ b/test/BUILD
@@ -311,11 +311,9 @@ pipeline_tests(
             "testdata/namer/parameter_names.rb",
             "testdata/namer/redefinition_method.rb",
             "testdata/namer/type_alias_inside_method.rb",
-            "testdata/namer/type_alias_not_on_T.rb",
             "testdata/namer/type_alias.rb",
             "testdata/namer/type_member_inside_method.rb",
             "testdata/namer/type_template_inside_method.rb",
-            "testdata/namer/yield.rb",
 
             # Sorbets' parser incorrectly accepts invalid syntax
             "testdata/desugar/pattern_matching_hash.rb", # See https://github.com/Shopify/sorbet/issues/362


### PR DESCRIPTION
Closes #389 

### Motivation
We needed to slightly modify the locations of keyword arguments and params in order to match the behavior of Sorbet's legacy parser. This allows us to run four of the previously-failing namer tests.

### Test plan
See included automated tests.
