### PR TITLE
Fix symbol location for hash, keyword argument keys

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -293,26 +293,7 @@ pipeline_tests(
             "testdata/lsp/completion/missing_const_name.rb",
             "testdata/lsp/completion/missing_fun.rb",
             "testdata/lsp/completion/self_receiver.rb",
-
-            # Desugar tests having to do with tree differences; will address later
-            "testdata/desugar/sclass.rb",
-
-            # Rewriter tests having to do with symbol table differences; will address later
-            "testdata/rewriter/attr_multi.rb",
-            "testdata/rewriter/attr.rb",
-            "testdata/rewriter/prop.rb",
-            "testdata/rewriter/struct.rb",
-
-            # Failing namer tests to investigate
-            "testdata/namer/class_alias_inside_method.rb",
             "testdata/namer/fuzz_repeated_kwarg.rb",
-            "testdata/namer/module_function.rb",
-            "testdata/namer/parameter_names.rb",
-            "testdata/namer/redefinition_method.rb",
-            "testdata/namer/type_alias_inside_method.rb",
-            "testdata/namer/type_alias.rb",
-            "testdata/namer/type_member_inside_method.rb",
-            "testdata/namer/type_template_inside_method.rb",
 
             # Sorbets' parser incorrectly accepts invalid syntax
             "testdata/desugar/pattern_matching_hash.rb", # See https://github.com/Shopify/sorbet/issues/362

--- a/test/BUILD
+++ b/test/BUILD
@@ -261,18 +261,8 @@ pipeline_tests(
         [
             # Replace [parser] with other phases to test Prism at that level
             # Phases: https://github.com/Shopify/sorbet/blob/prism/docs/internals.md#phases
-            "testdata/parser/**/*.rb",
-            "testdata/parser/**/*.exp",
-            "testdata/desugar/**/*.rb",
-            "testdata/desugar/**/*.exp",
-            "testdata/rewriter/**/*.rb",
-            "testdata/rewriter/**/*.exp",
-            "testdata/local_vars/**/*.rb",
-            "testdata/local_vars/**/*.exp",
-            "testdata/namer/**/*.rb",
-            "testdata/namer/**/*.exp",
-            "testdata/lsp/**/*.rb",
-            "testdata/lsp/**/*.exp",
+            "testdata/**/*.rb",
+            "testdata/**/*.exp",
         ],
         exclude = [
             # Tests having to do with tree differences in invalid Ruby code; will address later
@@ -294,6 +284,7 @@ pipeline_tests(
             "testdata/lsp/completion/missing_fun.rb",
             "testdata/lsp/completion/self_receiver.rb",
             "testdata/namer/fuzz_repeated_kwarg.rb",
+            "testdata/deviations/keyword_method_names.rb",
 
             # Sorbets' parser incorrectly accepts invalid syntax
             "testdata/desugar/pattern_matching_hash.rb", # See https://github.com/Shopify/sorbet/issues/362


### PR DESCRIPTION
### Motivation

When the symbol is used as `a: 1`, the location should not include the colon.

Closes #388
Closes #378
Closes #377
Closes #374
Closes #371
Closes #367

I also found that after this PR, we can run and pass ALL non-error-related Sorbet tests 😄 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
