### PR TITLE
Generate `desugar_tree_raw_with_locs` expectation files for Prism parser & test against them on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,5 @@ jobs:
         run: ./bazel test //test:prism_location_tests --config=dbg --test_output=errors
       - name: Run corpus tests
         run: ./bazel test //test:test_corpus_prism --config=dbg --test_output=errors
+      - name: Run prism desugar tests
+        run: ./bazel test //test:prism_desugar_tests --config=dbg --test_output=errors

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -84,6 +84,16 @@ string ExpressionPtr::showRaw(const core::GlobalState &gs, int tabs) const {
 #undef SHOW_RAW
 }
 
+string ExpressionPtr::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs) const {
+    auto *ptr = get();
+
+    ENFORCE(ptr != nullptr);
+
+#define SHOW_RAW_WITH_LOCS(name) return reinterpret_cast<name *>(ptr)->showRawWithLocs(gs, file, tabs);
+    GENERATE_TAG_SWITCH(tag(), SHOW_RAW_WITH_LOCS)
+#undef SHOW_RAW_WITH_LOCS
+}
+
 namespace {
 template <typename T> struct LocGetter {
     static core::LocOffsets loc(void *ptr) {
@@ -1025,6 +1035,10 @@ string Self::showRaw(const core::GlobalState &gs, int tabs) const {
     return "Self";
 }
 
+string Self::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs) const {
+    return string(nodeName()) + "{ loc = " + core::Loc(file, this->loc).filePosToString(gs, true) + " }";
+}
+
 const ast::Block *Send::block() const {
     if (hasBlock()) {
         auto block = ast::cast_tree<ast::Block>(this->args.back());
@@ -1515,6 +1529,491 @@ vector<ParsedFile> &ParsedFilesOrCancelled::result() {
         return trees.value();
     }
     Exception::raise("Attempted to retrieve result of an AST pass that did not complete.");
+}
+
+// showRawWithLocs implementations TODO: Code isn't vetted properly
+
+string ClassDef::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs) const {
+    fmt::memory_buffer buf;
+    fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "loc = {}\n", core::Loc(file, this->loc).filePosToString(gs, true));
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "kind = {}\n", kind == ClassDef::Kind::Module ? "module" : "class");
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "name = {}\n", name.showRawWithLocs(gs, file, tabs + 1));
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "symbol = {}\n", this->symbol.dataAllowingNone(gs)->name.showRaw(gs));
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "ancestors = [");
+    bool first = true;
+    for (auto &a : this->ancestors) {
+        if (!first) {
+            fmt::format_to(std::back_inserter(buf), ", ");
+        }
+        first = false;
+        fmt::format_to(std::back_inserter(buf), "{}", a.showRawWithLocs(gs, file, tabs + 2));
+    }
+    fmt::format_to(std::back_inserter(buf), "]\n");
+
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "rhs = [\n");
+
+    for (auto &a : this->rhs) {
+        printTabs(buf, tabs + 2);
+        fmt::format_to(std::back_inserter(buf), "{}\n", a.showRawWithLocs(gs, file, tabs + 2));
+        if (&a != &this->rhs.back()) {
+            fmt::format_to(std::back_inserter(buf), "{}", '\n');
+        }
+    }
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "]\n");
+    printTabs(buf, tabs);
+    fmt::format_to(std::back_inserter(buf), "}}");
+    return fmt::to_string(buf);
+}
+
+string MethodDef::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs) const {
+    fmt::memory_buffer buf;
+    fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "loc = {}\n", core::Loc(file, this->loc).filePosToString(gs, true));
+    printTabs(buf, tabs + 1);
+
+    auto stringifiedFlags = vector<string>{};
+    if (this->flags.isSelfMethod) {
+        stringifiedFlags.emplace_back("self");
+    }
+    if (this->flags.isRewriterSynthesized) {
+        stringifiedFlags.emplace_back("rewriterSynthesized");
+    }
+    fmt::format_to(std::back_inserter(buf), "flags = {{{}}}\n", fmt::join(stringifiedFlags, ", "));
+
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "name = {}<{}>\n", name.showRaw(gs),
+                   this->symbol.data(gs)->name.showRaw(gs));
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "args = [");
+    bool first = true;
+    if (this->symbol == core::Symbols::todoMethod()) {
+        for (auto &a : this->args) {
+            if (!first) {
+                fmt::format_to(std::back_inserter(buf), ", ");
+            }
+            first = false;
+            fmt::format_to(std::back_inserter(buf), "{}", a.showRawWithLocs(gs, file, tabs + 2));
+        }
+    } else {
+        for (auto &a : this->args) {
+            if (!first) {
+                fmt::format_to(std::back_inserter(buf), ", ");
+            }
+            first = false;
+            fmt::format_to(std::back_inserter(buf), "{}", a.showRawWithLocs(gs, file, tabs + 2));
+        }
+    }
+    fmt::format_to(std::back_inserter(buf), "]\n");
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "rhs = {}\n", this->rhs.showRawWithLocs(gs, file, tabs + 1));
+    printTabs(buf, tabs);
+    fmt::format_to(std::back_inserter(buf), "}}");
+    return fmt::to_string(buf);
+}
+
+string If::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs) const {
+    fmt::memory_buffer buf;
+
+    fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "loc = {}\n", core::Loc(file, this->loc).filePosToString(gs, true));
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "cond = {}\n", this->cond.showRawWithLocs(gs, file, tabs + 1));
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "thenp = {}\n", this->thenp.showRawWithLocs(gs, file, tabs + 1));
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "elsep = {}\n", this->elsep.showRawWithLocs(gs, file, tabs + 1));
+    printTabs(buf, tabs);
+    fmt::format_to(std::back_inserter(buf), "}}");
+    return fmt::to_string(buf);
+}
+
+string While::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs) const {
+    fmt::memory_buffer buf;
+
+    fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "loc = {}\n", core::Loc(file, this->loc).filePosToString(gs, true));
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "cond = {}\n", this->cond.showRawWithLocs(gs, file, tabs + 1));
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "body = {}\n", this->body.showRawWithLocs(gs, file, tabs + 1));
+    printTabs(buf, tabs);
+    fmt::format_to(std::back_inserter(buf), "}}");
+    return fmt::to_string(buf);
+}
+
+string Assign::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs) const {
+    fmt::memory_buffer buf;
+
+    fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "loc = {}\n", core::Loc(file, this->loc).filePosToString(gs, true));
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "lhs = {}\n", this->lhs.showRawWithLocs(gs, file, tabs + 1));
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "rhs = {}\n", this->rhs.showRawWithLocs(gs, file, tabs + 1));
+    printTabs(buf, tabs);
+    fmt::format_to(std::back_inserter(buf), "}}");
+    return fmt::to_string(buf);
+}
+
+string EmptyTree::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs) const {
+    return string(nodeName()) + "{ loc = " + core::Loc(file, this->loc).filePosToString(gs, true) + " }";
+}
+
+string ConstantLit::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs) const {
+    fmt::memory_buffer buf;
+
+    fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "loc = {}\n", core::Loc(file, this->loc()).filePosToString(gs, true));
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "symbol = ({} {})\n", this->symbol().showKind(gs),
+                   this->symbol().showFullName(gs));
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "orig = {}\n",
+                   this->original() ? this->original()->showRawWithLocs(gs, file, tabs + 1) : "nullptr");
+    // If resolutionScopes isn't null, it should not be empty.
+    ENFORCE(resolutionScopes() == nullptr || !resolutionScopes()->empty());
+    if (resolutionScopes() != nullptr && !resolutionScopes()->empty()) {
+        printTabs(buf, tabs + 1);
+        fmt::format_to(std::back_inserter(buf), "resolutionScopes = [{}]\n",
+                       fmt::map_join(*this->resolutionScopes(), ", ", [&](auto sym) { return sym.showFullName(gs); }));
+    }
+    printTabs(buf, tabs);
+
+    fmt::format_to(std::back_inserter(buf), "}}");
+    return fmt::to_string(buf);
+}
+
+string UnresolvedIdent::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs) const {
+    fmt::memory_buffer buf;
+    fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "loc = {}\n", core::Loc(file, this->loc).filePosToString(gs, true));
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "kind = ");
+    switch (this->kind) {
+        case Kind::Local:
+            fmt::format_to(std::back_inserter(buf), "Local");
+            break;
+        case Kind::Instance:
+            fmt::format_to(std::back_inserter(buf), "Instance");
+            break;
+        case Kind::Class:
+            fmt::format_to(std::back_inserter(buf), "Class");
+            break;
+        case Kind::Global:
+            fmt::format_to(std::back_inserter(buf), "Global");
+            break;
+    }
+    fmt::format_to(std::back_inserter(buf), "{}", '\n');
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "name = {}\n", this->name.showRaw(gs));
+    printTabs(buf, tabs);
+    fmt::format_to(std::back_inserter(buf), "}}");
+
+    return fmt::to_string(buf);
+}
+
+string Send::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs) const {
+    fmt::memory_buffer buf;
+    fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "loc = {}\n", core::Loc(file, this->loc).filePosToString(gs, true));
+
+    vector<string> stringifiedFlags;
+    if (this->flags.isPrivateOk) {
+        stringifiedFlags.emplace_back("privateOk");
+    }
+    if (this->flags.isRewriterSynthesized) {
+        stringifiedFlags.emplace_back("rewriterSynthesized");
+    }
+
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "flags = {{{}}}\n", fmt::join(stringifiedFlags, ", "));
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "recv = {}\n", this->recv.showRawWithLocs(gs, file, tabs + 1));
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "fun = {}\n", this->fun.showRaw(gs));
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "block = ");
+    if (this->hasBlock()) {
+        fmt::format_to(std::back_inserter(buf), "{}\n", this->block()->showRawWithLocs(gs, file, tabs + 1));
+    } else {
+        fmt::format_to(std::back_inserter(buf), "nullptr\n");
+    }
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "pos_args = {}\n", this->numPosArgs_);
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "args = [\n");
+    for (auto &a : args) {
+        if (this->hasBlock() && a == args.back()) {
+            continue;
+        }
+        printTabs(buf, tabs + 2);
+        fmt::format_to(std::back_inserter(buf), "{}\n", a.showRawWithLocs(gs, file, tabs + 2));
+    }
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "]\n");
+    printTabs(buf, tabs);
+    fmt::format_to(std::back_inserter(buf), "}}");
+
+    return fmt::to_string(buf);
+}
+
+string Literal::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs) const {
+    return string(nodeName()) + "{ loc = " + core::Loc(file, this->loc).filePosToString(gs, true) +
+           ", value = " + this->toStringWithTabs(gs, 0) + " }";
+}
+
+string UnresolvedConstantLit::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs) const {
+    fmt::memory_buffer buf;
+    fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "loc = {}\n", core::Loc(file, this->loc).filePosToString(gs, true));
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "cnst = {}\n", this->cnst.showRaw(gs));
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "scope = {}\n", this->scope.showRawWithLocs(gs, file, tabs + 1));
+    printTabs(buf, tabs);
+    fmt::format_to(std::back_inserter(buf), "}}");
+    return fmt::to_string(buf);
+}
+
+string Block::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs) const {
+    fmt::memory_buffer buf;
+    fmt::format_to(std::back_inserter(buf), "{} {{\n", nodeName());
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "loc = {}\n", core::Loc(file, this->loc).filePosToString(gs, true));
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "args = [\n");
+    for (auto &a : this->args) {
+        printTabs(buf, tabs + 2);
+        fmt::format_to(std::back_inserter(buf), "{}\n", a.showRawWithLocs(gs, file, tabs + 2));
+    }
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "]\n");
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "body = {}\n", this->body.showRawWithLocs(gs, file, tabs + 1));
+    printTabs(buf, tabs);
+    fmt::format_to(std::back_inserter(buf), "}}");
+    return fmt::to_string(buf);
+}
+
+string ZSuperArgs::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs) const {
+    return string(nodeName()) + "{ loc = " + core::Loc(file, this->loc).filePosToString(gs, true) + " }";
+}
+
+string RuntimeMethodDefinition::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs) const {
+    return string(nodeName()) + "{ loc = " + core::Loc(file, this->loc).filePosToString(gs, true) + ", " +
+           this->toStringWithTabs(gs, tabs) + " }";
+}
+
+string InsSeq::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs) const {
+    fmt::memory_buffer buf;
+    fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "loc = {}\n", core::Loc(file, this->loc).filePosToString(gs, true));
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "stats = [\n");
+    for (auto &a : this->stats) {
+        printTabs(buf, tabs + 2);
+        fmt::format_to(std::back_inserter(buf), "{}\n", a.showRawWithLocs(gs, file, tabs + 2));
+    }
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "],\n");
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "expr = {}\n", expr.showRawWithLocs(gs, file, tabs + 1));
+    printTabs(buf, tabs);
+    fmt::format_to(std::back_inserter(buf), "}}");
+    return fmt::to_string(buf);
+}
+
+string Array::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs) const {
+    fmt::memory_buffer buf;
+    fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "loc = {}\n", core::Loc(file, this->loc).filePosToString(gs, true));
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "elems = [\n");
+    for (auto &a : elems) {
+        printTabs(buf, tabs + 2);
+        fmt::format_to(std::back_inserter(buf), "{}\n", a.showRawWithLocs(gs, file, tabs + 2));
+    }
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "]\n");
+    printTabs(buf, tabs);
+    fmt::format_to(std::back_inserter(buf), "}}");
+    return fmt::to_string(buf);
+}
+
+string Next::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs) const {
+    return string(nodeName()) + "{ loc = " + core::Loc(file, this->loc).filePosToString(gs, true) +
+           ", expr = " + this->expr.showRawWithLocs(gs, file, tabs + 1) + " }";
+}
+
+string RescueCase::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs) const {
+    fmt::memory_buffer buf;
+    fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "loc = {}\n", core::Loc(file, this->loc).filePosToString(gs, true));
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "exceptions = [\n");
+    for (auto &a : exceptions) {
+        printTabs(buf, tabs + 2);
+        fmt::format_to(std::back_inserter(buf), "{}\n", a.showRawWithLocs(gs, file, tabs + 2));
+    }
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "]\n");
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "var = {}\n", this->var.showRawWithLocs(gs, file, tabs + 1));
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "body = {}\n", this->body.showRawWithLocs(gs, file, tabs + 1));
+    printTabs(buf, tabs);
+    fmt::format_to(std::back_inserter(buf), "}}");
+    return fmt::to_string(buf);
+}
+
+string ShadowArg::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs) const {
+    return string(nodeName()) + "{ loc = " + core::Loc(file, this->loc).filePosToString(gs, true) +
+           ", expr = " + expr.showRawWithLocs(gs, file, tabs) + " }";
+}
+
+string Break::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs) const {
+    return string(nodeName()) + "{ loc = " + core::Loc(file, this->loc).filePosToString(gs, true) +
+           ", expr = " + this->expr.showRawWithLocs(gs, file, tabs + 1) + " }";
+}
+
+string Hash::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs) const {
+    fmt::memory_buffer buf;
+    fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "loc = {}\n", core::Loc(file, this->loc).filePosToString(gs, true));
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "pairs = [\n");
+    int i = -1;
+    for (auto &key : keys) {
+        i++;
+        auto &value = values[i];
+        printTabs(buf, tabs + 2);
+        fmt::format_to(std::back_inserter(buf), "[\n");
+        printTabs(buf, tabs + 3);
+        fmt::format_to(std::back_inserter(buf), "key = {}\n", key.showRawWithLocs(gs, file, tabs + 3));
+        printTabs(buf, tabs + 3);
+        fmt::format_to(std::back_inserter(buf), "value = {}\n", value.showRawWithLocs(gs, file, tabs + 3));
+        printTabs(buf, tabs + 2);
+        fmt::format_to(std::back_inserter(buf), "]\n");
+    }
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "]\n");
+    printTabs(buf, tabs);
+    fmt::format_to(std::back_inserter(buf), "}}");
+    return fmt::to_string(buf);
+}
+
+string Cast::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs) const {
+    fmt::memory_buffer buf;
+    fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "loc = {}\n", core::Loc(file, this->loc).filePosToString(gs, true));
+    printTabs(buf, tabs + 2);
+    fmt::format_to(std::back_inserter(buf), "cast = {},\n", this->cast.showRaw(gs));
+    printTabs(buf, tabs + 2);
+    fmt::format_to(std::back_inserter(buf), "arg = {}\n", this->arg.showRawWithLocs(gs, file, tabs + 2));
+    printTabs(buf, tabs + 2);
+    fmt::format_to(std::back_inserter(buf), "type = {},\n", this->type.showWithMoreInfo(gs));
+    printTabs(buf, tabs + 2);
+    fmt::format_to(std::back_inserter(buf), "typeExpr = {},\n", this->typeExpr.showRawWithLocs(gs, file, tabs + 2));
+    printTabs(buf, tabs);
+    fmt::format_to(std::back_inserter(buf), "}}\n");
+    return fmt::to_string(buf);
+}
+
+string BlockArg::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs) const {
+    return string(nodeName()) + "{ loc = " + core::Loc(file, this->loc).filePosToString(gs, true) +
+           ", expr = " + expr.showRawWithLocs(gs, file, tabs) + " }";
+}
+
+string Retry::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs) const {
+    return string(nodeName()) + "{ loc = " + core::Loc(file, this->loc).filePosToString(gs, true) + " }";
+}
+
+string KeywordArg::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs) const {
+    return string(nodeName()) + "{ loc = " + core::Loc(file, this->loc).filePosToString(gs, true) +
+           ", expr = " + expr.showRawWithLocs(gs, file, tabs) + " }";
+}
+
+string Return::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs) const {
+    return string(nodeName()) + "{ loc = " + core::Loc(file, this->loc).filePosToString(gs, true) +
+           ", expr = " + this->expr.showRawWithLocs(gs, file, tabs + 1) + " }";
+}
+
+string Local::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs) const {
+    fmt::memory_buffer buf;
+    fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "loc = {}\n", core::Loc(file, this->loc).filePosToString(gs, true));
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "localVariable = {}\n", this->localVariable.showRaw(gs));
+    printTabs(buf, tabs);
+    fmt::format_to(std::back_inserter(buf), "}}");
+    return fmt::to_string(buf);
+}
+
+string Rescue::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs) const {
+    fmt::memory_buffer buf;
+    fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "loc = {}\n", core::Loc(file, this->loc).filePosToString(gs, true));
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "body = {}\n", this->body.showRawWithLocs(gs, file, tabs + 1));
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "rescueCases = [\n");
+    for (auto &a : rescueCases) {
+        printTabs(buf, tabs + 2);
+        fmt::format_to(std::back_inserter(buf), "{}\n", a.showRawWithLocs(gs, file, tabs + 2));
+    }
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "]\n");
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "else = {}\n", this->else_.showRawWithLocs(gs, file, tabs + 1));
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "ensure = {}\n", this->ensure.showRawWithLocs(gs, file, tabs + 1));
+    printTabs(buf, tabs);
+    fmt::format_to(std::back_inserter(buf), "}}");
+    return fmt::to_string(buf);
+}
+
+string RestArg::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs) const {
+    return string(nodeName()) + "{ loc = " + core::Loc(file, this->loc).filePosToString(gs, true) +
+           ", expr = " + expr.showRawWithLocs(gs, file, tabs) + " }";
+}
+
+string OptionalArg::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs) const {
+    fmt::memory_buffer buf;
+    fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "loc = {}\n", core::Loc(file, this->loc).filePosToString(gs, true));
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "expr = {}\n", expr.showRawWithLocs(gs, file, tabs + 1));
+    if (default_) {
+        printTabs(buf, tabs + 1);
+        fmt::format_to(std::back_inserter(buf), "default_ = {}\n", default_.showRawWithLocs(gs, file, tabs + 1));
+    }
+    printTabs(buf, tabs);
+    fmt::format_to(std::back_inserter(buf), "}}");
+    return fmt::to_string(buf);
 }
 
 } // namespace sorbet::ast

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -232,6 +232,8 @@ public:
 
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
 
+    std::string showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0) const;
+
     bool isSelfReference() const;
 
     void _sanityCheck() const;
@@ -419,6 +421,7 @@ public:
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0) const;
     std::string_view nodeName() const;
 
     void _sanityCheck();
@@ -449,6 +452,7 @@ public:
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0) const;
     std::string_view nodeName() const;
 
     void _sanityCheck();
@@ -470,6 +474,7 @@ public:
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0) const;
     std::string_view nodeName() const;
 
     void _sanityCheck();
@@ -490,6 +495,7 @@ public:
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0) const;
     std::string_view nodeName() const;
 
     void _sanityCheck();
@@ -509,6 +515,7 @@ public:
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0) const;
     std::string_view nodeName() const;
 
     void _sanityCheck();
@@ -526,6 +533,7 @@ public:
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0) const;
     std::string_view nodeName() const;
 
     void _sanityCheck();
@@ -545,6 +553,7 @@ public:
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0) const;
     std::string_view nodeName() const;
 
     void _sanityCheck();
@@ -564,6 +573,7 @@ public:
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0) const;
     std::string_view nodeName() const;
 
     void _sanityCheck();
@@ -591,6 +601,7 @@ public:
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0) const;
     std::string_view nodeName() const;
 
     void _sanityCheck();
@@ -617,6 +628,7 @@ public:
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0) const;
     std::string_view nodeName() const;
 
     void _sanityCheck();
@@ -636,6 +648,7 @@ public:
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0) const;
     std::string_view nodeName() const;
 
     void _sanityCheck();
@@ -662,6 +675,7 @@ public:
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0) const;
     std::string_view nodeName() const;
 
     void _sanityCheck();
@@ -681,6 +695,7 @@ public:
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0) const;
     std::string_view nodeName() const;
 
     void _sanityCheck();
@@ -700,6 +715,7 @@ public:
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0) const;
     std::string_view nodeName() const;
 
     void _sanityCheck();
@@ -720,6 +736,7 @@ public:
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0) const;
     std::string_view nodeName() const;
 
     void _sanityCheck();
@@ -739,6 +756,7 @@ public:
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0) const;
     std::string_view nodeName() const;
 
     void _sanityCheck();
@@ -758,6 +776,7 @@ public:
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0) const;
     std::string_view nodeName() const;
 
     void _sanityCheck();
@@ -778,6 +797,7 @@ public:
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0) const;
     std::string_view nodeName() const;
 
     void _sanityCheck();
@@ -870,6 +890,7 @@ public:
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0) const;
     std::string_view nodeName() const;
 
     // Add the given positional argument as the last positional argument.
@@ -1047,6 +1068,7 @@ public:
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0) const;
     std::string_view nodeName() const;
 
     void _sanityCheck();
@@ -1070,6 +1092,7 @@ public:
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0) const;
     std::string_view nodeName() const;
 
     void _sanityCheck();
@@ -1092,6 +1115,7 @@ public:
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0) const;
     std::string_view nodeName() const;
 
     void _sanityCheck();
@@ -1111,6 +1135,7 @@ public:
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0) const;
     std::string_view nodeName() const;
     bool isString() const;
     bool isSymbol() const;
@@ -1140,6 +1165,7 @@ public:
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0) const;
     std::string_view nodeName() const;
 
     void _sanityCheck();
@@ -1358,6 +1384,7 @@ public:
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0) const;
     std::string_view nodeName() const;
     std::optional<std::pair<core::SymbolRef, std::vector<core::NameRef>>> fullUnresolvedPath(core::Context ctx) const;
 
@@ -1410,6 +1437,7 @@ public:
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0) const;
     std::string_view nodeName() const;
 
     void _sanityCheck();
@@ -1430,6 +1458,7 @@ public:
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0) const;
     std::string_view nodeName() const;
     void _sanityCheck();
 };
@@ -1454,6 +1483,7 @@ public:
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0) const;
     std::string_view nodeName() const;
 
     void _sanityCheck();
@@ -1475,6 +1505,7 @@ public:
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0) const;
     std::string_view nodeName() const;
 
     void _sanityCheck();
@@ -1492,6 +1523,7 @@ public:
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0) const;
     std::string_view nodeName() const;
 
     void _sanityCheck();
@@ -1509,6 +1541,7 @@ public:
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0) const;
     std::string_view nodeName() const;
 
     void _sanityCheck();

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2086,6 +2086,7 @@ void GlobalState::copyOptions(const core::GlobalState &other) {
     this->cacheSensitiveOptions = other.cacheSensitiveOptions;
     this->ruby3KeywordArgs = other.ruby3KeywordArgs;
     this->parseWithPrism = other.parseWithPrism;
+    this->desugarInPrismTranslator = other.desugarInPrismTranslator;
     this->suppressPayloadSuperclassRedefinitionFor = other.suppressPayloadSuperclassRedefinitionFor;
     this->trackUntyped = other.trackUntyped;
     this->highlightUntypedDiagnosticSeverity = other.highlightUntypedDiagnosticSeverity;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -340,6 +340,10 @@ public:
     // If 'true', use the Prism parser.
     bool parseWithPrism = false;
 
+    // If 'true', the Prism Translator will desugar the Prism AST directly into ExpressPtrs used by `PrismDesugar.cc`,
+    // else the Prism Translator will only translate the parse tree, which will be desugared by the usual `Desugar.cc`.
+    bool desugarInPrismTranslator = false;
+
     // Some options change the behavior of things that might be cached, including ASTs, the file
     // table, the name table, the symbol table, etc.
     //

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -182,6 +182,7 @@ struct Options {
     bool noErrorSections = false;
     /** Prefix to remove from all printed paths. */
     std::string pathPrefix;
+    bool desugarInPrismTranslator = false;
 
     // Options which affect the contents of the `--cache-dir`.
     // If these options change, the cache needs to be invalidated.

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -433,16 +433,9 @@ ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, c
                 }
             }
 
-            switch (parser) {
-                case options::Parser::ORIGINAL: {
-                    tree = runDesugar(lgs, file, move(parseTree), print);
-                    break;
-                }
-                case options::Parser::PRISM: {
-                    tree = runPrismDesugar(lgs, file, move(parseTree), print);
-                    break;
-                }
-            }
+            tree = opts.desugarInPrismTranslator ? runPrismDesugar(lgs, file, move(parseTree), print)
+                                                 : runDesugar(lgs, file, move(parseTree), print);
+
             if (opts.stopAfterPhase == options::Phase::DESUGARER) {
                 return emptyParsedFile(file);
             }

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -318,6 +318,9 @@ ast::ExpressionPtr runDesugar(core::GlobalState &gs, core::FileRef file, unique_
     if (print.DesugarTreeRaw.enabled) {
         print.DesugarTreeRaw.fmt("{}\n", ast.showRaw(gs));
     }
+    if (print.DesugarTreeRawWithLocs.enabled) {
+        print.DesugarTreeRawWithLocs.fmt("{}\n", ast.showRawWithLocs(gs, file));
+    }
     return ast;
 }
 
@@ -335,6 +338,9 @@ ast::ExpressionPtr runPrismDesugar(core::GlobalState &gs, core::FileRef file, un
     }
     if (print.DesugarTreeRaw.enabled) {
         print.DesugarTreeRaw.fmt("{}\n", ast.showRaw(gs));
+    }
+    if (print.DesugarTreeRawWithLocs.enabled) {
+        print.DesugarTreeRawWithLocs.fmt("{}\n", ast.showRawWithLocs(gs, file));
     }
     return ast;
 }

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -448,6 +448,7 @@ int realmain(int argc, char *argv[]) {
     unique_ptr<core::GlobalState> gs =
         make_unique<core::GlobalState>(make_shared<core::ErrorQueue>(*typeErrorsConsole, *logger, errorFlusher));
     gs->parseWithPrism = opts.parser == options::Parser::PRISM;
+    gs->desugarInPrismTranslator = opts.desugarInPrismTranslator;
 
     logger->trace("building initial global state");
 

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -25,9 +25,13 @@ template <typename... Rest> bool hasExpr(const std::unique_ptr<parser::Node> &fi
 
 // Allocates a new `NodeWithExpr` with a pre-computed `ExpressionPtr` AST.
 template <typename SorbetNode, typename... TArgs>
-unique_ptr<NodeWithExpr> make_node_with_expr(ast::ExpressionPtr desugaredExpr, TArgs &&...args) {
+std::unique_ptr<parser::Node> Translator::make_node_with_expr(ast::ExpressionPtr desugaredExpr, TArgs &&...args) {
     auto whiteQuarkNode = make_unique<SorbetNode>(std::forward<TArgs>(args)...);
-    return make_unique<NodeWithExpr>(move(whiteQuarkNode), move(desugaredExpr));
+    if (this->ctx.state.desugarInPrismTranslator) {
+        return make_unique<NodeWithExpr>(move(whiteQuarkNode), move(desugaredExpr));
+    } else {
+        return move(whiteQuarkNode);
+    }
 }
 
 // Indicates that a particular code path should never be reached, with an explanation of why.

--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -101,6 +101,10 @@ private:
 
     // Context management helpers. These return a copy of `this` with some change to the context.
     Translator enterMethodDef();
+
+    // Helper function for creating nodes with cached expressions
+    template <typename SorbetNode, typename... TArgs>
+    std::unique_ptr<parser::Node> make_node_with_expr(ast::ExpressionPtr desugaredExpr, TArgs &&...args);
 };
 
 } // namespace sorbet::parser::Prism

--- a/test/BUILD
+++ b/test/BUILD
@@ -143,7 +143,13 @@ load("//test:prism_desugar_test.bzl", "prism_desugar_test_suite")
 # Run the macro
 prism_desugar_test_suite(
     name = "prism_desugar_tests",
-    source_files = glob(["testdata/desugar/**/*.rb"]),
+    source_files = glob(
+        ["testdata/desugar/**/*.rb"],
+        exclude = [
+            # Prism desugar crashes with "Unimplemented Parser Node: Mlhs"
+            "testdata/desugar/pattern_matching_hash.rb",
+        ],
+    ),
 )
 
 # Create a test suite to run all the prism desugar tests

--- a/test/BUILD
+++ b/test/BUILD
@@ -137,6 +137,21 @@ test_suite(
     tags = ["prism_location_test"],
 )
 
+# Load the macro that checks desugar output with and without prism desugaring
+load("//test:prism_desugar_test.bzl", "prism_desugar_test_suite")
+
+# Run the macro
+prism_desugar_test_suite(
+    name = "prism_desugar_tests",
+    source_files = glob(["testdata/desugar/**/*.rb"]),
+)
+
+# Create a test suite to run all the prism desugar tests
+test_suite(
+    name = "prism_desugar_tests",
+    tags = ["prism_desugar_test"],
+)
+
 cc_test(
     name = "hello-test",
     size = "small",

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -269,21 +269,13 @@ vector<ast::ParsedFile> index(core::GlobalState &gs, absl::Span<core::FileRef> f
 
         // Desugarer
         ast::ParsedFile desugared;
-        switch (parser) {
-            case realmain::options::Parser::ORIGINAL: {
-                core::UnfreezeNameTable nameTableAccess(gs); // enters original strings
+        {
+            core::UnfreezeNameTable nameTableAccess(gs); // enters original strings
+            core::MutableContext ctx(gs, core::Symbols::root(), file);
 
-                core::MutableContext ctx(gs, core::Symbols::root(), file);
-                desugared = testSerialize(gs, ast::ParsedFile{ast::desugar::node2Tree(ctx, move(nodes)), file});
-                break;
-            }
-            case realmain::options::Parser::PRISM: {
-                core::UnfreezeNameTable nameTableAccess(gs); // enters original strings
-
-                core::MutableContext ctx(gs, core::Symbols::root(), file);
-                desugared = testSerialize(gs, ast::ParsedFile{ast::prismDesugar::node2Tree(ctx, move(nodes)), file});
-                break;
-            }
+            auto ast = gs.desugarInPrismTranslator ? ast::prismDesugar::node2Tree(ctx, move(nodes))
+                                                   : ast::desugar::node2Tree(ctx, move(nodes));
+            desugared = testSerialize(gs, ast::ParsedFile{move(ast), file});
         }
 
         handler.addObserved(gs, "desugar-tree", [&]() { return desugared.tree.toString(gs); });
@@ -731,17 +723,9 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 
         handler.addObserved(*gs, "rbs-rewrite-tree", [&]() { return nodes->toString(*gs); });
 
-        ast::ParsedFile file;
-        switch (parser) {
-            case realmain::options::Parser::ORIGINAL: {
-                file = testSerialize(*gs, ast::ParsedFile{ast::desugar::node2Tree(ctx, move(nodes)), f.file});
-                break;
-            }
-            case realmain::options::Parser::PRISM: {
-                file = testSerialize(*gs, ast::ParsedFile{ast::prismDesugar::node2Tree(ctx, move(nodes)), f.file});
-                break;
-            }
-        }
+        auto ast = gs->desugarInPrismTranslator ? ast::prismDesugar::node2Tree(ctx, move(nodes))
+                                                : ast::desugar::node2Tree(ctx, move(nodes));
+        ast::ParsedFile file = testSerialize(*gs, ast::ParsedFile{move(ast), f.file});
 
         handler.addObserved(*gs, "desguar-tree", [&]() { return file.tree.toString(*gs); });
         handler.addObserved(*gs, "desugar-tree-raw", [&]() { return file.tree.showRaw(*gs); });

--- a/test/prism_desugar_test.bzl
+++ b/test/prism_desugar_test.bzl
@@ -1,0 +1,18 @@
+def prism_desugar_test_suite(name, source_files):
+    for source_file in source_files:
+        # Extract relative path for test naming
+        # testdata/desugar/foo/bar.rb -> foo_bar_prism_desugar_test
+        relative_path = source_file.replace("testdata/desugar/", "").replace(".rb", "")
+        test_name = relative_path.replace("/", "_") + "_prism_desugar_test"
+        
+        native.sh_test(
+            name = test_name,
+            srcs = ["prism_desugar_test.sh"],
+            args = [source_file],
+            tags = ["prism_desugar_test"],
+            data = [
+                "//main:sorbet",
+                "@bazel_tools//tools/bash/runfiles",
+                source_file,
+            ],
+        )

--- a/test/prism_desugar_test.sh
+++ b/test/prism_desugar_test.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Set up the runfiles
+# shellcheck disable=SC1090
+source "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+if [[ ! -d "${RUNFILES_DIR:-/dev/null}" ]]; then
+    echo >&2 "ERROR: could not find runfiles directory"
+    exit 1
+fi
+
+# Locate the Sorbet binary
+SORBET_BIN="$(rlocation com_stripe_ruby_typer/main/sorbet)"
+TEST_DIR="$(rlocation com_stripe_ruby_typer/test)"
+
+# The source file is passed as an argument
+SOURCE_FILE="$1"
+
+# Temporary files to hold sorbet outputs
+normal_output=$(mktemp)
+disabled_output=$(mktemp)
+
+# Run Sorbet with prism parser (normal desugaring)
+set +e # Temporarily disable exit on error
+SORBET_SILENCE_DEV_MESSAGE=1 "$SORBET_BIN" --quiet --no-error-count --print=desugar-tree-raw-with-locs --parser=prism "$TEST_DIR/$SOURCE_FILE" > "$normal_output" 2>/dev/null
+normal_exit_code=$?
+set -e # Re-enable exit on error
+
+# Run Sorbet with prism parser and disabled desugaring
+set +e # Temporarily disable exit on error
+SORBET_SILENCE_DEV_MESSAGE=1 "$SORBET_BIN" --quiet --no-error-count --print=desugar-tree-raw-with-locs --parser=prism --disable-prism-desugaring "$TEST_DIR/$SOURCE_FILE" > "$disabled_output" 2>/dev/null
+disabled_exit_code=$?
+set -e # Re-enable exit on error
+
+# Check if both sorbet runs were successful
+if [[ $normal_exit_code -ne 0 ]]; then
+    echo "ERROR: Sorbet failed to process $SOURCE_FILE with normal prism desugaring"
+    rm "$normal_output" "$disabled_output"
+    exit 1
+fi
+
+if [[ $disabled_exit_code -ne 0 ]]; then
+    echo "ERROR: Sorbet failed to process $SOURCE_FILE with disabled prism desugaring"
+    rm "$normal_output" "$disabled_output"
+    exit 1
+fi
+
+# Compare outputs - test passes if they're identical
+if ! diff -q "$normal_output" "$disabled_output" >/dev/null 2>&1; then
+    echo "Test failed for $SOURCE_FILE"
+    echo "Output differs between normal prism desugaring and disabled prism desugaring"
+    echo "Differences:"
+    diff -u "$normal_output" "$disabled_output"
+    rm "$normal_output" "$disabled_output"
+    exit 1
+fi
+
+# Clean up temporary files
+rm "$normal_output" "$disabled_output"
+echo "Test passed for $SOURCE_FILE" 


### PR DESCRIPTION
Part of https://github.com/Shopify/sorbet/issues/572 alongside https://github.com/Shopify/sorbet/pull/583

## Motivation

We want to ensure desugaring locations are consistent during our migration. One way to ensure we don't introduce bugs is to check desugar trees on `--parser=Prism` option before and after our migration work. This PR Uses the `--print=desugar-tree-raw-with-locs` option created in https://github.com/Shopify/sorbet/pull/583, generates desugar trees with locations **with** and **without** prism desugaring through a new `--disable-prism-desugaring` flag.
 