### PR TITLE
Correctly translate no-message calls' message locations

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -285,10 +285,18 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             auto callNode = down_cast<pm_call_node>(node);
 
             auto loc = location;
-            auto messageLoc = translateLoc(callNode->message_loc);
 
             auto name = parser.resolveConstant(callNode->name);
             auto receiver = translate(callNode->receiver);
+
+            core::LocOffsets messageLoc;
+
+            // When the message is empty, like `foo.()`, the message location is the same as the call operator location
+            if (callNode->message_loc.start == nullptr && callNode->message_loc.end == nullptr) {
+                messageLoc = translateLoc(callNode->call_operator_loc);
+            } else {
+                messageLoc = translateLoc(callNode->message_loc);
+            }
 
             // Handle `~[Integer]`, like `~42`
             // Unlike `-[Integer]`, Prism treats `~[Integer]` as a method call

--- a/test/BUILD
+++ b/test/BUILD
@@ -271,9 +271,11 @@ pipeline_tests(
             "testdata/local_vars/**/*.exp",
             "testdata/namer/**/*.rb",
             "testdata/namer/**/*.exp",
+            "testdata/lsp/**/*.rb",
+            "testdata/lsp/**/*.exp",
         ],
         exclude = [
-            # Parser tests having to do with tree differences in invalid Ruby code; will address later
+            # Tests having to do with tree differences in invalid Ruby code; will address later
             "testdata/parser/error_recovery/**",
             "testdata/parser/crash_block_pass_suggestion.rb",
             "testdata/parser/invalid_fatal.rb",
@@ -283,6 +285,14 @@ pipeline_tests(
             "testdata/parser/misc.rb",
             "testdata/parser/offset0.rb",
             "testdata/parser/ruby_25.rb",
+            "testdata/lsp/completion/bad_arguments.rb",
+            "testdata/lsp/completion/bad_list_elems.rb",
+            "testdata/lsp/completion/case_1.rb",
+            "testdata/lsp/completion/case_2.rb",
+            "testdata/lsp/completion/eof.rb",
+            "testdata/lsp/completion/missing_const_name.rb",
+            "testdata/lsp/completion/missing_fun.rb",
+            "testdata/lsp/completion/self_receiver.rb",
 
             # Desugar tests having to do with tree differences; will address later
             "testdata/desugar/constant_error.rb",

--- a/test/prism_regression/call.parse-tree.exp
+++ b/test/prism_regression/call.parse-tree.exp
@@ -19,6 +19,17 @@ Begin {
         args = [
         ]
       }
+      method = <U call>
+      args = [
+      ]
+    }
+    Send {
+      receiver = Send {
+        receiver = NULL
+        method = <U foo>
+        args = [
+        ]
+      }
       method = <U []>
       args = [
         Symbol {

--- a/test/prism_regression/call.rb
+++ b/test/prism_regression/call.rb
@@ -2,5 +2,6 @@
 
 foo
 foo()
+foo.()
 foo[:bar]
 foo[:baz] = 1


### PR DESCRIPTION
### Motivation

Fixes #394

In cases like `foo.()`, the message would be `:call`, but the message location would have null start and end. In this case, we need to fall back to use the call operator location.

With #394 fixed, Prism is now passing all non-error-recovery LSP tests too. So in this PR I also add LSP tests into Prism Corpus tests.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
