### PR TITLE
Sorbet support deprecated keyword.

### DIFF
--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -435,16 +435,14 @@ template <class To> bool isa_instruction(const InstructionPtr &what) {
 }
 
 template <class To> core::UntaggedPtr<To> cast_instruction(InstructionPtr &what) {
-    static_assert(!std::is_pointer<To>::value, "To has to be a pointer");
-    static_assert(std::is_assignable<Instruction *&, To *>::value,
-                  "Ill Formed To, has to be a subclass of Instruction");
+    static_assert(!std::is_pointer_v<To>, "To has to be a pointer");
+    static_assert(std::is_assignable_v<Instruction *&, To *>, "Ill Formed To, has to be a subclass of Instruction");
     return what.as_instruction<To>();
 }
 
 template <class To> core::UntaggedPtr<const To> cast_instruction(const InstructionPtr &what) {
-    static_assert(!std::is_pointer<To>::value, "To has to be a pointer");
-    static_assert(std::is_assignable<Instruction *&, To *>::value,
-                  "Ill Formed To, has to be a subclass of Instruction");
+    static_assert(!std::is_pointer_v<To>, "To has to be a pointer");
+    static_assert(std::is_assignable_v<Instruction *&, To *>, "Ill Formed To, has to be a subclass of Instruction");
     return what.as_instruction<To>();
 }
 

--- a/common/common.h
+++ b/common/common.h
@@ -106,8 +106,8 @@ template <typename ToCheck, std::size_t ExpectedAlign, std::size_t RealAlign = a
     }
 
 template <class From, class To> To *fast_cast(From *what) {
-    constexpr bool isFinal = std::is_final<To>::value;
-    if (std::is_same<From, To>::value) {
+    constexpr bool isFinal = std::is_final_v<To>;
+    if (std::is_same_v<From, To>) {
         return static_cast<To *>(what);
     }
     if (what == nullptr) {

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1375,6 +1375,9 @@ string MethodRef::toStringWithOptions(const GlobalState &gs, int tabs, bool show
     if (sym->flags.isIncompatibleOverride) {
         methodFlags.emplace_back("allow_incompatible");
     }
+    if (sym->flags.isDeprecated) {
+        methodFlags.emplace_back("deprecated");
+    }
     if (sym->flags.isFinal) {
         methodFlags.emplace_back("final");
     }

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -79,13 +79,14 @@ public:
         bool isOverride : 1;
         bool isIncompatibleOverride : 1;
         bool isPackagePrivate : 1;
+        bool isDeprecated : 1;
 
-        constexpr static uint16_t NUMBER_OF_FLAGS = 11;
+        constexpr static uint16_t NUMBER_OF_FLAGS = 12;
         constexpr static uint16_t VALID_BITS_MASK = (1 << NUMBER_OF_FLAGS) - 1;
         Flags() noexcept
             : isRewriterSynthesized(false), isProtected(false), isPrivate(false), isOverloaded(false),
               isAbstract(false), isGenericMethod(false), isOverridable(false), isFinal(false), isOverride(false),
-              isIncompatibleOverride(false), isPackagePrivate(false) {}
+              isIncompatibleOverride(false), isPackagePrivate(false), isDeprecated(false) {}
 
         uint16_t serialize() const {
             static_assert(sizeof(Flags) == sizeof(uint16_t));

--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -376,9 +376,9 @@ TypePtr TypePtr::_instantiate(const GlobalState &gs, absl::Span<const TypeMember
 void TypePtr::_sanityCheck(const GlobalState &gs) const {
     // Not really a dynamic check, but this is a convenient place to put this to
     // ensure that all relevant types get checked.
-#define SANITY_CHECK(T)                                                                        \
-    static_assert(TypePtr::TypeToIsInlined<T>::value || !std::is_copy_constructible<T>::value, \
-                  "non-inline types must not be copy-constructible");                          \
+#define SANITY_CHECK(T)                                                                   \
+    static_assert(TypePtr::TypeToIsInlined<T>::value || !std::is_copy_constructible_v<T>, \
+                  "non-inline types must not be copy-constructible");                     \
     break;
     GENERATE_TAG_SWITCH(tag(), SANITY_CHECK)
 #undef SANITY_CHECK

--- a/core/errors/infer.h
+++ b/core/errors/infer.h
@@ -55,6 +55,7 @@ constexpr ErrorClass UnknownSuperMethod{7048, StrictLevel::True};
 constexpr ErrorClass TypecheckOverloadBody{7049, StrictLevel::True};
 constexpr ErrorClass RedundantMust{7050, StrictLevel::Strict};
 constexpr ErrorClass BranchOnVoid{7051, StrictLevel::True};
+constexpr ErrorClass DeprecatedMethodUsage{7052, StrictLevel::True};
 // N.B infer does not run for untyped call at all. StrictLevel::False here would be meaningless
 
 ErrorClass errorClassForUntyped(const GlobalState &gs, FileRef file, const TypePtr &ptr);

--- a/core/errors/resolver.h
+++ b/core/errors/resolver.h
@@ -85,6 +85,7 @@ constexpr ErrorClass TNilableArity{5076, StrictLevel::False};
 constexpr ErrorClass UnsupportedLiteralType{5077, StrictLevel::False};
 constexpr ErrorClass GenericArgumentCountMismatch{5078, StrictLevel::True};
 constexpr ErrorClass GenericArgumentKeywordArgs{5079, StrictLevel::False};
+constexpr ErrorClass OverrideMustBeDeprecated{5080, StrictLevel::True};
 } // namespace sorbet::core::errors::Resolver
 
 #endif

--- a/core/source_generator/source_generator.cc
+++ b/core/source_generator/source_generator.cc
@@ -48,6 +48,9 @@ string prettySigForMethod(const core::GlobalState &gs, core::MethodRef method, c
     if (sym->flags.isFinal) {
         sigCall = "sig(:final)";
     }
+	if (sym->flags.isDeprecated) {
+		flags.emplace_back("deprecated");
+	}
     if (sym->flags.isAbstract && options.concretizeIfAbstract) {
         flags.emplace_back("override");
     } else if (sym->flags.isAbstract) {

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -581,6 +581,9 @@ NameDef names[] = {
     {"Account", "Account", true},
     {"Merchant", "Merchant", true},
 
+    // RBS
+    {"RBSBind", "<RBSBind>", true},
+
     // RBS synthetic generics
     {"syntheticSquareBrackets", "<syntheticSquareBrackets>"},
 

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -113,6 +113,7 @@ NameDef names[] = {
     {"abstract"},
     {"implementation"},
     {"override_", "override"},
+    {"deprecated"},
     {"overridable"},
     {"allowIncompatible", "allow_incompatible"},
     {"sigForMethod"},

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -938,6 +938,13 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
         }
     }
 
+    if (methodData->flags.isDeprecated && !args.suppressErrors) {
+        if (auto e = gs.beginError(args.errLoc(), core::errors::Infer::DeprecatedMethodUsage)) {
+			e.setHeader("Method `{}` is deprecated", method.show(gs));
+            e.addErrorLine(methodData->loc(), "Defined in `{}` here", methodData->owner.show(gs));
+        }
+    }
+
     DispatchResult result;
     auto &component = result.main;
     component.receiver = args.selfType;

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -1139,7 +1139,7 @@ void compareToUntyped(const GlobalState &gs, TypeConstraint &constr, const TypeP
 template <class T>
 bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &constr, UntypedMode mode, const TypePtr &t1,
                                     const TypePtr &t2, T &errorDetailsCollector) {
-    constexpr auto shouldAddErrorDetails = std::is_same<T, ErrorSection::Collector>::value;
+    constexpr auto shouldAddErrorDetails = std::is_same_v<T, ErrorSection::Collector>;
 
     ENFORCE(t1 != nullptr);
     ENFORCE(t2 != nullptr);
@@ -1558,7 +1558,7 @@ bool Types::isSubType(const GlobalState &gs, const TypePtr &t1, const TypePtr &t
 template <class T>
 bool Types::isSubTypeUnderConstraint(const GlobalState &gs, TypeConstraint &constr, const TypePtr &t1,
                                      const TypePtr &t2, UntypedMode mode, T &errorDetailsCollector) {
-    constexpr auto shouldAddErrorDetails = std::is_same<T, ErrorSection::Collector>::value;
+    constexpr auto shouldAddErrorDetails = std::is_same_v<T, ErrorSection::Collector>;
 
     if (t1 == t2) {
         return true;
@@ -1725,7 +1725,7 @@ bool Types::equivUnderConstraint(const GlobalState &gs, TypeConstraint &constr, 
 
     auto subCollector = errorDetailsCollector.newCollector();
     auto rightSubLeft = isSubTypeUnderConstraint(gs, constr, t2, t1, mode, subCollector);
-    if constexpr (std::is_same<T, ErrorSection::Collector>::value) {
+    if constexpr (std::is_same_v<T, ErrorSection::Collector>) {
         if (!rightSubLeft) {
             auto message = ErrorColors::format(
                 "`{}` is a subtype of `{}` but not the reverse, so they are not equivalent", t1.show(gs), t2.show(gs));

--- a/main/autogen/data/msgpack.cc
+++ b/main/autogen/data/msgpack.cc
@@ -208,8 +208,7 @@ string MsgpackWriterFull::pack(core::Context ctx, ParsedFile &pf, const AutogenC
 
         // requires
         {
-            MsgpackArray
-                requires(&writer, pf.requireStatements.size());
+            MsgpackArray requires_(&writer, pf.requireStatements.size());
             for (auto nm : pf.requireStatements) {
                 packString(&writer, nm.show(ctx));
             }

--- a/main/lsp/ErrorReporter.cc
+++ b/main/lsp/ErrorReporter.cc
@@ -150,13 +150,19 @@ void ErrorReporter::pushDiagnostics(uint32_t epoch, core::FileRef file, const ve
 
         auto diagnostic = make_unique<Diagnostic>(std::move(range), error->header);
         diagnostic->code = error->what.code;
+        
         if (error->what.code == sorbet::core::errors::Infer::DeadBranchInferencer.code) {
             vector<DiagnosticTag> tags;
             tags.push_back(DiagnosticTag::Unnecessary);
             diagnostic->tags = move(tags);
         }
-
-        diagnostic->severity = DiagnosticSeverity::Error;
+		diagnostic->severity = DiagnosticSeverity::Error;
+        if (error->what.code == sorbet::core::errors::Infer::DeprecatedMethodUsage.code) {
+            vector<DiagnosticTag> tags;
+            tags.push_back(DiagnosticTag::Deprecated);
+            diagnostic->tags = move(tags);
+            diagnostic->severity = DiagnosticSeverity::Warning;
+        }
         if (error->what == sorbet::core::errors::Infer::UntypedValueInformation) {
             diagnostic->severity = DiagnosticSeverity::Information;
         }

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -1061,6 +1061,10 @@ CompletionTask::getCompletionItemForMethod(LSPTypecheckerDelegate &typechecker, 
     if (documentation != nullopt && documentation->find("@deprecated") != documentation->npos) {
         item->deprecated = true;
     }
+    
+    if (what.data(gs)->flags.isDeprecated) {
+        item->deprecated = true;
+    }
 
     return item;
 }

--- a/main/lsp/requests/implementation.cc
+++ b/main/lsp/requests/implementation.cc
@@ -75,11 +75,12 @@ unique_ptr<ResponseMessage> ImplementationTask::runRequest(LSPTypecheckerDelegat
         return response;
     }
 
+    vector<unique_ptr<Location>> result;
     if (queryResult.responses.empty()) {
+        response->result = std::move(result);
         return response;
     }
 
-    vector<unique_ptr<Location>> result;
     auto queryResponse = move(queryResult.responses[0]);
     if (auto def = queryResponse->isMethodDef()) {
         // User called "Go to Implementation" from the abstract function definition

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -1206,6 +1206,10 @@ public:
                 // Label key is a symbol `sym: val`
                 return match_var_hash(label->loc, key->val.show(gs_));
             } else if (auto *key = parser::cast_node<DSymbol>(pair->key.get())) {
+                if (key->nodes.empty()) {
+                    error_without_recovery(ruby_parser::dclass::InvalidKey, key->loc);
+                    return error_node(key->loc.beginPos(), key->loc.endPos());
+                }
                 // Label key is a quoted string `"sym": val`
                 return match_var_hash_from_str(std::move(key->nodes));
             }
@@ -1276,6 +1280,8 @@ public:
     }
 
     unique_ptr<Node> match_var_hash_from_str(sorbet::parser::NodeVec strings) {
+        ENFORCE(!strings.empty());
+
         auto loc = collectionLoc(strings);
         if (strings.size() > 1) {
             error_without_recovery(ruby_parser::dclass::PatternInterpInVarName, loc);

--- a/parser/helper.h
+++ b/parser/helper.h
@@ -215,6 +215,13 @@ public:
     /* T methods */
 
     /*
+     * Create a `T.absurd()` send node.
+     */
+    static std::unique_ptr<parser::Node> TAbsurd(core::LocOffsets loc, std::unique_ptr<parser::Node> node) {
+        return Send1(loc, T(loc), core::Names::absurd(), loc, move(node));
+    }
+
+    /*
      * Create a `T.all(args...)` send node.
      */
     static std::unique_ptr<parser::Node> TAll(core::LocOffsets loc, parser::NodeVec args) {

--- a/parser/helper.h
+++ b/parser/helper.h
@@ -249,6 +249,10 @@ public:
         return Send0(loc, T(loc), core::Names::attachedClass(), loc);
     }
 
+    static std::unique_ptr<parser::Node> TBindSelf(core::LocOffsets loc, std::unique_ptr<parser::Node> type) {
+        return Send2(loc, T(loc), core::Names::bind(), loc, MK::Self(loc), move(type));
+    }
+
     /*
      * Create a `T.cast(value, type)` send node.
      */

--- a/parser/parser/codegen/generate_diagnostics.cc
+++ b/parser/parser/codegen/generate_diagnostics.cc
@@ -78,6 +78,7 @@ tuple<string, string> MESSAGES[] = {
     {"NoAnonymousBlockArg", "no anonymous block parameter"},
     {"NoAnonymousRestArg", "no anonymous rest parameter"},
     {"NoAnonymousKwrestArg", "no anonymous keyword rest parameter"},
+    {"InvalidKey", "key must be valid as local variables"},
 
     // Error recovery hints
     {"DedentedEnd", "Hint: this {} token might not be properly closed"},

--- a/parser/parser/include/ruby_parser/builder.hh
+++ b/parser/parser/include/ruby_parser/builder.hh
@@ -197,7 +197,7 @@ struct builder {
     ForeignPtr (*xstring_compose)(SelfPtr builder, const token *begin, const node_list *parts, const token *end);
 };
 
-static_assert(std::is_pod<builder>::value, "`builder` must be a POD type");
+static_assert(std::is_pod_v<builder>, "`builder` must be a POD type");
 
 } // namespace ruby_parser
 

--- a/parser/tools/generate_ast.cc
+++ b/parser/tools/generate_ast.cc
@@ -621,6 +621,12 @@ NodeDef nodes[] = {
         "rational",
         vector<FieldDef>({{"val", FieldType::String}}),
     },
+    // RBS placeholder for a bind comment
+    {
+        "RBSPlaceholder",
+        "rbs_placeholder",
+        vector<FieldDef>({{"kind", FieldType::Name}}),
+    },
     // `redo` keyword
     {
         "Redo",

--- a/rbi/sorbet/builder.rbi
+++ b/rbi/sorbet/builder.rbi
@@ -18,6 +18,9 @@ class T::Private::Methods::DeclBuilder
   sig {returns(T::Private::Methods::DeclBuilder)}
   def overridable; end
 
+  sig {returns(T::Private::Methods::DeclBuilder)}
+  def deprecated; end
+
   sig {params(klass: T.untyped).returns(T::Private::Methods::DeclBuilder)}
   def bind(klass); end
 

--- a/rbi/stdlib/bundler.rbi
+++ b/rbi/stdlib/bundler.rbi
@@ -190,6 +190,9 @@ module Bundler
   sig {returns(T.untyped)}
   def self.original_env(); end
 
+  sig { params(args: T.untyped).returns(T.nilable(T::Boolean)) }
+  def self.original_system(*args); end
+
   sig do
     params(
       file: T.untyped,

--- a/rbi/stdlib/cgi.rbi
+++ b/rbi/stdlib/cgi.rbi
@@ -1263,6 +1263,35 @@ module CGI::Util
     .returns(::T.untyped)
   end
   def unescape_html(_); end
+
+  # URL-encode a string following RFC 3986 Space characters (+“ ”+) are encoded with (+“%20”+)
+  #
+  # ```ruby
+  # url_encoded_string = CGI.escape("'Stop!' said Fred")
+  #    # => "%27Stop%21%27%20said%20Fred"
+  # ```
+  sig do
+    params(
+      string: ::T.untyped
+    )
+    .returns(::String)
+  end
+  def escapeURIComponent(string); end
+
+  # URL-decode a string following RFC 3986 with encoding(optional).
+  #
+  # ```ruby
+  # string = CGI.unescape("%27Stop%21%27+said%20Fred")
+  #    # => "'Stop!'+said Fred"
+  # ```
+  sig do
+    params(
+      string: ::T.untyped,
+      encoding: ::T.untyped
+    )
+    .returns(::String)
+  end
+  def unescapeURIComponent(string, encoding = T.unsafe(nil)); end
 end
 
 module CGI::Escape

--- a/rbi/stdlib/date.rbi
+++ b/rbi/stdlib/date.rbi
@@ -488,9 +488,6 @@ class Date
   sig {returns(T::Boolean)}
   def saturday?(); end
 
-  sig {returns(T::Boolean)}
-  def blank?(); end
-
   # This method is equivalent to step(min, -1){|date| ...}.
   sig {params(arg0: T.untyped).returns(T.untyped)}
   def downto(arg0); end

--- a/rbi/stdlib/date_time.rbi
+++ b/rbi/stdlib/date_time.rbi
@@ -520,9 +520,6 @@ class DateTime < Date
   sig {returns(DateTime)}
   def to_datetime(); end
 
-  sig {returns(T.untyped)}
-  def blank?(); end
-
   sig do
     params(
       locale: T.untyped,

--- a/rbs/AssertionsRewriter.cc
+++ b/rbs/AssertionsRewriter.cc
@@ -195,6 +195,10 @@ optional<rbs::InlineComment> AssertionsRewriter::commentForNode(const unique_ptr
             }
         } else if (regex_match(content.begin(), content.end(), absurd_pattern)) {
             kind = InlineComment::Kind::ABSURD;
+        } else if (absl::StartsWith(content, "self as ")) {
+            kind = InlineComment::Kind::BIND;
+            contentStart += 8;
+            content = content.substr(8);
         }
 
         if (hasConsumedComment(commentNode.loc)) {
@@ -271,6 +275,11 @@ AssertionsRewriter::insertCast(unique_ptr<parser::Node> node,
         return parser::MK::TUnsafe(type->loc, move(node));
     } else if (kind == InlineComment::Kind::ABSURD) {
         return parser::MK::TAbsurd(type->loc, move(node));
+    } else if (kind == InlineComment::Kind::BIND) {
+        if (auto e = ctx.beginIndexerError(type->loc, core::errors::Rewriter::RBSUnsupported)) {
+            e.setHeader("`{}` binding can't be used as a trailing comment", "self");
+        }
+        return node;
     } else {
         Exception::raise("Unknown assertion kind");
     }
@@ -292,6 +301,36 @@ unique_ptr<parser::Node> AssertionsRewriter::maybeInsertCast(unique_ptr<parser::
     }
 
     return node;
+}
+
+/**
+ * Replace the synthetic node with a `T.bind` call.
+ */
+unique_ptr<parser::Node> AssertionsRewriter::replaceSyntheticBind(unique_ptr<parser::Node> node) {
+    auto inlineComment = commentForNode(node);
+
+    if (!inlineComment) {
+        // This should never happen
+        Exception::raise("No inline comment found for synthetic bind");
+    }
+
+    auto pair = parseComment(ctx, inlineComment.value(), typeParams);
+
+    if (!pair) {
+        // We already raised an error while parsing the comment, so we just bind to `T.untyped`
+        return parser::MK::TBindSelf(node->loc, parser::MK::TUntyped(node->loc));
+    }
+
+    auto kind = pair->second;
+
+    if (kind != InlineComment::Kind::BIND) {
+        // This should never happen
+        Exception::raise("Invalid inline comment for synthetic bind");
+    }
+
+    auto type = move(pair->first);
+
+    return parser::MK::TBindSelf(type->loc, move(type));
 }
 
 /**
@@ -626,6 +665,7 @@ unique_ptr<parser::Node> AssertionsRewriter::rewriteNode(unique_ptr<parser::Node
             result = move(node);
         },
         [&](parser::Ensure *ensure) {
+            ensure->ensure = rewriteBody(move(ensure->ensure));
             ensure->body = rewriteBody(move(ensure->body));
             result = move(node);
         },
@@ -695,6 +735,14 @@ unique_ptr<parser::Node> AssertionsRewriter::rewriteNode(unique_ptr<parser::Node
         [&](parser::Kwsplat *splat) {
             splat->expr = rewriteNode(move(splat->expr));
             result = move(node);
+        },
+
+        [&](parser::RBSPlaceholder *placeholder) {
+            if (placeholder->kind == core::Names::Constants::RBSBind()) {
+                result = replaceSyntheticBind(move(node));
+            } else {
+                Exception::raise("Unknown RBS placeholder kind");
+            }
         },
 
         [&](parser::Node *other) { result = maybeInsertCast(move(node)); });

--- a/rbs/AssertionsRewriter.h
+++ b/rbs/AssertionsRewriter.h
@@ -10,8 +10,9 @@ namespace sorbet::rbs {
 
 struct InlineComment {
     enum class Kind {
-        LET,
+        ABSURD,
         CAST,
+        LET,
         MUST,
         UNSAFE,
     };

--- a/rbs/AssertionsRewriter.h
+++ b/rbs/AssertionsRewriter.h
@@ -11,6 +11,7 @@ namespace sorbet::rbs {
 struct InlineComment {
     enum class Kind {
         ABSURD,
+        BIND,
         CAST,
         LET,
         MUST,
@@ -45,6 +46,7 @@ private:
 
     bool saveTypeParams(parser::Block *block);
     std::unique_ptr<parser::Node> maybeInsertCast(std::unique_ptr<parser::Node> node);
+    std::unique_ptr<parser::Node> replaceSyntheticBind(std::unique_ptr<parser::Node> node);
     std::unique_ptr<parser::Node>
     insertCast(std::unique_ptr<parser::Node> node,
                std::optional<std::pair<std::unique_ptr<parser::Node>, InlineComment::Kind>> pair);

--- a/rbs/CommentsAssociator.cc
+++ b/rbs/CommentsAssociator.cc
@@ -512,7 +512,10 @@ void CommentsAssociator::walkNodes(parser::Node *node) {
         },
         [&](parser::When *when) {
             walkNodes(when->body.get());
-            consumeCommentsInsideNode(node, "when");
+
+            if (auto body = when->body.get()) {
+                consumeCommentsInsideNode(body, "when");
+            }
         },
         [&](parser::While *while_) {
             associateAssertionCommentsToNode(node);

--- a/rbs/CommentsAssociator.cc
+++ b/rbs/CommentsAssociator.cc
@@ -326,10 +326,21 @@ void CommentsAssociator::walkNodes(parser::Node *node) {
             consumeCommentsInsideNode(node, "hash");
         },
         [&](parser::If *if_) {
-            associateAssertionCommentsToNode(node);
+            auto beginLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.beginPos()).line;
+            auto endLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.endPos()).line;
+
+            if (beginLine == endLine) {
+                associateAssertionCommentsToNode(node);
+            }
+
             walkNodes(if_->condition.get());
             walkNodes(if_->then_.get());
             walkNodes(if_->else_.get());
+
+            if (beginLine != endLine) {
+                associateAssertionCommentsToNode(node);
+            }
+
             consumeCommentsInsideNode(node, "if");
         },
         [&](parser::InPattern *inPattern) {

--- a/rbs/CommentsAssociator.cc
+++ b/rbs/CommentsAssociator.cc
@@ -15,6 +15,7 @@ namespace sorbet::rbs {
 const string_view CommentsAssociator::RBS_PREFIX = "#:";
 const string_view CommentsAssociator::ANNOTATION_PREFIX = "# @";
 const string_view CommentsAssociator::MULTILINE_RBS_PREFIX = "#|";
+const string_view CommentsAssociator::BIND_PREFIX = "#: self as ";
 
 // Static regex pattern to avoid recompilation
 static const regex HEREDOC_PATTERN("\\s*=?\\s*<<(-|~)[^,\\s\\n#]+(,\\s*<<(-|~)[^,\\s\\n#]+)*");
@@ -177,7 +178,123 @@ void CommentsAssociator::associateSignatureCommentsToNode(parser::Node *node) {
     commentsByNode[node] = move(comments);
 }
 
-void CommentsAssociator::walkNodes(parser::Node *node) {
+int CommentsAssociator::maybeInsertStandalonePlaceholders(parser::NodeVec &nodes, int index, int lastLine,
+                                                          int currentLine) {
+    if (lastLine == currentLine) {
+        return 0;
+    }
+
+    auto inserted = 0;
+
+    // We look for all comments between lastLine and currentLine
+    for (auto it = commentByLine.begin(); it != commentByLine.end();) {
+        if (it->first <= lastLine) {
+            it++;
+            continue;
+        }
+
+        if (it->first >= currentLine) {
+            break;
+        }
+
+        if (absl::StartsWith(it->second.string, BIND_PREFIX)) {
+            auto placeholder = make_unique<parser::RBSPlaceholder>(it->second.loc, core::Names::Constants::RBSBind());
+
+            vector<CommentNode> comments;
+            comments.emplace_back(it->second);
+            it = commentByLine.erase(it);
+            commentsByNode[placeholder.get()] = move(comments);
+
+            nodes.insert(nodes.begin() + index, move(placeholder));
+
+            inserted++;
+            continue;
+        }
+
+        it++;
+    }
+
+    return inserted;
+}
+
+unique_ptr<parser::Node> CommentsAssociator::walkBody(parser::Node *node, unique_ptr<parser::Node> body) {
+    if (body == nullptr) {
+        return nullptr;
+    }
+
+    if (auto *begin = parser::cast_node<parser::Begin>(body.get())) {
+        // The body is already a Begin node, so we don't need any wrapping
+        walkNode(body.get());
+
+        // Visit standalone RBS comments after the last node in the body
+        int endLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.endPos()).line;
+        maybeInsertStandalonePlaceholders(begin->stmts, 0, lastLine, endLine);
+        lastLine = endLine;
+
+        return body;
+    }
+
+    // The body is a single node, we'll need to wrap it if we find standalone RBS comments
+    auto beforeNodes = parser::NodeVec();
+
+    // Visit standalone RBS comments after before the body node
+    auto currentLine = core::Loc::pos2Detail(ctx.file.data(ctx), body->loc.beginPos()).line;
+    maybeInsertStandalonePlaceholders(beforeNodes, 0, lastLine, currentLine);
+    lastLine = currentLine;
+
+    walkNode(body.get());
+
+    // Visit standalone RBS comments after the body node
+    auto afterNodes = parser::NodeVec();
+    int endLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.endPos()).line;
+    maybeInsertStandalonePlaceholders(afterNodes, 0, lastLine, endLine);
+    lastLine = endLine;
+
+    if (!beforeNodes.empty() || !afterNodes.empty()) {
+        auto nodes = parser::NodeVec();
+        for (auto &before : beforeNodes) {
+            nodes.emplace_back(move(before));
+        }
+        auto loc = body->loc;
+        nodes.emplace_back(move(body));
+        for (auto &after : afterNodes) {
+            nodes.emplace_back(move(after));
+        }
+        return make_unique<parser::Begin>(loc, move(nodes));
+    }
+
+    return body;
+}
+
+void CommentsAssociator::walkNodes(parser::NodeVec &nodes) {
+    for (auto &node : nodes) {
+        walkNode(node.get());
+    }
+}
+
+void CommentsAssociator::walkStatements(parser::NodeVec &nodes) {
+    for (int i = 0; i < nodes.size(); i++) {
+        auto *stmt = nodes[i].get();
+
+        if (parser::isa_node<parser::Ensure>(stmt)) {
+            // Ensure need to be visited handled differently because of how we desugar their structure.
+            // The bind needs to be added _inside_ them and not before if we want the type to be applied properly.
+            walkNode(stmt);
+            continue;
+        }
+
+        auto beginLine = core::Loc::pos2Detail(ctx.file.data(ctx), stmt->loc.beginPos()).line;
+
+        auto inserted = maybeInsertStandalonePlaceholders(nodes, i, lastLine, beginLine);
+        i += inserted;
+
+        walkNode(stmt);
+
+        lastLine = core::Loc::pos2Detail(ctx.file.data(ctx), stmt->loc.endPos()).line;
+    }
+}
+
+void CommentsAssociator::walkNode(parser::Node *node) {
     if (node == nullptr) {
         return;
     }
@@ -187,25 +304,23 @@ void CommentsAssociator::walkNodes(parser::Node *node) {
 
         [&](parser::And *and_) {
             associateAssertionCommentsToNode(node);
-            walkNodes(and_->right.get());
-            walkNodes(and_->left.get());
+            walkNode(and_->right.get());
+            walkNode(and_->left.get());
             consumeCommentsInsideNode(node, "and");
         },
         [&](parser::AndAsgn *andAsgn) {
             associateAssertionCommentsToNode(andAsgn->right.get(), true);
-            walkNodes(andAsgn->right.get());
+            walkNode(andAsgn->right.get());
             consumeCommentsInsideNode(node, "and_asgn");
         },
         [&](parser::Array *array) {
             associateAssertionCommentsToNode(node);
-            for (auto &elem : array->elts) {
-                walkNodes(elem.get());
-            }
+            walkNodes(array->elts);
             consumeCommentsInsideNode(node, "array");
         },
         [&](parser::Assign *assign) {
             associateAssertionCommentsToNode(assign->rhs.get(), true);
-            walkNodes(assign->rhs.get());
+            walkNode(assign->rhs.get());
             consumeCommentsInsideNode(node, "assign");
         },
         [&](parser::Begin *begin) {
@@ -221,9 +336,9 @@ void CommentsAssociator::walkNodes(parser::Node *node) {
             if (begin->stmts.size() > 0 && begin->stmts[0]->loc.endPos() + 1 == node->loc.endPos()) {
                 associateAssertionCommentsToNode(node);
             }
-            for (auto &stmt : begin->stmts) {
-                walkNodes(stmt.get());
-            }
+
+            walkStatements(begin->stmts);
+            lastLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.endPos()).line;
             consumeCommentsInsideNode(node, "begin");
         },
         [&](parser::Block *block) {
@@ -231,8 +346,8 @@ void CommentsAssociator::walkNodes(parser::Node *node) {
             consumeCommentsUntilLine(beginLine);
 
             associateAssertionCommentsToNode(node);
-            walkNodes(block->send.get());
-            walkNodes(block->body.get());
+            walkNode(block->send.get());
+            block->body = walkBody(block, move(block->body));
             auto endLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.endPos()).line;
             consumeCommentsBetweenLines(beginLine, endLine, "block");
         },
@@ -247,37 +362,28 @@ void CommentsAssociator::walkNodes(parser::Node *node) {
                 }
             }
 
-            for (auto it = break_->exprs.rbegin(); it != break_->exprs.rend(); ++it) {
-                walkNodes(it->get());
-            }
+            walkNodes(break_->exprs);
             consumeCommentsInsideNode(node, "break");
         },
         [&](parser::Case *case_) {
             associateAssertionCommentsToNode(node);
-            walkNodes(case_->condition.get());
-            for (auto &when : case_->whens) {
-                walkNodes(when.get());
-            }
-            walkNodes(case_->else_.get());
+            walkNode(case_->condition.get());
+            walkNodes(case_->whens);
+            case_->else_ = walkBody(case_, move(case_->else_));
             consumeCommentsInsideNode(node, "case");
         },
         [&](parser::CaseMatch *case_) {
             associateAssertionCommentsToNode(node);
-            walkNodes(case_->expr.get());
-            for (auto &inBody : case_->inBodies) {
-                walkNodes(inBody.get());
-            }
-            walkNodes(case_->elseBody.get());
+            walkNode(case_->expr.get());
+            walkNodes(case_->inBodies);
+            case_->elseBody = walkBody(case_, move(case_->elseBody));
             consumeCommentsInsideNode(node, "case");
         },
         [&](parser::Class *cls) {
             associateSignatureCommentsToNode(node);
             auto beginLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.beginPos()).line;
             consumeCommentsUntilLine(beginLine);
-
-            if (auto body = cls->body.get()) {
-                walkNodes(body);
-            }
+            cls->body = walkBody(cls, move(cls->body));
             auto endLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.endPos()).line;
             consumeCommentsBetweenLines(beginLine, endLine, "class");
         },
@@ -288,41 +394,37 @@ void CommentsAssociator::walkNodes(parser::Node *node) {
                 return;
             }
             associateAssertionCommentsToNode(node);
-            walkNodes(csend->receiver.get());
-            for (auto &arg : csend->args) {
-                walkNodes(arg.get());
-            }
+            walkNode(csend->receiver.get());
+            walkNodes(csend->args);
             consumeCommentsInsideNode(node, "csend");
         },
         [&](parser::DefMethod *def) {
             associateSignatureCommentsToNode(node);
-            walkNodes(def->body.get());
+            def->body = walkBody(def, move(def->body));
             consumeCommentsInsideNode(node, "method");
         },
         [&](parser::DefS *def) {
             associateSignatureCommentsToNode(node);
-            walkNodes(def->body.get());
+            def->body = walkBody(def, move(def->body));
             consumeCommentsInsideNode(node, "method");
         },
         [&](parser::Ensure *ensure) {
-            walkNodes(ensure->body.get());
-            walkNodes(ensure->ensure.get());
+            walkNode(ensure->body.get());
+            ensure->ensure = walkBody(ensure, move(ensure->ensure));
             consumeCommentsInsideNode(node, "ensure");
         },
         [&](parser::For *for_) {
             associateAssertionCommentsToNode(node);
-            walkNodes(for_->expr.get());
-            walkNodes(for_->vars.get());
-            walkNodes(for_->body.get());
+            walkNode(for_->expr.get());
+            walkNode(for_->vars.get());
+            for_->body = walkBody(for_, move(for_->body));
             consumeCommentsInsideNode(node, "for");
         },
         [&](parser::Hash *hash) {
             if (!hash->kwargs) {
                 associateAssertionCommentsToNode(node);
             }
-            for (auto &elem : hash->pairs) {
-                walkNodes(elem.get());
-            }
+            walkNodes(hash->pairs);
             consumeCommentsInsideNode(node, "hash");
         },
         [&](parser::If *if_) {
@@ -333,9 +435,15 @@ void CommentsAssociator::walkNodes(parser::Node *node) {
                 associateAssertionCommentsToNode(node);
             }
 
-            walkNodes(if_->condition.get());
-            walkNodes(if_->then_.get());
-            walkNodes(if_->else_.get());
+            walkNode(if_->condition.get());
+
+            lastLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.beginPos()).line;
+            if_->then_ = walkBody(if_->then_.get(), move(if_->then_));
+
+            if (if_->then_) {
+                lastLine = core::Loc::pos2Detail(ctx.file.data(ctx), if_->then_->loc.endPos()).line;
+            }
+            if_->else_ = walkBody(if_->else_.get(), move(if_->else_));
 
             if (beginLine != endLine) {
                 associateAssertionCommentsToNode(node);
@@ -344,35 +452,31 @@ void CommentsAssociator::walkNodes(parser::Node *node) {
             consumeCommentsInsideNode(node, "if");
         },
         [&](parser::InPattern *inPattern) {
-            walkNodes(inPattern->pattern.get());
-            walkNodes(inPattern->guard.get());
-            walkNodes(inPattern->body.get());
+            walkNode(inPattern->pattern.get());
+            walkNode(inPattern->guard.get());
+            inPattern->body = walkBody(inPattern, move(inPattern->body));
             consumeCommentsInsideNode(node, "in_pattern");
         },
         [&](parser::Kwsplat *kwsplat) {
-            walkNodes(kwsplat->expr.get());
+            walkNode(kwsplat->expr.get());
             consumeCommentsInsideNode(node, "kwsplat");
         },
         [&](parser::Kwbegin *kwbegin) {
             associateAssertionCommentsToNode(node);
-            for (auto &stmt : kwbegin->stmts) {
-                walkNodes(stmt.get());
-            }
+            walkStatements(kwbegin->stmts);
+            lastLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.endPos()).line;
             consumeCommentsInsideNode(node, "begin");
         },
         [&](parser::Masgn *masgn) {
             associateAssertionCommentsToNode(masgn->rhs.get(), true);
-            walkNodes(masgn->rhs.get());
+            walkNode(masgn->rhs.get());
             consumeCommentsInsideNode(node, "masgn");
         },
         [&](parser::Module *mod) {
             associateSignatureCommentsToNode(node);
             auto beginLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.beginPos()).line;
             consumeCommentsUntilLine(beginLine);
-
-            if (auto body = mod->body.get()) {
-                walkNodes(body);
-            }
+            mod->body = walkBody(mod, move(mod->body));
             auto endLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.endPos()).line;
             consumeCommentsBetweenLines(beginLine, endLine, "module");
         },
@@ -386,34 +490,32 @@ void CommentsAssociator::walkNodes(parser::Node *node) {
                 }
             }
 
-            for (auto &expr : next->exprs) {
-                walkNodes(expr.get());
-            }
+            walkNodes(next->exprs);
             consumeCommentsInsideNode(node, "next");
         },
         [&](parser::OpAsgn *opAsgn) {
             associateAssertionCommentsToNode(opAsgn->right.get(), true);
-            walkNodes(opAsgn->right.get());
+            walkNode(opAsgn->right.get());
             consumeCommentsInsideNode(node, "op_asgn");
         },
         [&](parser::Or *or_) {
             associateAssertionCommentsToNode(node);
-            walkNodes(or_->right.get());
-            walkNodes(or_->left.get());
+            walkNode(or_->right.get());
+            walkNode(or_->left.get());
             consumeCommentsInsideNode(node, "or");
         },
         [&](parser::OrAsgn *orAsgn) {
             associateAssertionCommentsToNode(orAsgn->right.get(), true);
-            walkNodes(orAsgn->right.get());
+            walkNode(orAsgn->right.get());
             consumeCommentsInsideNode(node, "or_asgn");
         },
         [&](parser::Pair *pair) {
-            walkNodes(pair->value.get());
-            walkNodes(pair->key.get());
+            walkNode(pair->value.get());
+            walkNode(pair->key.get());
             consumeCommentsInsideNode(node, "pair");
         },
         [&](parser::Resbody *resbody) {
-            walkNodes(resbody->body.get());
+            resbody->body = walkBody(resbody, move(resbody->body));
             consumeCommentsInsideNode(node, "rescue");
         },
         [&](parser::Rescue *rescue) {
@@ -422,18 +524,15 @@ void CommentsAssociator::walkNodes(parser::Node *node) {
 
             if (beginLine == endLine) {
                 // Single line rescue that may have an assertion comment so we need to start from the else node
-                walkNodes(rescue->else_.get());
-                for (auto &rescued : rescue->rescue) {
-                    walkNodes(rescued.get());
-                }
-                walkNodes(rescue->body.get());
+                rescue->else_ = walkBody(rescue, move(rescue->else_));
+                walkNodes(rescue->rescue);
+                rescue->body = walkBody(rescue, move(rescue->body));
             } else {
-                walkNodes(rescue->body.get());
-                for (auto &rescued : rescue->rescue) {
-                    walkNodes(rescued.get());
-                }
-                walkNodes(rescue->else_.get());
+                rescue->body = walkBody(rescue->body.get(), move(rescue->body));
+                walkNodes(rescue->rescue);
+                rescue->else_ = walkBody(rescue, move(rescue->else_));
             }
+
             consumeCommentsBetweenLines(beginLine, endLine, "rescue");
         },
         [&](parser::Return *ret) {
@@ -446,19 +545,14 @@ void CommentsAssociator::walkNodes(parser::Node *node) {
                 }
             }
 
-            for (auto &expr : ret->exprs) {
-                walkNodes(expr.get());
-            }
+            walkNodes(ret->exprs);
             consumeCommentsInsideNode(node, "return");
         },
         [&](parser::SClass *sclass) {
             associateSignatureCommentsToNode(node);
             auto beginLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.beginPos()).line;
             consumeCommentsUntilLine(beginLine);
-
-            if (auto body = sclass->body.get()) {
-                walkNodes(body);
-            }
+            sclass->body = walkBody(sclass, move(sclass->body));
             auto endLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.endPos()).line;
             consumeCommentsBetweenLines(beginLine, endLine, "sclass");
         },
@@ -476,42 +570,39 @@ void CommentsAssociator::walkNodes(parser::Node *node) {
             } else {
                 if (send->method == core::Names::squareBracketsEq()) {
                     // This is a `foo[key]=(y)` method, walk y for chained method calls
-                    walkNodes(send->args.back().get());
-                    walkNodes(send->receiver.get());
+                    walkNode(send->args.back().get());
+                    walkNode(send->receiver.get());
                     return;
                 } else if (send->method.isSetter(ctx.state) && send->args.size() == 1) {
                     // This is a `foo.x=(y)` method, we treat it as a `x = y` assignment
                     associateAssertionCommentsToNode(send->args[0].get());
-                    walkNodes(send->receiver.get());
+                    walkNode(send->receiver.get());
                     return;
                 }
                 associateAssertionCommentsToNode(send);
 
-                walkNodes(send->receiver.get());
-
-                for (auto &arg : send->args) {
-                    walkNodes(arg.get());
-                }
+                walkNode(send->receiver.get());
+                walkNodes(send->args);
                 consumeCommentsInsideNode(node, "send");
             }
         },
         [&](parser::Splat *splat) {
-            walkNodes(splat->var.get());
+            walkNode(splat->var.get());
             consumeCommentsInsideNode(node, "splat");
         },
         [&](parser::Until *until) {
             associateAssertionCommentsToNode(node);
-            walkNodes(until->cond.get());
-            walkNodes(until->body.get());
+            walkNode(until->cond.get());
+            until->body = walkBody(until, move(until->body));
             consumeCommentsInsideNode(node, "until");
         },
         [&](parser::UntilPost *untilPost) {
-            walkNodes(untilPost->cond.get());
-            walkNodes(untilPost->body.get());
+            walkNode(untilPost->cond.get());
+            untilPost->body = walkBody(untilPost, move(untilPost->body));
             consumeCommentsInsideNode(node, "until");
         },
         [&](parser::When *when) {
-            walkNodes(when->body.get());
+            when->body = walkBody(when, move(when->body));
 
             if (auto body = when->body.get()) {
                 consumeCommentsInsideNode(body, "when");
@@ -519,13 +610,13 @@ void CommentsAssociator::walkNodes(parser::Node *node) {
         },
         [&](parser::While *while_) {
             associateAssertionCommentsToNode(node);
-            walkNodes(while_->cond.get());
-            walkNodes(while_->body.get());
+            walkNode(while_->cond.get());
+            while_->body = walkBody(while_, move(while_->body));
             consumeCommentsInsideNode(node, "while");
         },
         [&](parser::WhilePost *whilePost) {
-            walkNodes(whilePost->cond.get());
-            walkNodes(whilePost->body.get());
+            walkNode(whilePost->cond.get());
+            whilePost->body = walkBody(whilePost, move(whilePost->body));
             consumeCommentsInsideNode(node, "while");
         },
         [&](parser::Node *other) {
@@ -546,7 +637,8 @@ map<parser::Node *, vector<CommentNode>> CommentsAssociator::run(unique_ptr<pars
         }
     }
 
-    walkNodes(node.get());
+    lastLine = 0;
+    walkNode(node.get());
 
     // Check for any remaining comments
     for (const auto &[line, comment] : commentByLine) {

--- a/rbs/CommentsAssociator.h
+++ b/rbs/CommentsAssociator.h
@@ -23,19 +23,26 @@ public:
 private:
     static const std::string_view ANNOTATION_PREFIX;
     static const std::string_view MULTILINE_RBS_PREFIX;
+    static const std::string_view BIND_PREFIX;
 
     core::MutableContext ctx;
     std::vector<core::LocOffsets> commentLocations;
     std::map<int, CommentNode> commentByLine;
     std::map<parser::Node *, std::vector<CommentNode>> commentsByNode;
+    int lastLine;
 
-    void walkNodes(parser::Node *node);
+    void walkNode(parser::Node *node);
+    void walkNodes(parser::NodeVec &nodes);
+    void walkStatements(parser::NodeVec &nodes);
+    std::unique_ptr<parser::Node> walkBody(parser::Node *node, std::unique_ptr<parser::Node> body);
     void associateAssertionCommentsToNode(parser::Node *node, bool adjustLocForHeredoc);
     void associateSignatureCommentsToNode(parser::Node *node);
     void consumeCommentsInsideNode(parser::Node *node, std::string kind);
     void consumeCommentsBetweenLines(int startLine, int endLine, std::string kind);
     void consumeCommentsUntilLine(int line);
     std::optional<uint32_t> locateTargetLine(parser::Node *node);
+
+    int maybeInsertStandalonePlaceholders(parser::NodeVec &nodes, int index, int lastLine, int currentLine);
 };
 
 } // namespace sorbet::rbs

--- a/rbs/MethodTypeToParserNode.cc
+++ b/rbs/MethodTypeToParserNode.cc
@@ -65,6 +65,9 @@ unique_ptr<parser::Node> handleAnnotations(unique_ptr<parser::Node> sigBuilder, 
         } else if (annotation.string == "override") {
             sigBuilder =
                 parser::MK::Send0(annotation.typeLoc, move(sigBuilder), core::Names::override_(), annotation.typeLoc);
+        } else if (annotation.string == "deprecated") {
+            sigBuilder =
+                parser::MK::Send0(annotation.typeLoc, move(sigBuilder), core::Names::deprecated(), annotation.typeLoc);
         } else if (annotation.string == "override(allow_incompatible: true)") {
             auto pairs = parser::NodeVec();
             auto key = parser::MK::Symbol(annotation.typeLoc, core::Names::allowIncompatible());

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3777,8 +3777,6 @@ public:
                     e.setHeader("Abstract methods must not contain any code in their body");
                     e.replaceWith("Delete the body", ctx.locAt(mdef.rhs.loc()), "");
                 }
-
-                mdef.rhs = ast::MK::EmptyTree();
             }
             if (!mdef.symbol.enclosingClass(ctx).data(ctx)->flags.isAbstract) {
                 if (auto e = ctx.beginError(mdef.loc, core::errors::Resolver::AbstractMethodOutsideAbstract)) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3327,31 +3327,6 @@ private:
             method.data(ctx)->flags.isFinal = true;
         }
         
-        // Inherit deprecated flag from parent methods if this method overrides and isn't explicitly deprecated
-        if (sig.seen.override_ && !sig.seen.deprecated_) {
-            auto owner = method.data(ctx)->owner;
-            auto name = method.data(ctx)->name;
-            
-            // Check superclass
-            if (owner.data(ctx)->superClass().exists()) {
-                auto parentMethod = owner.data(ctx)->superClass().data(ctx)->findMethodTransitive(ctx, name);
-                if (parentMethod.exists() && parentMethod != method && parentMethod.data(ctx)->flags.isDeprecated) {
-                    sig.seen.deprecated_ = true;
-                    method.data(ctx)->flags.isDeprecated = true;
-                }
-            }
-            
-            // Check mixins if not already inherited
-			for (const auto &mixin : owner.data(ctx)->mixins()) {
-				auto mixinMethod = mixin.data(ctx)->findMethod(ctx, name);
-				if (mixinMethod.exists() && mixinMethod != method && mixinMethod.data(ctx)->flags.isDeprecated) {
-					sig.seen.deprecated_ = true;
-					method.data(ctx)->flags.isDeprecated = true;
-					break;
-				}
-            }
-        }
-        
         if (sig.seen.bind) {
             if (sig.bind == core::Symbols::MagicBindToAttachedClass()) {
                 if (auto e = ctx.beginError(exprLoc, core::errors::Resolver::BindNonBlockParameter)) {

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -1045,7 +1045,7 @@ TypeSyntax::ResultType reportUnknownTypeSyntaxError(core::Context ctx, const ast
                                                     TypeSyntax::ResultType &&result) {
     if (auto e = ctx.beginError(s.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
         auto klass = sendLooksLikeBadTypeApplication(ctx, s);
-        if (klass.exists()) {
+        if (klass.exists() && s.hasPosArgs()) {
             auto scope =
                 s.recv.isSelfReference() ? "" : fmt::format("{}::", ctx.locAt(s.recv.loc()).source(ctx).value());
             auto replacement =

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -483,6 +483,9 @@ optional<ParsedSig> parseSigWithSelfTypeParams(core::Context ctx, const ast::Sen
                 }
                 sig.seen.overridable = true;
                 break;
+            case core::Names::deprecated().rawId():
+                sig.seen.deprecated_ = true;
+                break;
             case core::Names::returns().rawId(): {
                 sig.seen.returns = true;
                 if (send->hasKwArgs()) {

--- a/resolver/type_syntax/type_syntax.h
+++ b/resolver/type_syntax/type_syntax.h
@@ -49,6 +49,7 @@ struct ParsedSig {
         bool params = false;
         bool abstract = false;
         bool override_ = false;
+        bool deprecated_ = false;
         bool overridable = false;
         bool returns = false;
         bool void_ = false;

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -355,15 +355,13 @@ ast::ExpressionPtr prepareTestEachBody(core::MutableContext ctx, core::NameRef e
         }
 
         for (auto &exp : bodySeq->stats) {
-            exp = runUnderEach(ctx, eachName, absl::MakeSpan(destructuringStmts), std::move(exp), args, iteratee,
-                               insideDescribe);
+            exp = runUnderEach(ctx, eachName, destructuringStmts, std::move(exp), args, iteratee, insideDescribe);
         }
 
-        bodySeq->expr = runUnderEach(ctx, eachName, absl::MakeSpan(destructuringStmts), std::move(bodySeq->expr), args,
-                                     iteratee, insideDescribe);
+        bodySeq->expr =
+            runUnderEach(ctx, eachName, destructuringStmts, std::move(bodySeq->expr), args, iteratee, insideDescribe);
     } else {
-        body = runUnderEach(ctx, eachName, absl::MakeSpan(destructuringStmts), std::move(body), args, iteratee,
-                            insideDescribe);
+        body = runUnderEach(ctx, eachName, destructuringStmts, std::move(body), args, iteratee, insideDescribe);
     }
 
     return body;

--- a/test/helpers/lsp.cc
+++ b/test/helpers/lsp.cc
@@ -177,6 +177,13 @@ unique_ptr<LSPMessage> makeDefinitionRequest(int id, string_view uri, int line, 
                                                 make_unique<Position>(line, character))));
 }
 
+unique_ptr<LSPMessage> makeImplementationRequest(int id, string_view uri, int line, int character) {
+    return make_unique<LSPMessage>(
+        make_unique<RequestMessage>("2.0", id, LSPMethod::TextDocumentImplementation,
+                                    make_unique<ImplementationParams>(make_unique<TextDocumentIdentifier>(string(uri)),
+                                                                      make_unique<Position>(line, character))));
+}
+
 unique_ptr<LSPMessage> makeReferenceRequest(int id, string_view uri, int line, int character, bool includeDecl) {
     return make_unique<LSPMessage>(
         make_unique<RequestMessage>("2.0", id, LSPMethod::TextDocumentReferences,

--- a/test/helpers/lsp.h
+++ b/test/helpers/lsp.h
@@ -22,6 +22,9 @@ makeInitializeParams(std::optional<std::variant<std::string, JSONNullObject>> ro
 /** Create an LSPMessage containing a textDocument/definition request. */
 std::unique_ptr<LSPMessage> makeDefinitionRequest(int id, std::string_view uri, int line, int character);
 
+/** Create an LSPMessage containing a textDocument/implementation request. */
+std::unique_ptr<LSPMessage> makeImplementationRequest(int id, std::string_view uri, int line, int character);
+
 /** Create an LSPMessage containing a textDocument/hover request. */
 std::unique_ptr<LSPMessage> makeHover(int id, std::string_view uri, int line, int character);
 

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -68,22 +68,34 @@ void reportMissingError(const string &filename, const T &assertion, string_view 
 
 void reportUnexpectedError(const string &filename, const Diagnostic &diagnostic, string_view sourceLine,
                            string_view errorPrefix) {
-    auto diagnosticMessage = (diagnostic.severity == DiagnosticSeverity::Information)
-                                 ? fmt::format("untyped: {}", diagnostic.message)
-                                 : fmt::format("error: {}", diagnostic.message);
-    ADD_FAIL_CHECK_AT(
-        filename.c_str(), diagnostic.range->start->line + 1,
-        fmt::format(
-            "{}Found unexpected error:\n{}\nNote: If there is already an assertion for this error, then this is a "
-            "duplicate error. Change the assertion to `# error-with-dupes: <error message>` if the duplicate is "
-            "expected.",
-            errorPrefix, prettyPrintRangeComment(sourceLine, *diagnostic.range, diagnosticMessage)));
+    std::string messageType;
+	if (diagnostic.severity == DiagnosticSeverity::Error) {
+		messageType = "error";
+	} else if (diagnostic.severity == DiagnosticSeverity::Warning) {
+		messageType = "warning";
+	} else if (diagnostic.severity == DiagnosticSeverity::Information) {
+		messageType = "untyped";
+	} else if (diagnostic.severity == DiagnosticSeverity::Hint) {
+		messageType = "hint";
+	} else {
+		messageType = "unknown";
+	}
+
+	std::string diagnosticMessage = fmt::format("{}: {}", messageType, diagnostic.message);
+
+	ADD_FAIL_CHECK_AT(
+		filename.c_str(), diagnostic.range->start->line + 1,
+		fmt::format(
+			"{}Found unexpected error:\n{}\nNote: If there is already an assertion for this error, then this is a "
+			"duplicate error. Change the assertion to `# error-with-dupes: <error message>` if the duplicate is "
+			"expected.",
+			errorPrefix, prettyPrintRangeComment(sourceLine, *diagnostic.range, diagnosticMessage)));
 }
 string getSourceLine(const UnorderedMap<string, shared_ptr<core::File>> &sourceFileContents, const string &filename,
-                     int line) {
-    if (absl::StartsWith(filename, core::File::URL_PREFIX)) {
-        return "";
-    }
+					 int line) {
+	if (absl::StartsWith(filename, core::File::URL_PREFIX)) {
+		return "";
+	}
 
     auto it = sourceFileContents.find(filename);
     if (it == sourceFileContents.end()) {
@@ -242,6 +254,7 @@ const UnorderedMap<
         {"untyped", UntypedAssertion::make},
         {"error", ErrorAssertion::make},
         {"error-with-dupes", ErrorAssertion::make},
+        {"warning", WarningAssertion::make},
         {"usage", UsageAssertion::make},
         {"import", ImportAssertion::make},
         {"importusage", ImportUsageAssertion::make},
@@ -478,6 +491,12 @@ shared_ptr<ErrorAssertion> ErrorAssertion::make(string_view filename, unique_ptr
                                        assertionType == "error-with-dupes");
 }
 
+shared_ptr<WarningAssertion> WarningAssertion::make(string_view filename, unique_ptr<Range> &range, int assertionLine,
+                                                   string_view assertionContents, string_view assertionType) {
+    return make_shared<WarningAssertion>(filename, range, assertionLine, assertionContents,
+                                        assertionType == "warning-with-dupes");
+}
+
 string ErrorAssertion::toString() const {
     return fmt::format("{}: {}", (matchesDuplicateErrors ? "error-with-dupes" : "error"), message);
 }
@@ -493,6 +512,35 @@ bool ErrorAssertion::check(const Diagnostic &diagnostic, string_view sourceLine,
         return false;
     }
     return true;
+}
+
+WarningAssertion::WarningAssertion(string_view filename, unique_ptr<Range> &range, int assertionLine,
+                                 string_view message, bool matchesDuplicateWarnings)
+    : RangeAssertion(filename, range, assertionLine), message(message), matchesDuplicateErrors(matchesDuplicateWarnings) {
+}
+
+string WarningAssertion::toString() const {
+    return fmt::format("{}: {}", (matchesDuplicateErrors ? "warning-with-dupes" : "warning"), message);
+}
+
+bool WarningAssertion::check(const Diagnostic &diagnostic, string_view sourceLine, string_view errorPrefix) {
+    // The warning message must contain `message`.
+    if (diagnostic.message.find(message) == string::npos) {
+        ADD_FAIL_CHECK_AT(filename.c_str(), range->start->line + 1,
+                          fmt::format("{}Expected warning of form:\n{}\nFound warning:\n{}", errorPrefix,
+                                      prettyPrintRangeComment(sourceLine, *range, toString()),
+                                      prettyPrintRangeComment(sourceLine, *diagnostic.range,
+                                                              fmt::format("warning: {}", diagnostic.message))));
+        return false;
+    }
+    return true;
+}
+
+bool WarningAssertion::checkAll(const UnorderedMap<string, shared_ptr<core::File>> &files,
+                               vector<shared_ptr<WarningAssertion>> warningAssertions,
+                               map<string, vector<unique_ptr<Diagnostic>>> &filenamesAndDiagnostics,
+                               string warningPrefix) {
+    return checkAllInner<WarningAssertion>(files, warningAssertions, filenamesAndDiagnostics, warningPrefix);
 }
 
 UntypedAssertion::UntypedAssertion(string_view filename, unique_ptr<Range> &range, int assertionLine,

--- a/test/helpers/position_assertions.h
+++ b/test/helpers/position_assertions.h
@@ -11,6 +11,7 @@ namespace sorbet::test {
 using namespace sorbet::realmain::lsp;
 
 class ErrorAssertion;
+class WarningAssertion;
 class UntypedAssertion;
 
 /**
@@ -94,6 +95,32 @@ public:
 
     ErrorAssertion(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine,
                    std::string_view message, bool matchesDuplicateErrors);
+
+    std::string toString() const override;
+
+    bool check(const Diagnostic &diagnostic, std::string_view sourceLine, std::string_view errorPrefix);
+};
+
+class WarningAssertion final : public RangeAssertion {
+public:
+    static std::shared_ptr<WarningAssertion> make(std::string_view filename, std::unique_ptr<Range> &range,
+                                                int assertionLine, std::string_view assertionContents,
+                                                std::string_view assertionType);
+
+    /**
+     * Given a set of position-based assertions and Sorbet-generated diagnostics, check that the assertions pass.
+     */
+    static bool checkAll(const UnorderedMap<std::string, std::shared_ptr<core::File>> &files,
+                         std::vector<std::shared_ptr<WarningAssertion>> warningAssertions,
+                         std::map<std::string, std::vector<std::unique_ptr<Diagnostic>>> &filenamesAndDiagnostics,
+                         std::string warningPrefix = "");
+
+    const std::string message;
+    const bool matchesDuplicateErrors;  // Template compatibility - same as matchesDuplicateWarnings
+    static constexpr DiagnosticSeverity severity = DiagnosticSeverity::Warning;
+
+    WarningAssertion(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine,
+                   std::string_view message, bool matchesDuplicateWarnings);
 
     std::string toString() const override;
 

--- a/test/lsp/ProtocolTest.cc
+++ b/test/lsp/ProtocolTest.cc
@@ -123,6 +123,10 @@ unique_ptr<LSPMessage> ProtocolTest::getDefinition(string_view path, int line, i
     return makeDefinitionRequest(nextId++, getUri(path), line, character);
 }
 
+unique_ptr<LSPMessage> ProtocolTest::implementation(string_view path, int line, int character) {
+    return makeImplementationRequest(nextId++, getUri(path), line, character);
+}
+
 unique_ptr<LSPMessage> ProtocolTest::getReference(string_view path, int line, int character) {
     return makeReferenceRequest(nextId++, getUri(path), line, character);
 }

--- a/test/lsp/ProtocolTest.h
+++ b/test/lsp/ProtocolTest.h
@@ -69,6 +69,8 @@ protected:
 
     std::unique_ptr<LSPMessage> getDefinition(std::string_view path, int line, int character);
 
+    std::unique_ptr<LSPMessage> implementation(std::string_view path, int line, int character);
+
     std::unique_ptr<LSPMessage> getReference(std::string_view path, int line, int character);
 
     std::unique_ptr<LSPMessage> hover(std::string_view path, int line, int character);

--- a/test/lsp/protocol_test_corpus.cc
+++ b/test/lsp/protocol_test_corpus.cc
@@ -1053,4 +1053,13 @@ TEST_CASE_FIXTURE(ProtocolTest, "OpeningExistingFilesTakesTheFastPath") {
     }
 }
 
+TEST_CASE_FIXTURE(ProtocolTest, "ImplementationOnBrokenLambda") {
+    assertErrorDiagnostics(initializeLSP(), {});
+    assertErrorDiagnostics(send(*openFile("foo.rb", "->... {}")), {{"foo.rb", 0, "unexpected token \"...\""}});
+
+    auto responses = send(*implementation("foo.rb", 0, 2));
+    const auto numResponses = absl::c_count_if(responses, [](const auto &m) { return m->isResponse(); });
+    REQUIRE_EQ(1, numResponses);
+}
+
 } // namespace sorbet::test::lsp

--- a/test/testdata/lsp/deprecated_method_diagnostics.rb
+++ b/test/testdata/lsp/deprecated_method_diagnostics.rb
@@ -1,0 +1,25 @@
+# typed: true
+
+class TestClass
+  extend T::Sig
+
+  sig { deprecated.returns(String) }
+  def old_method
+    "legacy"
+  end
+
+  sig { returns(String) }
+  def new_method
+    "current"  
+  end
+end
+
+# This should generate a diagnostic with deprecated tag
+obj = TestClass.new
+result = obj.old_method
+#            ^^^^^^^^^^ warning: Method `TestClass#old_method` is deprecated
+puts result
+
+# This should not generate any diagnostic
+result2 = obj.new_method
+puts result2

--- a/test/testdata/lsp/hover.rb
+++ b/test/testdata/lsp/hover.rb
@@ -169,3 +169,24 @@ def main
   # ^ hover-line: 11 # result type:
   # ^ hover-line: 12 T.noreturn
 end
+
+# Test deprecated method hover
+class DeprecatedTestClass
+  extend T::Sig
+  
+  sig { deprecated.returns(String) }
+  def deprecated_method
+    "old way"
+  end
+  
+  sig { returns(String) }
+  def normal_method
+    "new way"
+  end
+end
+
+deprecated_obj = DeprecatedTestClass.new
+deprecated_obj.deprecated_method
+#              ^^^^^^^^^^^^^^^^^ hover: sig { deprecated.returns(String) }
+deprecated_obj.normal_method
+#              ^^^^^^^^^^^^^ hover: sig { returns(String) }

--- a/test/testdata/lsp/rename/rename_overload.A.rbedited
+++ b/test/testdata/lsp/rename/rename_overload.A.rbedited
@@ -1,0 +1,11 @@
+# typed: true
+
+class Main
+    extend T::Sig
+
+    sig {params(val: T::Set[String]).returns(T.nilable(String))}
+    def set(val)
+        val.first
+          # ^ apply-rename: [A] newName: second placeholderText: first invalid: true
+    end
+end

--- a/test/testdata/lsp/rename/rename_overload.rb
+++ b/test/testdata/lsp/rename/rename_overload.rb
@@ -1,0 +1,11 @@
+# typed: true
+
+class Main
+    extend T::Sig
+
+    sig {params(val: T::Set[String]).returns(T.nilable(String))}
+    def set(val)
+        val.first
+          # ^ apply-rename: [A] newName: second placeholderText: first invalid: true
+    end
+end

--- a/test/testdata/parser/crash_case_empty_var.rb
+++ b/test/testdata/parser/crash_case_empty_var.rb
@@ -1,0 +1,5 @@
+# typed: true
+
+# Crash with an empty string literal in a case-in expression.
+case T.unsafe(nil); in {"":} then true; end
+                      # ^^^ error: key must be valid as local variables

--- a/test/testdata/rbi/cgi.rb
+++ b/test/testdata/rbi/cgi.rb
@@ -1,0 +1,6 @@
+# typed: true
+require 'cgi'
+
+T.assert_type!(CGI.escapeURIComponent("'Stop!' said Fred"), String)
+T.assert_type!(CGI.unescapeURIComponent("%27Stop%21%27+said%20Fred"), String)
+T.assert_type!(CGI.unescapeURIComponent("%27Stop%21%27+said%20Fred", "ISO-8859-1"), String)

--- a/test/testdata/rbs/assertions_absurd.rb
+++ b/test/testdata/rbs/assertions_absurd.rb
@@ -1,0 +1,260 @@
+# typed: true
+# enable-experimental-rbs-comments: true
+
+#: (Integer | String) -> void
+def normal_usage(x)
+  case x
+  when Integer
+    puts x
+  when String
+    puts x
+  else
+    x #: absurd
+  end
+end
+
+#: (Integer | String) -> void
+def forgotten_case(x)
+  case x
+  when Integer
+    puts x
+  else
+    x #: absurd # error: Control flow could reach `T.absurd` because the type `String` wasn't handled
+  end
+end
+
+#: (Integer | String) -> void
+def got_all_cases_but_untyped(x)
+  y = T.unsafe(x)
+  case y
+  when Integer
+    puts y
+  when String
+    puts y
+  else
+    y #: absurd # error: Control flow could reach `T.absurd` because argument was `T.untyped`
+  end
+end
+
+#: (Integer | String | Array[Integer]) -> void
+def forgotten_two_cases(x)
+  case x
+  when Integer
+    puts x
+  else
+    x #: absurd # error: Control flow could reach `T.absurd` because the type `T.any(String, T::Array[Integer])` wasn't handled
+  end
+end
+
+#: (String | Array[Integer]) -> void
+def missing_case_with_generic(x)
+  case x
+  when Array
+    puts x
+  else
+    x #: absurd # error: Control flow could reach `T.absurd` because the type `String` wasn't handled
+  end
+end
+
+#: (Array[String] | Array[Integer]) -> void
+def ok_when_generic_cases_overlap(x)
+  case x
+  when Array
+    puts x
+  else
+    x #: absurd
+  end
+end
+
+#: (Integer | String) -> void
+def dead_code_before(x)
+  case x
+  when Integer
+    puts x
+  when String
+    puts x
+  else
+    puts 1 # error: This code is unreachable
+    x #: absurd
+  end
+end
+
+#: (Integer | String) -> void
+def dead_code_after(x)
+  case x
+  when Integer
+    puts x
+  when String
+    puts x
+  else
+    x #: absurd
+    puts 1 # error: This code is unreachable
+  end
+end
+
+#: (Integer | String) -> void
+def cant_alias_local_variables(x)
+  case x
+  when Integer
+    puts x
+  when String
+    puts x
+  else
+    # Hello future Sorbet contributor.
+    # It's not that we MUST have an error here, but rather that we were fine
+    # with it, and couldn't see a simple solution that avoided emitting one.
+    y = x
+    #   ^ error: This code is unreachable
+    y #: absurd
+  end
+end
+
+#: (Integer | String) -> void
+def normal_usage_with_isa(x)
+  if x.is_a?(Integer)
+    puts x
+  elsif x.is_a?(String)
+    puts x
+  else
+    x #: absurd
+  end
+end
+
+#: (Integer | String) -> void
+def missing_case_with_isa(x)
+  if x.is_a?(Integer)
+    puts x
+  else
+    x #: absurd # error: Control flow could reach `T.absurd` because the type `String` wasn't handled
+  end
+end
+
+#: (Integer) -> void
+def enforce_something_is_always_non_nil(x)
+  if !x.nil?
+    puts x
+  else
+    x #: absurd
+  end
+end
+
+#: (Integer) -> void
+def error_when_predicate_always_true(x)
+  if !x.nil?
+    puts 1 # not a dead code error, because it's always true!
+    # This is a strange error message given the test case.
+    x #: absurd # error: Control flow could reach `T.absurd` because the type `Integer` wasn't handled
+  end
+end
+
+# --- trying to subvert normal usage ------------------------------------------
+
+def only_absurd
+  temp1 = T.let(T.unsafe(nil), T.noreturn)
+  temp1 #: absurd
+end
+
+#: (bot) -> void
+def allows_arg_noreturn(x)
+  x #: absurd
+  puts(x)
+# ^^^^^^^ error: This code is unreachable
+end
+
+#: (bot, bot) -> void
+def allows_args_noreturn(x, y)
+  x #: absurd
+  y #: absurd
+  puts(x)
+# ^^^^^^^ error: This code is unreachable
+end
+
+#: (Integer & String) -> void
+def intersects_to_bottom(x)
+  x #: absurd
+  puts(x)
+# ^^^^^^^ error: This code is unreachable
+end
+
+# --- reasonable usage on global, class, instance, and local variables --------
+$some_global = true #: bool
+
+#: -> void
+def absurd_not_reached_on_global_var
+  case $some_global
+  when TrueClass
+  when FalseClass
+  else $some_global #: absurd # error: Control flow could reach `T.absurd` because argument was `T.untyped`
+  end
+end
+
+#: -> void
+def absurd_reached_on_global_var
+  if !$some_global
+    $some_global #: absurd # error: Control flow could reach `T.absurd` because the type `T.nilable(FalseClass)` wasn't handled
+  end
+end
+
+class SomeClass
+  @@some_class_var = true #: bool
+
+  #: -> void
+  def initialize
+    @some_instance_var = true #: bool
+  end
+
+  #: -> void
+  def absurd_not_reached_on_class_var
+    case @@some_class_var
+    when TrueClass
+    when FalseClass
+    else
+      @@some_class_var #: absurd
+    end
+  end
+
+  #: -> void
+  def absurd_reached_on_class_var
+    if !@@some_class_var
+      @@some_class_var #: absurd # error: Control flow could reach `T.absurd` because the type `FalseClass` wasn't handled
+    end
+  end
+
+  #: -> void
+  def absurd_not_reached_on_instance_var
+    case @some_instance_var
+    when TrueClass
+    when FalseClass
+    else
+      @some_instance_var #: absurd
+    end
+  end
+
+  #: -> void
+  def absurd_reached_on_instance_var
+    if !@some_instance_var
+      @some_instance_var #: absurd # error: Control flow could reach `T.absurd` because the type `FalseClass` wasn't handled
+    end
+  end
+end
+
+#: (bool) -> void
+def absurd_reached_on_local_var(some_local_var)
+  if !some_local_var
+    some_local_var #: absurd # error: Control flow could reach `T.absurd` because the type `FalseClass` wasn't handled
+  end
+end
+
+# --- incorrect usage ---------------------------------------------------------
+
+#: (Integer) -> void
+def not_enough_args(x)
+  #: absurd # error: Unexpected RBS assertion comment found in `method`
+end
+
+#: (Integer) -> void
+def too_many_args(x)
+  if x.nil?
+    nil #: absurd # error: `T.absurd` expects to be called on a variable
+  end
+end

--- a/test/testdata/rbs/assertions_bind.rb
+++ b/test/testdata/rbs/assertions_bind.rb
@@ -1,0 +1,130 @@
+# typed: true
+# enable-experimental-rbs-comments: true
+
+#: self as Foo
+T.reveal_type(self) # error: Revealed type: `Foo`
+
+class Foo
+  #: self as Foo
+  T.reveal_type(self) # error: Revealed type: `Foo`
+end
+
+module Bar
+  #: self as Foo
+  T.reveal_type(self) # error: Revealed type: `Foo`
+  #: self as Bar
+  T.reveal_type(self) # error: Revealed type: `Bar`
+
+  class << self
+    #: self as Foo
+    T.reveal_type(self) # error: Revealed type: `Foo`
+  end
+end
+
+class Baz; end
+
+def foo
+  #: self as Foo
+  T.reveal_type(self) # error: Revealed type: `Foo`
+end
+
+def bar
+  #: self as Foo
+  T.reveal_type(self) # error: Revealed type: `Foo`
+  #: self as Bar
+  T.reveal_type(self) # error: Revealed type: `Bar`
+end
+
+def self.baz
+  #: self as Foo
+  T.reveal_type(self) # error: Revealed type: `Foo`
+end
+
+[].each do
+  #: self as Foo
+  T.reveal_type(self) # error: Revealed type: `Foo`
+end
+
+case ARGV.first
+when "foo"
+  #: self as Foo
+  T.reveal_type(self) # error: Revealed type: `Foo`
+else
+  #: self as Bar
+  T.reveal_type(self) # error: Revealed type: `Bar`
+end
+
+case ARGV.first
+in "foo"
+  #: self as Foo
+  T.reveal_type(self) # error: Revealed type: `Foo`
+else
+  #: self as Bar
+  T.reveal_type(self) # error: Revealed type: `Bar`
+end
+
+for _i in 0..10
+  #: self as Foo
+  T.reveal_type(self) # error: Revealed type: `Foo`
+end
+
+if ARGV.first == "foo"
+  #: self as Foo
+  T.reveal_type(self) # error: Revealed type: `Foo`
+elsif ARGV.first == "bar"
+  #: self as Bar
+  T.reveal_type(self) # error: Revealed type: `Bar`
+else
+  #: self as untyped
+  T.reveal_type(self) # error: Revealed type: `T.untyped`
+end
+
+begin
+  #: self as Foo
+  T.reveal_type(self) # error: Revealed type: `Foo`
+rescue
+  #: self as Bar
+  T.reveal_type(self) # error: Revealed type: `Bar`
+else
+  #: self as Baz
+  T.reveal_type(self) # error: Revealed type: `Baz`
+ensure
+  #: self as untyped
+  T.reveal_type(self) # error: Revealed type: `T.untyped`
+end
+
+until ARGV.first == "foo"
+  #: self as Bar
+  T.reveal_type(self) # error: Revealed type: `Bar`
+end
+
+begin
+  #: self as Bar
+  T.reveal_type(self) # error: Revealed type: `Bar`
+end until ARGV.first == "foo"
+
+while ARGV.first == "foo"
+  #: self as Bar
+  T.reveal_type(self) # error: Revealed type: `Bar`
+end
+
+begin
+  #: self as Bar
+  T.reveal_type(self) # error: Revealed type: `Bar`
+end while ARGV.first == "foo"
+
+module Errors
+  #: self as foo
+  #          ^^^ error: RBS aliases are not supported
+
+  #: self as (
+  #          ^ error: Failed to parse RBS type (unexpected token for simple type)
+
+  T.reveal_type(self) # error: Revealed type: `T.untyped`
+
+  self #: self as String
+  #               ^^^^^^ error: `self` binding can't be used as a trailing comment
+end
+
+#: self as Bar
+T.reveal_type(self) # error: Revealed type: `Bar`

--- a/test/testdata/rbs/assertions_bind.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_bind.rb.rewrite-tree.exp
@@ -1,0 +1,198 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  def foo<<todo method>>(&<blk>)
+    begin
+      <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Foo>)
+      <emptyTree>::<C T>.reveal_type(<self>)
+    end
+  end
+
+  def bar<<todo method>>(&<blk>)
+    begin
+      <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Foo>)
+      <emptyTree>::<C T>.reveal_type(<self>)
+      <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Bar>)
+      <emptyTree>::<C T>.reveal_type(<self>)
+    end
+  end
+
+  def self.baz<<todo method>>(&<blk>)
+    begin
+      <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Foo>)
+      <emptyTree>::<C T>.reveal_type(<self>)
+    end
+  end
+
+  <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Foo>)
+
+  <emptyTree>::<C T>.reveal_type(<self>)
+
+  class <emptyTree>::<C Foo><<C <todo sym>>> < (::<todo sym>)
+    <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Foo>)
+
+    <emptyTree>::<C T>.reveal_type(<self>)
+  end
+
+  module <emptyTree>::<C Bar><<C <todo sym>>> < ()
+    <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Foo>)
+
+    <emptyTree>::<C T>.reveal_type(<self>)
+
+    <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Bar>)
+
+    <emptyTree>::<C T>.reveal_type(<self>)
+
+    class <singleton class><<C <todo sym>>> < ()
+      <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Foo>)
+
+      <emptyTree>::<C T>.reveal_type(<self>)
+    end
+  end
+
+  class <emptyTree>::<C Baz><<C <todo sym>>> < (::<todo sym>)
+  end
+
+  <runtime method definition of foo>
+
+  <runtime method definition of bar>
+
+  <runtime method definition of self.baz>
+
+  [].each() do ||
+    begin
+      <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Foo>)
+      <emptyTree>::<C T>.reveal_type(<self>)
+    end
+  end
+
+  begin
+    <assignTemp>$2 = <emptyTree>::<C ARGV>.first()
+    if "foo".===(<assignTemp>$2)
+      begin
+        <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Foo>)
+        <emptyTree>::<C T>.reveal_type(<self>)
+      end
+    else
+      begin
+        <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Bar>)
+        <emptyTree>::<C T>.reveal_type(<self>)
+      end
+    end
+  end
+
+  begin
+    <assignTemp>$3 = <emptyTree>::<C ARGV>.first()
+    if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      begin
+        <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Foo>)
+        <emptyTree>::<C T>.reveal_type(<self>)
+      end
+    else
+      begin
+        <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Bar>)
+        <emptyTree>::<C T>.reveal_type(<self>)
+      end
+    end
+  end
+
+  ::<Magic>.<build-range>(0, 10, false).each() do |_i|
+    begin
+      <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Foo>)
+      <emptyTree>::<C T>.reveal_type(<self>)
+    end
+  end
+
+  if <emptyTree>::<C ARGV>.first().==("foo")
+    begin
+      <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Foo>)
+      <emptyTree>::<C T>.reveal_type(<self>)
+    end
+  else
+    if <emptyTree>::<C ARGV>.first().==("bar")
+      begin
+        <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Bar>)
+        <emptyTree>::<C T>.reveal_type(<self>)
+      end
+    else
+      begin
+        <cast:bind>(<self>, <todo sym>, ::<root>::<C T>.untyped())
+        <emptyTree>::<C T>.reveal_type(<self>)
+      end
+    end
+  end
+
+  begin
+    <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Foo>)
+    <emptyTree>::<C T>.reveal_type(<self>)
+  end
+rescue => <rescueTemp>$4
+  begin
+    <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Bar>)
+    <emptyTree>::<C T>.reveal_type(<self>)
+  end
+else
+  begin
+    <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Baz>)
+    <emptyTree>::<C T>.reveal_type(<self>)
+  end
+ensure
+  begin
+    <cast:bind>(<self>, <todo sym>, ::<root>::<C T>.untyped())
+    <emptyTree>::<C T>.reveal_type(<self>)
+  end
+
+  while <emptyTree>::<C ARGV>.first().==("foo").!()
+    begin
+      <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Bar>)
+      <emptyTree>::<C T>.reveal_type(<self>)
+    end
+  end
+
+  while true
+    begin
+      begin
+        <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Bar>)
+        <emptyTree>::<C T>.reveal_type(<self>)
+      end
+      if <emptyTree>::<C ARGV>.first().==("foo")
+        break(<emptyTree>)
+      else
+        <emptyTree>
+      end
+    end
+  end
+
+  while <emptyTree>::<C ARGV>.first().==("foo")
+    begin
+      <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Bar>)
+      <emptyTree>::<C T>.reveal_type(<self>)
+    end
+  end
+
+  while true
+    begin
+      begin
+        <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Bar>)
+        <emptyTree>::<C T>.reveal_type(<self>)
+      end
+      if <emptyTree>::<C ARGV>.first().==("foo").!()
+        break(<emptyTree>)
+      else
+        <emptyTree>
+      end
+    end
+  end
+
+  module <emptyTree>::<C Errors><<C <todo sym>>> < ()
+    <cast:bind>(<self>, <todo sym>, ::<root>::<C T>.untyped())
+
+    <cast:bind>(<self>, <todo sym>, ::<root>::<C T>.untyped())
+
+    <emptyTree>::<C T>.reveal_type(<self>)
+
+    <self>
+  end
+
+  <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Bar>)
+
+  <emptyTree>::<C T>.reveal_type(<self>)
+end

--- a/test/testdata/rbs/assertions_case.rb
+++ b/test/testdata/rbs/assertions_case.rb
@@ -35,3 +35,8 @@ T.reveal_type(c1) # error: Revealed type: `Integer`
 case ARGV.shift #: as String
 when "foo"
 end
+
+case ARGV.shift
+when "foo"
+else ARGV.shift #: as String
+end

--- a/test/testdata/rbs/assertions_case.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_case.rb.rewrite-tree.exp
@@ -62,4 +62,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>
     end
   end
+
+  begin
+    <assignTemp>$7 = <emptyTree>::<C ARGV>.shift()
+    if "foo".===(<assignTemp>$7)
+      <emptyTree>
+    else
+      <cast:cast>(<emptyTree>::<C ARGV>.shift(), <todo sym>, <emptyTree>::<C String>)
+    end
+  end
 end

--- a/test/testdata/rbs/assertions_ensure.rb
+++ b/test/testdata/rbs/assertions_ensure.rb
@@ -1,0 +1,8 @@
+# typed: strict
+# enable-experimental-rbs-comments: true
+
+begin
+  ARGV.first #: as Integer
+ensure
+  ARGV.first #: as String
+end

--- a/test/testdata/rbs/assertions_ensure.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_ensure.rb.rewrite-tree.exp
@@ -1,0 +1,5 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  <cast:cast>(<emptyTree>::<C ARGV>.first(), <todo sym>, <emptyTree>::<C Integer>)
+ensure
+  <cast:cast>(<emptyTree>::<C ARGV>.first(), <todo sym>, <emptyTree>::<C String>)
+end

--- a/test/testdata/rbs/assertions_if.rb
+++ b/test/testdata/rbs/assertions_if.rb
@@ -48,3 +48,14 @@ T.reveal_type(if8) # error: Revealed type: `Float`
 if9 = if ARGV.empty? #: as Integer
 else
 end
+
+if ARGV.size == 1
+  ARGV.shift #: Integer
+elsif ARGV.size == 2
+  [ARGV.shift, ARGV.shift] #: Array[Integer]
+else
+  ARGV.shift #: NilClass
+end
+
+42 if ARGV.any? #: Integer?
+42 unless ARGV.empty? #: Integer?

--- a/test/testdata/rbs/assertions_if.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_if.rb.rewrite-tree.exp
@@ -66,4 +66,26 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   else
     <emptyTree>
   end
+
+  if <emptyTree>::<C ARGV>.size().==(1)
+    <cast:let>(<emptyTree>::<C ARGV>.shift(), <todo sym>, <emptyTree>::<C Integer>)
+  else
+    if <emptyTree>::<C ARGV>.size().==(2)
+      <cast:let>([<emptyTree>::<C ARGV>.shift(), <emptyTree>::<C ARGV>.shift()], <todo sym>, ::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
+    else
+      <cast:let>(<emptyTree>::<C ARGV>.shift(), <todo sym>, <emptyTree>::<C NilClass>)
+    end
+  end
+
+  <cast:let>(if <emptyTree>::<C ARGV>.any?()
+    42
+  else
+    <emptyTree>
+  end, <todo sym>, ::<root>::<C T>.nilable(<emptyTree>::<C Integer>))
+
+  <cast:let>(if <emptyTree>::<C ARGV>.empty?()
+    <emptyTree>
+  else
+    42
+  end, <todo sym>, ::<root>::<C T>.nilable(<emptyTree>::<C Integer>))
 end

--- a/test/testdata/resolver/cast_in_abstract_crash.rb
+++ b/test/testdata/resolver/cast_in_abstract_crash.rb
@@ -1,0 +1,15 @@
+# typed: true
+class A
+  extend T::Sig
+  extend T::Helpers
+
+  abstract!
+
+  sig {abstract.void}
+  def foo
+    @z ||= T.let(nil, T.nilable(T.type_parameter(:U)))
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Abstract methods must not contain any code in their body
+#          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve declared type for `@z`
+#                                                ^^ error: Unspecified type parameter
+  end
+end

--- a/test/testdata/resolver/deprecated.rb
+++ b/test/testdata/resolver/deprecated.rb
@@ -1,0 +1,141 @@
+# typed: true
+
+# Basic deprecated method
+class BasicDeprecated
+  extend T::Sig
+  
+  sig { deprecated.returns(String) }
+  def old_method
+    "legacy"
+  end
+  
+  sig { returns(String) }
+  def new_method
+    "current"
+  end
+end
+
+BasicDeprecated.new.old_method # error: Method `BasicDeprecated#old_method` is deprecated
+BasicDeprecated.new.new_method
+
+class DeprecatedVoid
+  extend T::Sig
+  
+  sig { deprecated.void }
+  def old_method
+  end
+end
+
+DeprecatedVoid.new.old_method # error: Method `DeprecatedVoid#old_method` is deprecated
+
+# Deprecated with parameters
+class DeprecatedWithParams
+  extend T::Sig
+  
+  sig { deprecated.params(x: String, y: Integer).returns(String) }
+  def old_method(x, y)
+    "#{x}#{y}"
+  end
+end
+
+DeprecatedWithParams.new.old_method("test", 42) # error: Method `DeprecatedWithParams#old_method` is deprecated
+
+# Deprecated class method
+class DeprecatedClassMethod
+  extend T::Sig
+  
+  sig { deprecated.returns(String) }
+  def self.old_method
+    "legacy class method"
+  end
+end
+
+DeprecatedClassMethod.old_method # error: Method `DeprecatedClassMethod.old_method` is deprecated
+
+# Deprecated with inheritance - deprecated method in parent
+class ParentWithDeprecated
+  extend T::Sig
+  
+  sig { deprecated.returns(String) }
+  def inherited_deprecated
+    "parent deprecated"
+  end
+  
+  sig { overridable.deprecated.returns(String) }
+  def overridable_deprecated
+    "parent overridable deprecated"
+  end
+end
+
+class ChildInheritsDeprecated < ParentWithDeprecated
+  extend T::Sig
+  
+  # Child overrides deprecated method - should still be deprecated
+  sig { override.deprecated.returns(String) }
+  def overridable_deprecated
+    "child overrides deprecated"
+  end
+end
+
+ChildInheritsDeprecated.new.inherited_deprecated # error: Method `ParentWithDeprecated#inherited_deprecated` is deprecated
+ChildInheritsDeprecated.new.overridable_deprecated # error: Method `ChildInheritsDeprecated#overridable_deprecated` is deprecated
+
+class ChildMissingInheritedDeprecated < ParentWithDeprecated
+  extend T::Sig
+  
+  # Child overrides deprecated method - should still be deprecated
+  sig { override.returns(String) }
+  def overridable_deprecated
+    "child overrides deprecated"
+  end
+end
+
+ChildMissingInheritedDeprecated.new.inherited_deprecated # error: Method `ParentWithDeprecated#inherited_deprecated` is deprecated
+ChildMissingInheritedDeprecated.new.overridable_deprecated
+
+# Deprecated with other annotations
+class DeprecatedCombinations
+  extend T::Sig
+  extend T::Helpers
+  abstract!
+  
+  sig { deprecated.overridable.returns(String) }
+  def deprecated_and_overridable
+    "deprecated but overridable"
+  end
+  
+  # Can be both deprecated and abstract
+  sig { deprecated.abstract.void }
+  def deprecated_abstract; end
+  
+  # Can't be both deprecated and final (if we add validation)
+  sig(:final) { deprecated.void }
+  def deprecated_final; end
+end
+
+class ConcreteDeprecatedCombinations < DeprecatedCombinations
+  extend T::Sig
+  
+  sig { override.returns(String) }
+  def deprecated_abstract
+    "concrete implementation"
+  end
+end
+
+ConcreteDeprecatedCombinations.new.deprecated_and_overridable # warning: Method `DeprecatedCombinations#deprecated_and_overridable` is deprecated
+ConcreteDeprecatedCombinations.new.deprecated_abstract # warning: Method `ConcreteDeprecatedCombinations#deprecated_abstract` is deprecated
+ConcreteDeprecatedCombinations.new.deprecated_final # warning: Method `DeprecatedCombinations#deprecated_final` is deprecated
+
+# Test deprecated with attr_accessor-style methods
+class DeprecatedAccessors
+  extend T::Sig
+  
+  sig { deprecated.returns(T.nilable(String)) }
+  attr_reader :old_attr
+  
+  sig { deprecated.params(old_attr: String).returns(String) }
+  attr_writer :old_attr
+end
+accessor_instance = DeprecatedAccessors.new
+accessor_instance.old_attr # error: Method `DeprecatedAccessors#old_attr` is deprecated
+accessor_instance.old_attr = "test" # error: Method `DeprecatedAccessors#old_attr=` is deprecated

--- a/test/testdata/resolver/deprecated.rb
+++ b/test/testdata/resolver/deprecated.rb
@@ -85,7 +85,7 @@ class ChildMissingInheritedDeprecated < ParentWithDeprecated
   
   # Child overrides deprecated method - should still be deprecated
   sig { override.returns(String) }
-  def overridable_deprecated
+  def overridable_deprecated # error: Method `ChildMissingInheritedDeprecated#overridable_deprecated` overrides deprecated method but is not marked deprecated
     "child overrides deprecated"
   end
 end
@@ -117,14 +117,14 @@ class ConcreteDeprecatedCombinations < DeprecatedCombinations
   extend T::Sig
   
   sig { override.returns(String) }
-  def deprecated_abstract
+  def deprecated_abstract # error: Method `ConcreteDeprecatedCombinations#deprecated_abstract` overrides deprecated method but is not marked deprecated
     "concrete implementation"
   end
 end
 
-ConcreteDeprecatedCombinations.new.deprecated_and_overridable # warning: Method `DeprecatedCombinations#deprecated_and_overridable` is deprecated
-ConcreteDeprecatedCombinations.new.deprecated_abstract # warning: Method `ConcreteDeprecatedCombinations#deprecated_abstract` is deprecated
-ConcreteDeprecatedCombinations.new.deprecated_final # warning: Method `DeprecatedCombinations#deprecated_final` is deprecated
+ConcreteDeprecatedCombinations.new.deprecated_and_overridable # error: Method `DeprecatedCombinations#deprecated_and_overridable` is deprecated
+ConcreteDeprecatedCombinations.new.deprecated_abstract
+ConcreteDeprecatedCombinations.new.deprecated_final # error: Method `DeprecatedCombinations#deprecated_final` is deprecated
 
 # Test deprecated with attr_accessor-style methods
 class DeprecatedAccessors

--- a/test/testdata/resolver/generic_missing_args_in_sig.rb
+++ b/test/testdata/resolver/generic_missing_args_in_sig.rb
@@ -1,0 +1,10 @@
+# typed: true
+
+class A
+  extend T::Sig, T::Generic
+  Elem = type_member
+  sig { params(x: self.A).void }
+                # ^^^^^^ error: Malformed type declaration
+                #      ^ error: Method `A` does not exist
+  def test(x); end
+end

--- a/website/docs/rbs-support.md
+++ b/website/docs/rbs-support.md
@@ -1084,6 +1084,28 @@ x = T.unsafe(42)
 x.undefined_method
 ```
 
+### `T.absurd`
+
+[`T.absurd`](exhaustiveness.md) can be expressed using RBS comments:
+
+```ruby
+#: (Integer | String) -> void
+def foo(x)
+  case x
+  when Integer
+  when String
+  else
+    x #: absurd
+  end
+end
+```
+
+This is equivalent to:
+
+```ruby
+T.absurd(x)
+```
+
 [Class instance type]:
   https://github.com/ruby/rbs/blob/master/docs/syntax.md#class-instance-type
 [Class singleton type]:

--- a/website/docs/rbs-support.md
+++ b/website/docs/rbs-support.md
@@ -624,13 +624,6 @@ specify them using `@` annotation comments.
 The following signatures are equivalent:
 
 ```ruby
-# @abstract
-#: (Integer) -> void
-def foo1(x); end
-
-sig { abstract.params(x: Integer).void }
-def foo2(x); end
-
 # @override
 #: (Integer) -> void
 def bar1(x); end
@@ -653,9 +646,12 @@ sig(:final) { params(x: Integer).void }
 def qux2(x); end
 ```
 
-Note: these annotations like `@abstract` use normal comments, like `# @abstract`
+Note: these annotations like `@override` use normal comments, like `# @override`
 (not the special `#:` comment). This makes it possible to reuse any existing
 YARD or RDoc annotations.
+
+> While the `@abstract` method annotation is technically supported, it is not
+> recommended. [Read more about abstract methods below.](#abstract-methods)
 
 ## Class and module annotations
 
@@ -870,6 +866,73 @@ Note that non-generic types are not translated, so `Array` without a type
 argument stays `Array`.
 
 ## Unsupported features
+
+### Abstract methods
+
+While the `@abstract` annotation is technically supported for methods, it is
+currently not recommended. To understand why, take the following example:
+
+```ruby
+# @abstract
+class Foo
+  # @abstract
+  # -> void
+  def foo; end
+end
+
+class Bar < Foo
+  # @override
+  # -> void
+  def foo
+    super
+  end
+end
+```
+
+When using traditional Sorbet sigs, the call to `super` inside of `Bar#foo`
+would error at runtime, because `sorbet-runtime` uses metaprogramming to remove
+the `Foo#foo` method. Any mistaken calls to this method would raise an error at
+runtime.
+
+However, RBS signatures have no runtime component. This means that any
+inadvertent calls to abstract methods will silently no-op, which has the
+potential to create subtle bugs and unintended behavior in production.
+
+Instead of using the `@abstract` annotation on methods, place any abstract
+methods in a separate `.rbi` shim file.
+
+Modifying the example above, leave only the abstract class definition in the
+Ruby file, along with the definition of its subclass.
+
+Note: the class `Foo` **must** still be defined in a Ruby file. Without this
+definition, `Foo` will not exist at Runtime, and the program will error when
+referencing the `Foo` class.
+
+```ruby
+# @abstract
+class Foo; end
+
+class Bar < Foo
+  # @override
+  # -> void
+  def foo
+    super
+  end
+end
+```
+
+Then, in a separate shim file, add any abstract methods:
+
+```ruby
+class Foo
+  sig { abstract.returns(String) }
+  def foo; end
+end
+```
+
+Using this approach, the abstract method will be visible to Sorbet during static
+type checking, but it will not exist at runtime, resulting in obvious errors if
+any child classes attempt to call it.
 
 ### Class types
 

--- a/website/docs/rbs-support.md
+++ b/website/docs/rbs-support.md
@@ -1106,6 +1106,33 @@ This is equivalent to:
 T.absurd(x)
 ```
 
+### `T.bind`
+
+[`T.bind`](type-assertions.md#tbind) can be expressed using RBS comments with
+the special `self as` construct:
+
+```ruby
+class Foo
+  def foo; end
+end
+
+def bar
+  #: self as Foo
+
+  foo
+end
+```
+
+This is equivalent to:
+
+```ruby
+def bar
+  T.bind(self, Foo)
+
+  foo
+end
+```
+
 [Class instance type]:
   https://github.com/ruby/rbs/blob/master/docs/syntax.md#class-instance-type
 [Class singleton type]:


### PR DESCRIPTION
Closes: https://github.com/sorbet/sorbet/issues/4481

Sorbet now supports `# @deprecated` and the `deprecated` keyword in method signatures. On hover, we show `deprecated` in the signature. Method calls now are marked as deprecated. Autocomplete items are also marked as deprecated. We have validation logic that child classes that override methods must mark their methods as deprecated if the parent is marked as deprecated. 


### Motivation
We don't currently support deprecation at the lsp level. It's difficult to know if code is deprecated at a glance.


### Test plan

See included automated tests.
