### PR TITLE
Fix RBS signatures in send nodes like `prepend`

### DIFF
--- a/rbs/SigsRewriter.cc
+++ b/rbs/SigsRewriter.cc
@@ -528,6 +528,12 @@ unique_ptr<parser::Node> SigsRewriter::rewriteNode(unique_ptr<parser::Node> node
             when->body = rewriteBody(move(when->body));
             result = move(node);
         },
+        [&](parser::Send *send) {
+            if (!parser::MK::isVisibilitySend(send)) {
+                send->args = rewriteNodes(move(send->args));
+            }
+            result = move(node);
+        },
         [&](parser::Node *other) { result = move(node); });
 
     return result;

--- a/test/testdata/rbs/signatures_defs.rb
+++ b/test/testdata/rbs/signatures_defs.rb
@@ -249,6 +249,15 @@ def method24(x)
   end
 end
 
+# Test prepending modules with signatures
+
+Integer.prepend(Module.new do
+  #: (Integer) -> void
+  def bar(x)
+    T.reveal_type(x) # error: Revealed type: `Integer`
+  end
+end)
+
 class UnusedTypeAnnotation
   class Inner
     def foo; end # error: The method `foo` does not have a `sig`

--- a/test/testdata/rbs/signatures_defs.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_defs.rb.rewrite-tree.exp
@@ -327,6 +327,14 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(x)
   end
 
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+    <self>.params(:x, <emptyTree>::<C Integer>).void()
+  end
+
+  def bar<<todo method>>(x, &<blk>)
+    <emptyTree>::<C T>.reveal_type(x)
+  end
+
   <self>.extend(<emptyTree>::<C T>::<C Sig>)
 
   class <emptyTree>::<C P1><<C <todo sym>>> < (::<todo sym>)
@@ -484,6 +492,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <runtime method definition of method23>
 
   <runtime method definition of method24>
+
+  <emptyTree>::<C Integer>.prepend(<emptyTree>::<C Module>.new() do ||
+      <runtime method definition of bar>
+    end)
 
   class <emptyTree>::<C UnusedTypeAnnotation><<C <todo sym>>> < (::<todo sym>)
     def foo<<todo method>>(&<blk>)


### PR DESCRIPTION
## Fix RBS signature recognition in send node contexts

Ticket: https://github.com/Shopify/team-ruby-dx/issues/1451

### Solution
**SigsRewriter changes:**
- Added logic to rewrite arguments in non-visibility send nodes
- This enables the rewriter to traverse into send node arguments and process any method definitions found there
- Specifically skip visibility modifier sends (like `private def method_name`) to prevent double-processing, since those method definitions are already handled directly by the main AST traversal

### Example
```ruby
# typed: strict

class A; end

A.prepend(Module.new do
  #: -> void
  def foo; end  # Now properly recognizes the RBS signature
end)
```
