### PR TITLE
Handle integer literals prefixed with `~` (unary complement) consistently as a call to `~` instead of changing the literal to the complement

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1797,13 +1797,11 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     }
                 }
 
+                ExpressionPtr res = MK::Int(loc, val);
                 if (hasTilde) {
-                    core::LocOffsets adjustedLoc = dctx.ctx.locAt(loc).adjust(dctx.ctx, 1, 1).offsets();
-                    result = MK::Int(adjustedLoc, val);
-                    result = MK::Send0(loc, move(result), core::Names::tilde(), loc.copyEndWithZeroLength());
-                } else {
-                    result = MK::Int(loc, val);
+                    res = MK::Send0(loc, move(res), core::Names::unaryTilde(), loc.copyEndWithZeroLength());
                 }
+                result = std::move(res);
             },
             [&](parser::DString *dstring) {
                 ExpressionPtr res = desugarDString(dctx, loc, std::move(dstring->nodes));

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -47,6 +47,7 @@ NameDef names[] = {
     {"squareBracketsEq", "[]="},
     {"unaryPlus", "+@"},
     {"unaryMinus", "-@"},
+    {"unaryTilde", "~"},
     {"plus", "+"},
     {"minus", "-"},
     {"star", "*"},

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1,14 +1,18 @@
 #include "Translator.h"
 #include "Helpers.h"
 
+#include "absl/strings/str_replace.h"
 #include "ast/Helpers.h"
 #include "ast/Trees.h"
 #include "core/errors/desugar.h"
 
+<<<<<<< HEAD
 #include "absl/strings/str_replace.h"
 
-template class std::unique_ptr<sorbet::parser::Node>;
+    template class std::unique_ptr<sorbet::parser::Node>;
 
+=======
+>>>>>>> cecabdaee (Handle integer literals prefixed with ~ (unary complement) consistently as a call to `~` instead of changing the literal to the complement)
 using namespace std;
 
 namespace sorbet::parser::Prism {
@@ -322,6 +326,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
                 messageLoc = translateLoc(callNode->message_loc);
             }
 
+<<<<<<< HEAD
             // Handle `~[Integer]`, like `~42`
             // Unlike `-[Integer]`, Prism treats `~[Integer]` as a method call
             // But Sorbet's legacy parser treats both `~[Integer]` and `-[Integer]` as integer literals
@@ -331,6 +336,8 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
                 return make_unique<parser::Integer>(location, move(valueString));
             }
 
+=======
+>>>>>>> 1a248de11 (Handle integer literals prefixed with ~ (unary complement) consistently as a call to `~` instead of changing the literal to the complement)
             pm_node_t *prismBlock = callNode->block;
             NodeVec args;
             // PM_BLOCK_ARGUMENT_NODE models the `&b` in `a.map(&b)`,
@@ -799,13 +806,9 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
 
             int64_t val;
 
-            // complemented literals
-            bool hasTilde = valueString.find("~") != string::npos;
-            const string &withoutTilde = !hasTilde ? valueString : absl::StrReplaceAll(valueString, {{"~", ""}});
-
-            auto underscorePos = withoutTilde.find("_");
+            auto underscorePos = valueString.find("_");
             const string &withoutUnderscores =
-                (underscorePos == string::npos) ? withoutTilde : absl::StrReplaceAll(withoutTilde, {{"_", ""}});
+                (underscorePos == string::npos) ? valueString : absl::StrReplaceAll(valueString, {{"_", ""}});
 
             if (!absl::SimpleAtoi(withoutUnderscores, &val)) {
                 val = 0;
@@ -813,10 +816,14 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
                     e.setHeader("Unsupported integer literal: `{}`", valueString);
                 }
             }
+<<<<<<< HEAD
 
             // Should desugar to Send node (like `42.~()`)
             // ExpressionPtr expr = MK::Int(location, hasTilde ? ~val : val);
             ExpressionPtr expr;
+=======
+            ExpressionPtr expr = MK::Int(location, val);
+>>>>>>> 1a248de11 (Handle integer literals prefixed with ~ (unary complement) consistently as a call to `~` instead of changing the literal to the complement)
 
             if (hasTilde) {
                 auto loc = location.copyEndWithZeroLength();

--- a/test/testdata/parser/complement_literal.rb.parse-tree.exp
+++ b/test/testdata/parser/complement_literal.rb.parse-tree.exp
@@ -1,7 +1,12 @@
 Begin {
   stmts = [
-    Integer {
-      val = "~10"
+    Send {
+      receiver = Integer {
+        val = "10"
+      }
+      method = <U ~>
+      args = [
+      ]
     }
     Assign {
       lhs = LVarLhs {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Related to: https://github.com/Shopify/sorbet/pull/577

Will need to be refactored to reflect changes in upstream: https://github.com/sorbet/sorbet/pull/9032

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
