### PR TITLE
Always raise in unreachable code

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -11,17 +11,10 @@ using std::unique_ptr;
 namespace sorbet::parser::Prism {
 
 // Indicates that a particular code path should never be reached, with an explanation of why.
-// Throws a `sorbet::SorbetException` in debug mode, and is undefined behaviour otherwise.
+// Throws a `sorbet::SorbetException` when triggered to help with debugging.
 template <typename... TArgs>
 [[noreturn]] void unreachable(fmt::format_string<TArgs...> reason_format_str, TArgs &&...args) {
-    if constexpr (sorbet::debug_mode) {
-        Exception::raise(reason_format_str, std::forward<TArgs>(args)...);
-    } else {
-        // Basically a backport of C++23's `std::unreachable()`:
-        // > `ABSL_UNREACHABLE()` is an unreachable statement.  A program which reaches
-        // > one has undefined behavior, and the compiler may optimize accordingly.
-        ABSL_UNREACHABLE();
-    }
+    Exception::raise(reason_format_str, std::forward<TArgs>(args)...);
 }
 
 template <typename PrismAssignmentNode, typename SorbetLHSNode>


### PR DESCRIPTION
### Motivation

Given that some problem may only be found when running a release build against a large codebase, raising in unreachable code makes sure we spot the issues at its source instead of crashing later downstream.

Example: https://github.com/sorbet/sorbet/pull/8485/files#r1943210573

(I'm addressing the erroring issue in a separate PR)


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
