### PR TITLE
Handle post `while`/`until` modifiers

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1286,7 +1286,14 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             auto predicate = translate(untilNode->predicate);
             auto body = translate(up_cast(untilNode->statements));
 
-            return make_unique<parser::Until>(location, move(predicate), move(body));
+            auto flags = untilNode->base.flags;
+
+            // When the until loop is placed after a `begin` block, like `begin; end until false`,
+            if (flags & PM_LOOP_FLAGS_BEGIN_MODIFIER) {
+                return make_unique<parser::UntilPost>(location, move(predicate), move(body));
+            } else {
+                return make_unique<parser::Until>(location, move(predicate), move(body));
+            }
         }
         case PM_WHEN_NODE: { // A `when` clause, as part of a `case` statement
             auto whenNode = down_cast<pm_when_node>(node);

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1306,7 +1306,14 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
 
             auto statements = translateStatements(whileNode->statements, inlineIfSingle);
 
-            return make_unique<parser::While>(location, move(predicate), move(statements));
+            auto flags = whileNode->base.flags;
+
+            // When the while loop is placed after a `begin` block, like `begin; end while false`,
+            if (flags & PM_LOOP_FLAGS_BEGIN_MODIFIER) {
+                return make_unique<parser::WhilePost>(location, move(predicate), move(statements));
+            } else {
+                return make_unique<parser::While>(location, move(predicate), move(statements));
+            }
         }
         case PM_X_STRING_NODE: { // An interpolated x-string, like `/usr/bin/env ls`
             auto strNode = down_cast<pm_x_string_node>(node);

--- a/test/prism_regression/until.parse-tree.exp
+++ b/test/prism_regression/until.parse-tree.exp
@@ -1,7 +1,78 @@
-Until {
-  cond = True {
-  }
-  body = String {
-    val = <U body>
-  }
+Begin {
+  stmts = [
+    Until {
+      cond = True {
+      }
+      body = String {
+        val = <U body>
+      }
+    }
+    Until {
+      cond = True {
+      }
+      body = NULL
+    }
+    UntilPost {
+      cond = False {
+      }
+      body = Kwbegin {
+        stmts = [
+          Send {
+            receiver = NULL
+            method = <U puts>
+            args = [
+              Integer {
+                val = "4"
+              }
+            ]
+          }
+        ]
+      }
+    }
+    Until {
+      cond = False {
+      }
+      body = Assign {
+        lhs = LVarLhs {
+          name = <U x>
+        }
+        rhs = Kwbegin {
+          stmts = [
+            Send {
+              receiver = NULL
+              method = <U puts>
+              args = [
+                Integer {
+                  val = "5"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+    Until {
+      cond = False {
+      }
+      body = Send {
+        receiver = NULL
+        method = <U foo>
+        args = [
+          Kwbegin {
+            stmts = [
+              Send {
+                receiver = NULL
+                method = <U puts>
+                args = [
+                  Integer {
+                    val = "6"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/test/prism_regression/until.rb
+++ b/test/prism_regression/until.rb
@@ -3,3 +3,25 @@
 until true
   "body"
 end
+
+# empty
+until true
+end
+
+# When the until loop is placed after a `begin` block, it should be a UntilPost.
+begin
+  puts 4
+end until false
+
+# If the begin block is assigned, the until loop should NOT be a UntilPost.
+x = begin
+  puts 5
+end until false
+
+# Below is the same as:
+# ```rb
+# foo(begin; puts 5; end) until false
+# ```
+foo begin
+  puts 6
+end until false

--- a/test/prism_regression/while.parse-tree.exp
+++ b/test/prism_regression/while.parse-tree.exp
@@ -49,5 +49,67 @@ Begin {
         ]
       }
     }
+    WhilePost {
+      cond = False {
+      }
+      body = Kwbegin {
+        stmts = [
+          Send {
+            receiver = NULL
+            method = <U puts>
+            args = [
+              Integer {
+                val = "4"
+              }
+            ]
+          }
+        ]
+      }
+    }
+    While {
+      cond = False {
+      }
+      body = Assign {
+        lhs = LVarLhs {
+          name = <U x>
+        }
+        rhs = Kwbegin {
+          stmts = [
+            Send {
+              receiver = NULL
+              method = <U puts>
+              args = [
+                Integer {
+                  val = "5"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+    While {
+      cond = False {
+      }
+      body = Send {
+        receiver = NULL
+        method = <U foo>
+        args = [
+          Kwbegin {
+            stmts = [
+              Send {
+                receiver = NULL
+                method = <U puts>
+                args = [
+                  Integer {
+                    val = "6"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
   ]
 }

--- a/test/prism_regression/while.rb
+++ b/test/prism_regression/while.rb
@@ -13,3 +13,21 @@ while true
   x = 3 + 2
   puts "hi"
 end
+
+# When the while loop is placed after a `begin` block, it should be a WhilePost.
+begin
+  puts 4
+end while false
+
+# If the begin block is assigned, the while loop should NOT be a WhilePost.
+x = begin
+  puts 5
+end while false
+
+# Below is the same as:
+# ```rb
+# foo(begin; puts 5; end) while false
+# ```
+foo begin
+  puts 6
+end while false


### PR DESCRIPTION
### Motivation

The current translation does not handle cases like:

```rb
begin
  puts "foo"
end while false # or end until false
```

In such cases, Sorbet's parser creates `WhilePost` and `UntilPost` nodes instead.

Closes #385


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
