### PR TITLE
Generate `desugar_tree_raw_with_locs` expectation files for Prism parser & test against them on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,5 @@ jobs:
         run: ./bazel test //test:prism_location_tests --config=dbg --test_output=errors
       - name: Run corpus tests
         run: ./bazel test //test:test_corpus_prism --config=dbg --test_output=errors
+      - name: Run prism desugar tests
+        run: ./bazel test //test:prism_desugar_tests --config=dbg --test_output=errors

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2090,6 +2090,7 @@ void GlobalState::copyOptions(const core::GlobalState &other) {
     this->cacheSensitiveOptions = other.cacheSensitiveOptions;
     this->ruby3KeywordArgs = other.ruby3KeywordArgs;
     this->parseWithPrism = other.parseWithPrism;
+    this->desugarInPrismTranslator = other.desugarInPrismTranslator;
     this->suppressPayloadSuperclassRedefinitionFor = other.suppressPayloadSuperclassRedefinitionFor;
     this->trackUntyped = other.trackUntyped;
     this->highlightUntypedDiagnosticSeverity = other.highlightUntypedDiagnosticSeverity;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -340,6 +340,10 @@ public:
     // If 'true', use the Prism parser.
     bool parseWithPrism = false;
 
+    // If 'true', the Prism Translator will desugar the Prism AST directly into ExpressPtrs used by `PrismDesugar.cc`,
+    // else the Prism Translator will only translate the parse tree, which will be desugared by the usual `Desugar.cc`.
+    bool desugarInPrismTranslator = false;
+
     // Some options change the behavior of things that might be cached, including ASTs, the file
     // table, the name table, the symbol table, etc.
     //

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -743,6 +743,12 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
                                  "development. Correct code should still parse correctly, but error diagnostics "
                                  "and auto-corrections are a work-in-progress.",
                                  cxxopts::value<string>()->default_value("original"), "{[original], prism}");
+    options.add_options(section)("disable-prism-desugaring",
+                                 "A development option for testing Prism desugaring. When true, the Prism Translator "
+                                 "will only generate plain Nodes (instead of NodeWith Expr), which will be desugared "
+                                 "by the regular `Desugar.cc` instead of `PrismDesugar.cc`. "
+                                 "Must be used with --parser=prism",
+                                 cxxopts::value<bool>());
 
     // }}}
 
@@ -1023,6 +1029,13 @@ void readOptions(Options &opts,
                           "with RBS signatures. https://github.com/Shopify/sorbet/issues/574");
             throw EarlyReturnWithCode(1);
         }
+
+        auto disablePrismDesugaring = raw["disable-prism-desugaring"].as<bool>();
+        if (disablePrismDesugaring && opts.parser != Parser::PRISM) {
+            logger->error("--disable-prism-desugaring can only be used with --parser=prism");
+            throw EarlyReturnWithCode(1);
+        }
+        opts.desugarInPrismTranslator = opts.parser == Parser::PRISM && !disablePrismDesugaring;
 
         opts.silenceErrors = raw["quiet"].as<bool>();
         opts.autocorrect = raw["autocorrect"].as<bool>();

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -183,6 +183,7 @@ struct Options {
     bool noErrorSections = false;
     /** Prefix to remove from all printed paths. */
     std::string pathPrefix;
+    bool desugarInPrismTranslator = false;
 
     // Options which affect the contents of the `--cache-dir`.
     // If these options change, the cache needs to be invalidated.

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -81,6 +81,7 @@ void setGlobalStateOptions(core::GlobalState &gs, const options::Options &opts) 
         gs.includeErrorSections = false;
     }
     gs.parseWithPrism = opts.parser == options::Parser::PRISM;
+    gs.desugarInPrismTranslator = opts.desugarInPrismTranslator;
     gs.ruby3KeywordArgs = opts.ruby3KeywordArgs;
     gs.suppressPayloadSuperclassRedefinitionFor = opts.suppressPayloadSuperclassRedefinitionFor;
     if (!opts.uniquelyDefinedBehavior) {
@@ -310,8 +311,8 @@ ast::ExpressionPtr runDesugar(core::GlobalState &gs, core::FileRef file, unique_
     core::MutableContext ctx(gs, core::Symbols::root(), file);
     {
         core::UnfreezeNameTable nameTableAccess(gs); // creates temporaries during desugaring
-        ast = gs.parseWithPrism ? ast::prismDesugar::node2Tree(ctx, move(parseTree), preserveConcreteSyntax)
-                                : ast::desugar::node2Tree(ctx, move(parseTree), preserveConcreteSyntax);
+        ast = gs.desugarInPrismTranslator ? ast::prismDesugar::node2Tree(ctx, move(parseTree), preserveConcreteSyntax)
+                                          : ast::desugar::node2Tree(ctx, move(parseTree), preserveConcreteSyntax);
     }
     if (print.DesugarTree.enabled) {
         print.DesugarTree.fmt("{}\n", ast.toStringWithTabs(gs, 0));

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -31,9 +31,13 @@ bool hasExpr(const parser::NodeVec &nodes) {
 
 // Allocates a new `NodeWithExpr` with a pre-computed `ExpressionPtr` AST.
 template <typename SorbetNode, typename... TArgs>
-unique_ptr<NodeWithExpr> make_node_with_expr(ast::ExpressionPtr desugaredExpr, TArgs &&...args) {
+std::unique_ptr<parser::Node> Translator::make_node_with_expr(ast::ExpressionPtr desugaredExpr, TArgs &&...args) {
     auto whiteQuarkNode = make_unique<SorbetNode>(std::forward<TArgs>(args)...);
-    return make_unique<NodeWithExpr>(move(whiteQuarkNode), move(desugaredExpr));
+    if (ctx.state.desugarInPrismTranslator) {
+        return make_unique<NodeWithExpr>(move(whiteQuarkNode), move(desugaredExpr));
+    } else {
+        return whiteQuarkNode;
+    }
 }
 
 // Indicates that a particular code path should never be reached, with an explanation of why.

--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -101,6 +101,10 @@ private:
 
     // Context management helpers. These return a copy of `this` with some change to the context.
     Translator enterMethodDef();
+
+    // Helper function for creating nodes with cached expressions
+    template <typename SorbetNode, typename... TArgs>
+    std::unique_ptr<parser::Node> make_node_with_expr(ast::ExpressionPtr desugaredExpr, TArgs &&...args);
 };
 
 } // namespace sorbet::parser::Prism

--- a/test/BUILD
+++ b/test/BUILD
@@ -137,6 +137,27 @@ test_suite(
     tags = ["prism_location_test"],
 )
 
+# Load the macro that checks desugar output with and without prism desugaring
+load("//test:prism_desugar_test.bzl", "prism_desugar_test_suite")
+
+# Run the macro
+prism_desugar_test_suite(
+    name = "prism_desugar_tests",
+    source_files = glob(
+        ["testdata/desugar/**/*.rb"],
+        exclude = [
+            # Prism desugar crashes with "Unimplemented Parser Node: Mlhs"
+            "testdata/desugar/pattern_matching_hash.rb",
+        ],
+    ),
+)
+
+# Create a test suite to run all the prism desugar tests
+test_suite(
+    name = "prism_desugar_tests",
+    tags = ["prism_desugar_test"],
+)
+
 cc_test(
     name = "hello-test",
     size = "small",

--- a/test/prism_desugar_test.bzl
+++ b/test/prism_desugar_test.bzl
@@ -1,0 +1,18 @@
+def prism_desugar_test_suite(name, source_files):
+    for source_file in source_files:
+        # Extract relative path for test naming
+        # testdata/desugar/foo/bar.rb -> foo_bar_prism_desugar_test
+        relative_path = source_file.replace("testdata/desugar/", "").replace(".rb", "")
+        test_name = relative_path.replace("/", "_") + "_prism_desugar_test"
+        
+        native.sh_test(
+            name = test_name,
+            srcs = ["prism_desugar_test.sh"],
+            args = [source_file],
+            tags = ["prism_desugar_test"],
+            data = [
+                "//main:sorbet",
+                "@bazel_tools//tools/bash/runfiles",
+                source_file,
+            ],
+        )

--- a/test/prism_desugar_test.sh
+++ b/test/prism_desugar_test.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Set up the runfiles
+# shellcheck disable=SC1090
+source "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+if [[ ! -d "${RUNFILES_DIR:-/dev/null}" ]]; then
+    echo >&2 "ERROR: could not find runfiles directory"
+    exit 1
+fi
+
+# Locate the Sorbet binary
+SORBET_BIN="$(rlocation com_stripe_ruby_typer/main/sorbet)"
+TEST_DIR="$(rlocation com_stripe_ruby_typer/test)"
+
+# The source file is passed as an argument
+SOURCE_FILE="$1"
+
+# Temporary files to hold sorbet outputs
+normal_output=$(mktemp)
+disabled_output=$(mktemp)
+
+# Run Sorbet with prism parser (normal desugaring)
+set +e # Temporarily disable exit on error
+SORBET_SILENCE_DEV_MESSAGE=1 "$SORBET_BIN" --quiet --no-error-count --print=desugar-tree-raw-with-locs --parser=prism "$TEST_DIR/$SOURCE_FILE" > "$normal_output" 2>/dev/null
+normal_exit_code=$?
+set -e # Re-enable exit on error
+
+# Run Sorbet with prism parser and disabled desugaring
+set +e # Temporarily disable exit on error
+SORBET_SILENCE_DEV_MESSAGE=1 "$SORBET_BIN" --quiet --no-error-count --print=desugar-tree-raw-with-locs --parser=prism --disable-prism-desugaring "$TEST_DIR/$SOURCE_FILE" > "$disabled_output" 2>/dev/null
+disabled_exit_code=$?
+set -e # Re-enable exit on error
+
+# Check if both sorbet runs were successful
+if [[ $normal_exit_code -ne 0 ]]; then
+    echo "ERROR: Sorbet failed to process $SOURCE_FILE with normal prism desugaring"
+    rm "$normal_output" "$disabled_output"
+    exit 1
+fi
+
+if [[ $disabled_exit_code -ne 0 ]]; then
+    echo "ERROR: Sorbet failed to process $SOURCE_FILE with disabled prism desugaring"
+    rm "$normal_output" "$disabled_output"
+    exit 1
+fi
+
+# Compare outputs - test passes if they're identical
+if ! diff -q "$normal_output" "$disabled_output" >/dev/null 2>&1; then
+    echo "Test failed for $SOURCE_FILE"
+    echo "Output differs between normal prism desugaring and disabled prism desugaring"
+    echo "Differences:"
+    diff -u "$normal_output" "$disabled_output"
+    rm "$normal_output" "$disabled_output"
+    exit 1
+fi
+
+# Clean up temporary files
+rm "$normal_output" "$disabled_output"
+echo "Test passed for $SOURCE_FILE" 


### PR DESCRIPTION
Part of https://github.com/Shopify/sorbet/issues/572 alongside https://github.com/Shopify/sorbet/pull/583


## Motivation

We want to ensure desugaring locations are consistent during our migration. One way to ensure we don't introduce bugs is to check desugar trees on `--parser=Prism` option before and after our migration work. This PR Uses the `--print=desugar-tree-raw-with-locs` option created in https://github.com/Shopify/sorbet/pull/583, generates desugar trees with locations **with** and **without** prism desugaring through a new `--disable-prism-desugaring` flag.