### PR TITLE
Run CI on every branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,8 @@
 name: CI
 
 on:
-  push:
-    branches: [prism, prism-squashed]
-  pull_request:
-    branches: [prism, prism-squashed]
+  [push, pull_request]
+
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
As we start stacking it's going to be hard to keep CI to specific branches so instead we can run it on every branch and ignore the CI result when unnecessary.
