### PR TITLE
Rename `Prism::Node` to `Prism::ProgramNodeContainer`

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -138,7 +138,7 @@ unique_ptr<parser::Node> runPrismParser(core::GlobalState &gs, core::FileRef fil
     core::UnfreezeNameTable nameTableAccess(gs);
 
     Prism::Parser parser{source};
-    Prism::Node root = parser.parse_root();
+    Prism::ProgramNodeContainer root = parser.parse_root();
 
     if (stopAfterParser) {
         return std::unique_ptr<parser::Node>();

--- a/parser/prism/Parser.cc
+++ b/parser/prism/Parser.cc
@@ -6,9 +6,9 @@ pm_parser_t *Parser::getRawParserPointer() {
     return &storage->parser;
 }
 
-Node Parser::parse_root() {
+ProgramNodeContainer Parser::parse_root() {
     pm_node_t *root = pm_parse(getRawParserPointer());
-    return Node{*this, root};
+    return ProgramNodeContainer{*this, root};
 };
 
 core::LocOffsets Parser::translateLocation(pm_location_t location) {

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1350,8 +1350,8 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
     }
 }
 
-unique_ptr<parser::Node> Translator::translate(const Node &node) {
-    return translate(node.getRawNodePointer());
+unique_ptr<parser::Node> Translator::translate(const ProgramNodeContainer &container) {
+    return translate(container.getRawNodePointer());
 }
 
 core::LocOffsets Translator::translateLoc(pm_location_t loc) {

--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -47,7 +47,7 @@ public:
 
     // Translates the given AST from Prism's node types into the equivalent AST in Sorbet's legacy parser node types.
     std::unique_ptr<parser::Node> translate(pm_node_t *node);
-    std::unique_ptr<parser::Node> translate(const Node &node);
+    std::unique_ptr<parser::Node> translate(const ProgramNodeContainer &container);
 
 private:
     // Private constructor used only for creating child translators


### PR DESCRIPTION
### Motivation

1. Makes it clear that it represents the program node, not nodes in general
2. Makes it easier to distinguish from Sorbet parser's Node class

Addressed https://github.com/sorbet/sorbet/pull/8485#discussion_r1943220198


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
