### PR TITLE
Explore `NodeWithExpr` idea

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -713,6 +713,8 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
         auto locZeroLen = what->loc.copyWithZeroLength();
         ENFORCE(loc.exists(), "parse-tree node has no location: {}", what->toString(dctx.ctx));
         ExpressionPtr result;
+
+        categoryCounterInc("node2TreeImpl", "check_for_prism");
         typecase(
             what.get(),
             // The top N clauses here are ordered according to observed

--- a/parser/Node.h
+++ b/parser/Node.h
@@ -100,11 +100,17 @@ template <class To> To *cast_node(Node *what) {
 #endif
 
     if (auto casted = fast_cast<Node, To>(what)) {
+        categoryCounterInc("cast_node", "correct");
         return casted;
     }
 
     if (auto casted = fast_cast<Node, NodeWithExpr>(what)) {
+        categoryCounterInc("cast_node", "nullptr");
+        categoryCounterInc("cast_node_delegation", "delegated_to_wrapped_node");
         return cast_node<To>(casted->wrappedNode.get());
+    } else {
+        categoryCounterInc("cast_node", "nullptr");
+        categoryCounterInc("cast_node_delegation", "nullptr");
     }
 
     return nullptr;

--- a/parser/Node.h
+++ b/parser/Node.h
@@ -103,9 +103,9 @@ template <class To> To *cast_node(Node *what) {
         return casted;
     }
 
-    // if (auto casted = fast_cast<Node, NodeWithExpr>(what)) {
-    //     return cast_node<To>(casted->wrappedNode.get());
-    // }
+    if (auto casted = fast_cast<Node, NodeWithExpr>(what)) {
+        return cast_node<To>(casted->wrappedNode.get());
+    }
 
     return nullptr;
 }


### PR DESCRIPTION
Two approaches:

1. #240: Create one templated subclass, which stamps out a subclass of each WhiteQuark Node type (125 of them), which adds a `ast::ExpressionPtr` field.
    * Needs [a single check](https://github.com/Shopify/sorbet/pull/240/files#diff-a1993e092f77b3f386d10ef886011bc073a960d39c10c56dfa6e696437f15cd1R726-R734) at the start of the desugarer, to see if we're running in Prism mode.
2. This PR: Create a single new `NodeWithExpr` that wraps a real WhiteQuark node and an `ast::ExpressionPtr`
    * Implements all of Node's virtual methods by delegating to the wrapped node
    * Needs a hack in `cast_node`, so it can be casted "as if" it were the wrapped type ([read more here](https://github.com/Shopify/sorbet/pull/438))

On a small code base of ours (981 files):

1. Approach 1 would require 687k bool checks in the desugarer
2. Approach 2 would require ~1.7m~ 1.3M extra dynamic type casts in `cast_node`

Approach 2 requires ~2.5x~ 1.9x as many branches in the non-Prism case, and of a slower kind (reading a bool, vs a dynamic type cast)

[Diagram source](https://sankeymatic.com/build/?i=PTAEFEDsBcFMCdQDEA2B7A7gZ1AI1tBrLJKAHJoAmsWANKCgJYDWso0AFo1gFwBQIUEOHCAymgCu8AMZsA2gEEAsgHkAqmQAqAXVCaAhvADmBPn2pYJRwwlDT9KFDjkA2ABwB2D27e6Awhyw0sygAGZoiAAK8NwAtmb2WNAA%2BpBUbPaOzgBMAJwAjAAsHrn%2B%2BkmgXNCgAMQADEh1fIkpadR2Dk6gcvkevS7Z%2BWUVsdw4NUiNZjx%2B5dWjWOONTbMjY92FdYUuAKxDoADq8PoADiewlBTtLZWM0Hyr8%2Bs9AMz5eR51upASjifQiAmdSaWEYAC82BhQC5gXwhBxobDYoYjIxSChQO84aBEFihNV8m5sbhQNkmrgjHY0OhAaE6fTsQD9JAsCcbDBQABNPhtSGkprw0A7AWgVn6aRoyn5FwAOh2xIi1EQIs4sFibH02Ok1IitR8%2BqJQjQbIl0AAnpi%2BKF0FDpFIAG76aBSNh1GXbbFowIxaCheBoWKgSTQUHUAC0aK1OsBuVjcexxvFdwtbvlKH0ZuDQfgStA%2Bgk0ADTsY0mxACsJElGKFMzFUSzyOXK9Bq2aSJQcGRsfBYPaEFhYEZjicEV2hE7oOKuJBtbETigCDRC6BILAbEk%2BOn8F1tTTasCDyKuO0x7cjBwmOfqm6PPKhOEYKFxWwsMysGGBzFQtimKuxRLIEpN1sm7WB0xbPtQQhTF8hFZEjEgVtMVhLcwMgfR1TzM413gHBuSEKC2GlbEiEYK9QE2JpUJQR0UAkDVsMMPDsVCX4UBOHsJVBNBSHw0ATjQUEWx4vAwMwEjYDIjhqkozd9G3AShMYET80LBwyNIEUsGkQJMNUtAWMYXDqnwcIe2JHt9GYAS0RkvhaPosIImRaoAHJaBlVzsQ42BQkYAAPUBXK8giJDpAKgq81V1TQOkB2qfRoWJUARWkFLsUodL1UnUB1RgZSWWZVgzRcksuR%2DbgW1iXAHGZWQ8KAA)

<img src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ndbFSUYr3AbUJVhfupaC/1430d3a0-09cb-414d-8ef5-e58f0dcde739.png" width="400" />

