### PR TITLE
Desugar `PM_ALIAS_METHOD_NODE`

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -191,7 +191,18 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             auto newName = translate(aliasMethodNode->new_name);
             auto oldName = translate(aliasMethodNode->old_name);
 
-            return make_unique<parser::Alias>(location, move(newName), move(oldName));
+            if (!directlyDesugar || !hasExpr(newName, oldName)) {
+                return make_unique<parser::Alias>(location, move(newName), move(oldName));
+            }
+
+            auto toExpr = newName->takeDesugaredExpr();
+            auto fromExpr = oldName->takeDesugaredExpr();
+
+            // Desugar methods: `alias new old` to `self.alias_method(new, old)`
+            auto expr = MK::Send2(location, MK::Self(location), core::Names::aliasMethod(),
+                                  location.copyWithZeroLength(), std::move(toExpr), std::move(fromExpr));
+
+            return make_node_with_expr<parser::Alias>(move(expr), location, move(newName), move(oldName));
         }
         case PM_AND_NODE: { // operator `&&` and `and`
             auto andNode = down_cast<pm_and_node>(node);


### PR DESCRIPTION
Closes https://github.com/Shopify/sorbet/issues/447

The `PM_ALIAS_METHOD` node only takes symbols as arguments, which have already been desugared.