### PR TITLE
Desugar PM_SPLAT_NODE

### DIFF
--- a/test/prism_regression/literal_array.parse-tree.exp
+++ b/test/prism_regression/literal_array.parse-tree.exp
@@ -87,11 +87,8 @@ Begin {
             val = "2"
           }
           Splat {
-            var = Send {
-              receiver = NULL
-              method = <U rest>
-              args = [
-              ]
+            var = LVar {
+              name = <U args>
             }
           }
           Integer {

--- a/test/prism_regression/literal_array.rb
+++ b/test/prism_regression/literal_array.rb
@@ -13,7 +13,7 @@
 %W[string7 string8 string9]
 
 def has_named_rest_args(*args)
-  [1, 2, *rest, 3]
+  [1, 2, *args, 3]
 end
 
 def has_anonymous_rest_args(*)

--- a/test/prism_regression/literal_array.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/literal_array.rb.desugar-tree-raw.exp
@@ -86,14 +86,9 @@ ClassDef{
               block = nullptr
               pos_args = 1
               args = [
-                Send{
-                  flags = {privateOk}
-                  recv = Self
-                  fun = <U rest>
-                  block = nullptr
-                  pos_args = 0
-                  args = [
-                  ]
+                UnresolvedIdent{
+                  kind = Local
+                  name = <U args>
                 }
               ]
             }


### PR DESCRIPTION
Closes https://github.com/Shopify/sorbet/issues/557

- Updates the parse tree expectations for array literals with splats, since the previous test had a typo `rest`​ instead of `args`​