### PR TITLE
Avoid translating implicit rest nodes in parameters

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1037,8 +1037,11 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             translateMultiInto(params, requireds);
             translateMultiInto(params, optionals);
 
-            if (paramsNode->rest != nullptr)
-                params.emplace_back(translate(paramsNode->rest));
+            auto prismRestNode = paramsNode->rest;
+            // Implicit rest node in parameters don't need to be translated
+            if (prismRestNode != nullptr && !PM_NODE_TYPE_P(prismRestNode, PM_IMPLICIT_REST_NODE)) {
+                params.emplace_back(translate(prismRestNode));
+            }
 
             translateMultiInto(params, posts);
             translateMultiInto(params, keywords);

--- a/test/prism_regression/call_block_param.parse-tree.exp
+++ b/test/prism_regression/call_block_param.parse-tree.exp
@@ -198,6 +198,25 @@ Begin {
       }
       body = NULL
     }
+    Block {
+      send = Send {
+        receiver = NULL
+        method = <U foo>
+        args = [
+        ]
+      }
+      args = Args {
+        args = [
+          Arg {
+            name = <U bar>
+          }
+          Arg {
+            name = <U baz>
+          }
+        ]
+      }
+      body = NULL
+    }
     Send {
       receiver = NULL
       method = <U foo>

--- a/test/prism_regression/call_block_param.rb
+++ b/test/prism_regression/call_block_param.rb
@@ -30,6 +30,8 @@ end
 
 foo { |bar; baz, qux| }
 
+foo { |bar, baz,| }
+
 foo(&forwarded_block)
 
 foo&.bar {}


### PR DESCRIPTION
### Motivation

Similar to the case in array pattern translation, Sorbet's parser doesn't care about the implicit rest node in parameters either. So the translator should skip its translation.

Addressed the issue mentioned in https://github.com/sorbet/sorbet/pull/8485/files#r1943210573

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
