### PR TITLE
Reame `--parser` option

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -723,10 +723,13 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
                                  "Show help. Can pass an optional SECTION to show help for only one section instead of "
                                  "the default of all sections",
                                  cxxopts::value<vector<string>>()->implicit_value("all"), "SECTION");
-    // }}}
+    options.add_options(section)("parser",
+                                 "Which parser to use. Prism support is experimental and still under active "
+                                 "development. Correct code should still parse correctly, but error diagnostics "
+                                 "and auto-corrections are a work-in-progress.",
+                                 cxxopts::value<string>()->default_value("original"), "{[original], prism}");
 
-    options.add_options("dev")("parser", "Which parser to use", cxxopts::value<string>()->default_value("sorbet"),
-                               "{sorbet, prism}");
+    // }}}
 
     for (auto &provider : semanticExtensionProviders) {
         provider->injectOptions(options);
@@ -809,7 +812,7 @@ Parser extractParser(cxxopts::ParseResult &raw, shared_ptr<spdlog::logger> logge
     }
 
     logger->error("Unknown --parser option: {}\nValid values: {}", opt, fmt::join(allOptions, ", "));
-    return Parser::SORBET;
+    return Parser::ORIGINAL;
 }
 
 // Given a path, strips any trailing forward slashes (/) at the end of the path.

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -8,6 +8,7 @@
 #include "core/TrackUntyped.h"
 #include "main/pipeline/semantic_extension/SemanticExtension.h"
 #include "spdlog/spdlog.h"
+#include <cxxopts.hpp>
 #include <optional>
 
 namespace sorbet::realmain::options {
@@ -107,8 +108,8 @@ enum class Phase {
 };
 
 enum class Parser {
+    ORIGINAL,
     PRISM,
-    SORBET,
 };
 
 struct ParserOptions {
@@ -117,7 +118,7 @@ struct ParserOptions {
 };
 
 const std::vector<ParserOptions> parser_options({
-    {"sorbet", Parser::SORBET},
+    {"original", Parser::ORIGINAL},
     {"prism", Parser::PRISM},
 });
 
@@ -135,7 +136,7 @@ constexpr size_t MAX_CACHE_SIZE_BYTES = 1L * 1024 * 1024 * 1024; // 1 GiB
 struct Options {
     Printers print;
     Phase stopAfterPhase = Phase::INFERENCER;
-    Parser parser = Parser::SORBET;
+    Parser parser = Parser::ORIGINAL;
     bool noStdlib = false;
 
     // Should we monitor STDOUT for HUP and exit if it hangs up. This is a
@@ -309,6 +310,8 @@ void readOptions(
     int argc, char *argv[],
     const std::vector<pipeline::semantic_extension::SemanticExtensionProvider *> &semanticExtensionProviders,
     std::shared_ptr<spdlog::logger> logger) noexcept(false); // throw(EarlyReturnWithCode);
+
+Parser extractParser(cxxopts::ParseResult &raw, std::shared_ptr<spdlog::logger> logger);
 
 void flushPrinters(Options &);
 } // namespace sorbet::realmain::options

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -229,7 +229,7 @@ ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, c
 
             unique_ptr<parser::Node> parseTree;
             switch (parser) {
-                case options::Parser::SORBET:
+                case options::Parser::ORIGINAL:
                     parseTree = runParser(lgs, file, print, opts.traceLexer, opts.traceParser);
                     break;
                 case options::Parser::PRISM:

--- a/prism_benchmarks/memory/run_benchmarks.sh
+++ b/prism_benchmarks/memory/run_benchmarks.sh
@@ -34,7 +34,7 @@ if ! command -v gtime &> /dev/null; then
 fi
 
 output_file_name="$(date '+%Y-%m-%d')-$(git rev-parse --short HEAD).txt"
-parsers=("prism" "sorbet")
+parsers=("prism" "original")
 
 # ----- Run Benchmarks -----
 

--- a/prism_benchmarks/time/run_benchmarks.sh
+++ b/prism_benchmarks/time/run_benchmarks.sh
@@ -50,7 +50,7 @@ run_benchmark() {
   output_file="prism_benchmarks/time/data/$output_dir/${output_file_name}"
 
   hyperfine \
-    --warmup=10 --export-json="$output_file" --parameter-list parser sorbet,prism \
+    --warmup=10 --export-json="$output_file" --parameter-list parser original,prism \
     "bazel-bin/main/sorbet --parser={parser} $command" --ignore-failure
 }
 

--- a/test/pipeline_test.bzl
+++ b/test/pipeline_test.bzl
@@ -51,7 +51,7 @@ exp_test = rule(
         "_llvm_symbolizer": attr.label(
             default = "//test:llvm-symbolizer",
         ),
-        "parser": attr.string(default="sorbet"),
+        "parser": attr.string(default="original"),
     },
 )
 
@@ -114,7 +114,7 @@ _TEST_RUNNERS = {
     "PackagerTests": ":pipeline_test_runner",
 }
 
-def pipeline_tests(suite_name, all_paths, test_name_prefix, extra_files = [], tags = [], parser = "sorbet"):
+def pipeline_tests(suite_name, all_paths, test_name_prefix, extra_files = [], tags = [], parser = "original"):
     tests = {}  # test_name-> {"path": String, "prefix": String, "sentinel": String, "isPackage": bool}
 
     # The packager step needs folder-based steps since folder structure dictates package membership.

--- a/test/prism_location_test.sh
+++ b/test/prism_location_test.sh
@@ -23,7 +23,7 @@ sorbet_output_sorbet=$(mktemp)
 
 set +e  # Temporarily disable exit on error
 # Run Sorbet with default parser
-"$SORBET_BIN" --print=parse-tree-json-with-locs --parser=sorbet "$TEST_DIR/$TEST_FILE" > "$sorbet_output_sorbet" 2>/dev/null
+"$SORBET_BIN" --print=parse-tree-json-with-locs --parser=original "$TEST_DIR/$TEST_FILE" > "$sorbet_output_sorbet" 2>/dev/null
 # Run Sorbet with Prism parser
 "$SORBET_BIN" --print=parse-tree-json-with-locs --parser=prism "$TEST_DIR/$TEST_FILE" > "$sorbet_output_prism" 2>/dev/null
 set -e  # Re-enable exit on error


### PR DESCRIPTION
Fixes #415

Decided to rename `--parser sorbet` to `--parser original` because strictly speaking, [it's not Sorbet's parser](https://github.com/sorbet/sorbet/pull/8122#discussion_r1765457524). It's [typedruby](https://github.com/typedruby/typedruby), which is based on [whitequark](https://github.com/whitequark/parser). That's a mouthful, so "default" or "original" will do.