### PR TITLE
Correctly translate constant write nodes' location

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1893,6 +1893,14 @@ unique_ptr<parser::Node> Translator::translateConst(PrismLhsNode *node, bool rep
             is_same_v<PrismLhsNode, pm_constant_operator_write_node> ||
             is_same_v<PrismLhsNode, pm_constant_target_node> || is_same_v<PrismLhsNode, pm_constant_read_node> ||
             is_same_v<PrismLhsNode, pm_constant_write_node>);
+
+        // For writes, location should only include the name, like `FOO` in `FOO = 1`.
+        if constexpr (is_same_v<PrismLhsNode, pm_constant_and_write_node> ||
+                      is_same_v<PrismLhsNode, pm_constant_or_write_node> ||
+                      is_same_v<PrismLhsNode, pm_constant_operator_write_node> ||
+                      is_same_v<PrismLhsNode, pm_constant_write_node>) {
+            location = translateLoc(node->name_loc);
+        }
         parent = nullptr;
     }
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -295,8 +295,6 @@ pipeline_tests(
             "testdata/lsp/completion/self_receiver.rb",
 
             # Desugar tests having to do with tree differences; will address later
-            "testdata/desugar/constant_error.rb",
-            "testdata/desugar/for.rb",
             "testdata/desugar/sclass.rb",
 
             # Rewriter tests having to do with symbol table differences; will address later
@@ -306,17 +304,8 @@ pipeline_tests(
             "testdata/rewriter/struct.rb",
 
             # Failing namer tests to investigate
-            "testdata/namer/alias_cross_file__01.rb",
-            "testdata/namer/alias_cross_file__02.rb",
-            "testdata/namer/all_constant_redefinitions.rb",
             "testdata/namer/class_alias_inside_method.rb",
-            "testdata/namer/class_and_alias.rb",
-            "testdata/namer/constant_in_block.rb",
-            "testdata/namer/constant_types.rb",
-            "testdata/namer/constants.rb",
-            "testdata/namer/fuzz_class_in_field.rb",
             "testdata/namer/fuzz_repeated_kwarg.rb",
-            "testdata/namer/fuzz_type_template_overwrite.rb",
             "testdata/namer/module_function.rb",
             "testdata/namer/parameter_names.rb",
             "testdata/namer/redefinition_method.rb",


### PR DESCRIPTION
### Motivation

This is not covered in parse tree location tests, but reflected in symbol table tests: when we write `FOO = 1` (or other constant write nodes), the location of `FOO` should just be the name, not the entire assignment.

In those cases, we should use `name_loc` instead of `base.location`.

Fixes #342, #391, and some items in #388

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
