### PR TITLE
Decouple parser errors with parser

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -138,13 +138,13 @@ unique_ptr<parser::Node> runPrismParser(core::GlobalState &gs, core::FileRef fil
     core::UnfreezeNameTable nameTableAccess(gs);
 
     Prism::Parser parser{source};
-    Prism::ProgramNodeContainer root = parser.parse_root();
+    Prism::ParseResult parseResult = parser.parse_root();
 
     if (stopAfterParser) {
         return std::unique_ptr<parser::Node>();
     }
 
-    auto nodes = Prism::Translator(parser, gs, file).translate(std::move(root));
+    auto nodes = Prism::Translator(parser, gs, file).translate(std::move(parseResult));
 
     if (print.ParseTree.enabled) {
         print.ParseTree.fmt("{}\n", nodes->toStringWithTabs(gs, 0));

--- a/parser/prism/Parser.cc
+++ b/parser/prism/Parser.cc
@@ -6,9 +6,9 @@ pm_parser_t *Parser::getRawParserPointer() {
     return &storage->parser;
 }
 
-ProgramNodeContainer Parser::parse_root() {
+ParseResult Parser::parse_root() {
     pm_node_t *root = pm_parse(getRawParserPointer());
-    return ProgramNodeContainer{*this, root, collectErrors()};
+    return ParseResult{*this, root, collectErrors()};
 };
 
 core::LocOffsets Parser::translateLocation(pm_location_t location) {

--- a/parser/prism/Parser.h
+++ b/parser/prism/Parser.h
@@ -13,7 +13,7 @@ extern "C" {
 
 namespace sorbet::parser::Prism {
 
-class ProgramNodeContainer;
+class ParseResult;
 
 class ParseError {
 public:
@@ -51,7 +51,7 @@ struct ParserStorage {
 };
 
 class Parser final {
-    friend class ProgramNodeContainer;
+    friend class ParseResult;
     friend struct NodeDeleter;
 
     std::shared_ptr<ParserStorage> storage;
@@ -62,7 +62,7 @@ public:
     Parser(const Parser &) = default;
     Parser &operator=(const Parser &) = default;
 
-    ProgramNodeContainer parse_root();
+    ParseResult parse_root();
     core::LocOffsets translateLocation(pm_location_t location);
     std::string_view resolveConstant(pm_constant_id_t constant_id);
     std::string_view extractString(pm_string_t *string);
@@ -72,9 +72,7 @@ private:
     pm_parser_t *getRawParserPointer();
 };
 
-// This class holds a pointer to the parser and a pointer to the root node of Prism's AST
-// It's main purpose is to provide a way to clean up the AST nodes
-class ProgramNodeContainer final {
+class ParseResult final {
     struct NodeDeleter {
         Parser parser;
 
@@ -90,11 +88,11 @@ class ProgramNodeContainer final {
     std::unique_ptr<pm_node_t, NodeDeleter> node;
     std::vector<ParseError> parseErrors;
 
-    ProgramNodeContainer(Parser parser, pm_node_t *node, std::vector<ParseError> parseErrors)
+    ParseResult(Parser parser, pm_node_t *node, std::vector<ParseError> parseErrors)
         : parser{parser}, node{node, NodeDeleter{parser}}, parseErrors{parseErrors} {}
 
-    ProgramNodeContainer(const ProgramNodeContainer &) = delete;            // Copy constructor
-    ProgramNodeContainer &operator=(const ProgramNodeContainer &) = delete; // Copy assignment
+    ParseResult(const ParseResult &) = delete;            // Copy constructor
+    ParseResult &operator=(const ParseResult &) = delete; // Copy assignment
 
     pm_node_t *getRawNodePointer() const {
         return node.get();

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1350,9 +1350,9 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
     }
 }
 
-unique_ptr<parser::Node> Translator::translate(const ProgramNodeContainer &container) {
-    this->parseErrors = container.parseErrors;
-    return translate(container.getRawNodePointer());
+unique_ptr<parser::Node> Translator::translate(const ParseResult &parseResult) {
+    this->parseErrors = parseResult.parseErrors;
+    return translate(parseResult.getRawNodePointer());
 }
 
 core::LocOffsets Translator::translateLoc(pm_location_t loc) {

--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -50,7 +50,7 @@ public:
 
     // Translates the given AST from Prism's node types into the equivalent AST in Sorbet's legacy parser node types.
     std::unique_ptr<parser::Node> translate(pm_node_t *node);
-    std::unique_ptr<parser::Node> translate(const ProgramNodeContainer &container);
+    std::unique_ptr<parser::Node> translate(const ParseResult &parseResult);
 
 private:
     // Private constructor used only for creating child translators


### PR DESCRIPTION
### Motivation

Addresses https://github.com/sorbet/sorbet/pull/8485#discussion_r1943256670
Closes #420

- Instead of accessing parse errors through parser, we should store the parse errors directly in the translator
- We can do it by storing the parse errors in the return value of `parse_root`
- But in that case, the data will not just be a container of the program node but a general container of the parse result. So we should rename its class name to reflect that


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
