### PR TITLE
Pass MutableContext to Prism Translator

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -282,8 +282,9 @@ unique_ptr<parser::Node> runPrismParser(core::GlobalState &gs, core::FileRef fil
 
     unique_ptr<parser::Node> nodes;
     {
+        core::MutableContext ctx(gs, core::Symbols::root(), file);
         core::UnfreezeNameTable nameTableAccess(gs); // enters strings from source code as names
-        nodes = parser::Prism::Parser::run(gs, file);
+        nodes = parser::Prism::Parser::run(ctx);
     }
 
     if (print.ParseTree.enabled) {

--- a/parser/prism/Parser.cc
+++ b/parser/prism/Parser.cc
@@ -7,12 +7,13 @@ using namespace std;
 
 namespace sorbet::parser::Prism {
 
-unique_ptr<parser::Node> Parser::run(core::GlobalState &gs, core::FileRef file, bool directlyDesugar) {
-    auto source = file.data(gs).source();
+unique_ptr<parser::Node> Parser::run(core::MutableContext &ctx, bool directlyDesugar) {
+    auto file = ctx.file;
+    auto source = file.data(ctx).source();
     Prism::Parser parser{source};
     Prism::ParseResult parseResult = parser.parse();
 
-    return Prism::Translator(parser, gs, file, parseResult.parseErrors, directlyDesugar)
+    return Prism::Translator(parser, ctx, parseResult.parseErrors, directlyDesugar)
         .translate(parseResult.getRawNodePointer());
 }
 

--- a/parser/prism/Parser.h
+++ b/parser/prism/Parser.h
@@ -54,7 +54,7 @@ public:
     Parser(Parser &&) = delete;
     Parser &operator=(Parser &&) = delete;
 
-    static std::unique_ptr<parser::Node> run(core::GlobalState &gs, core::FileRef file, bool directlyDesugar = true);
+    static std::unique_ptr<parser::Node> run(core::MutableContext &ctx, bool directlyDesugar = true);
 
     ParseResult parse();
     core::LocOffsets translateLocation(pm_location_t location) const;

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -236,7 +236,8 @@ vector<ast::ParsedFile> index(core::GlobalState &gs, absl::Span<core::FileRef> f
             case realmain::options::Parser::PRISM: {
                 core::UnfreezeNameTable nameTableAccess(gs); // enters original strings
 
-                auto nodes = parser::Prism::Parser::run(gs, file);
+                core::MutableContext ctx(gs, core::Symbols::root(), file);
+                auto nodes = parser::Prism::Parser::run(ctx);
                 parseResult = parser::Parser::ParseResult{move(nodes), {}};
                 break;
             }
@@ -712,8 +713,8 @@ TEST_CASE("PerPhaseTest") { // NOLINT
                 break;
             }
             case realmain::options::Parser::PRISM: {
-                parseResult = parser::Parser::ParseResult{parser::Prism::Parser::run(ctx, f.file, false), {}};
-                directlyDesugaredTree = parser::Prism::Parser::run(ctx, f.file, true);
+                parseResult = parser::Parser::ParseResult{parser::Prism::Parser::run(ctx, false), {}};
+                directlyDesugaredTree = parser::Prism::Parser::run(ctx, true);
                 break;
             }
         }


### PR DESCRIPTION
# Update Prism Parser to use MutableContext

This PR updates the Prism parser to use `MutableContext` instead of directly using `GlobalState`. 

Upstreamed in https://github.com/sorbet/sorbet/pull/9147