### PR TITLE
Implement desugaring context

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -277,7 +277,8 @@ unique_ptr<parser::Node> runRBSRewrite(core::GlobalState &gs, core::FileRef file
     return node;
 }
 
-unique_ptr<parser::Node> runPrismParser(core::GlobalState &gs, core::FileRef file, const options::Printers &print) {
+unique_ptr<parser::Node> runPrismParser(core::GlobalState &gs, core::FileRef file, const options::Printers &print,
+                                        bool preserveConcreteSyntax = false) {
     Timer timeit(gs.tracer(), "runParser", {{"file", string(file.data(gs).path())}});
 
     unique_ptr<parser::Node> nodes;

--- a/parser/prism/Parser.cc
+++ b/parser/prism/Parser.cc
@@ -7,13 +7,13 @@ using namespace std;
 
 namespace sorbet::parser::Prism {
 
-unique_ptr<parser::Node> Parser::run(core::MutableContext &ctx, bool directlyDesugar) {
+unique_ptr<parser::Node> Parser::run(core::MutableContext &ctx, bool directlyDesugar, bool preserveConcreteSyntax) {
     auto file = ctx.file;
     auto source = file.data(ctx).source();
     Prism::Parser parser{source};
     Prism::ParseResult parseResult = parser.parse();
 
-    return Prism::Translator(parser, ctx, parseResult.parseErrors, directlyDesugar)
+    return Prism::Translator(parser, ctx, parseResult.parseErrors, directlyDesugar, preserveConcreteSyntax)
         .translate(parseResult.getRawNodePointer());
 }
 

--- a/parser/prism/Parser.h
+++ b/parser/prism/Parser.h
@@ -54,7 +54,8 @@ public:
     Parser(Parser &&) = delete;
     Parser &operator=(Parser &&) = delete;
 
-    static std::unique_ptr<parser::Node> run(core::MutableContext &ctx, bool directlyDesugar = true);
+    static std::unique_ptr<parser::Node> run(core::MutableContext &ctx, bool directlyDesugar = true,
+                                             bool preserveConcreteSyntax = false);
 
     ParseResult parse();
     core::LocOffsets translateLocation(pm_location_t location) const;

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1754,16 +1754,15 @@ unique_ptr<parser::Node> Translator::translateCallWithBlock(pm_node_t *prismBloc
                                                             unique_ptr<parser::Node> sendNode) {
     unique_ptr<parser::Node> parametersNode;
     unique_ptr<parser::Node> body;
-
     if (PM_NODE_TYPE_P(prismBlockOrLambdaNode, PM_BLOCK_NODE)) {
         auto prismBlockNode = down_cast<pm_block_node>(prismBlockOrLambdaNode);
         parametersNode = translate(prismBlockNode->parameters);
-        body = translate(prismBlockNode->body);
+        body = this->enterBlockContext().translate(prismBlockNode->body);
     } else {
         ENFORCE(PM_NODE_TYPE_P(prismBlockOrLambdaNode, PM_LAMBDA_NODE))
         auto prismLambdaNode = down_cast<pm_lambda_node>(prismBlockOrLambdaNode);
         parametersNode = translate(prismLambdaNode->parameters);
-        body = translate(prismLambdaNode->body);
+        body = this->enterBlockContext().translate(prismLambdaNode->body);
     }
 
     if (parser::NodeWithExpr::cast_node<parser::NumParams>(parametersNode.get())) {
@@ -2031,21 +2030,30 @@ bool Translator::isInMethodDef() const {
 
 Translator Translator::enterMethodDef(core::LocOffsets methodLoc, core::NameRef methodName) const {
     auto resetDesugarUniqueCounter = true;
-    return Translator(*this, resetDesugarUniqueCounter, methodLoc, methodName, this->isInModule);
+    return Translator(*this, resetDesugarUniqueCounter, methodLoc, methodName, this->isInAnyBlock, this->isInModule);
+}
+
+Translator Translator::enterBlockContext() const {
+    auto resetDesugarUniqueCounter = false; // Blocks inherit their parent's numbering
+    auto isInAnyBlock = true;
+    return Translator(*this, resetDesugarUniqueCounter, this->enclosingMethodLoc, this->enclosingMethodName,
+                      isInAnyBlock, this->isInModule);
 }
 
 Translator Translator::enterModuleContext() const {
     auto resetDesugarUniqueCounter = true;
     auto isInModule = true;
+    auto isInAnyBlock = false; // Blocks never persist across a class/module boundary
     return Translator(*this, resetDesugarUniqueCounter, this->enclosingMethodLoc, this->enclosingMethodName,
-                      isInModule);
+                      isInAnyBlock, isInModule);
 }
 
 Translator Translator::enterClassContext() const {
     auto resetDesugarUniqueCounter = true;
-    auto isInModule = false;
+    auto isInModule = true;
+    auto isInAnyBlock = false; // Blocks never persist across a class/module boundary
     return Translator(*this, resetDesugarUniqueCounter, this->enclosingMethodLoc, this->enclosingMethodName,
-                      isInModule);
+                      isInAnyBlock, isInModule);
 }
 
 void Translator::reportError(core::LocOffsets loc, const string &message) const {

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -448,7 +448,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             auto name = translate(classNode->constant_path);
             auto declLoc = translateLoc(classNode->class_keyword_loc).join(name->loc);
             auto superclass = translate(classNode->superclass);
-            auto body = translate(classNode->body);
+            auto body = this->enterClassContext().translate(classNode->body);
 
             if (superclass != nullptr) {
                 declLoc = declLoc.join(superclass->loc);
@@ -549,7 +549,8 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
                 params = translate(up_cast(defNode->parameters));
             }
 
-            Translator methodContext = this->enterMethodDef(declLoc, name);
+            Translator methodContext = this->isInModule ? this->enterMethodDef(declLoc, name).enterModuleContext()
+                                                        : this->enterMethodDef(declLoc, name);
             auto body = methodContext.translate(defNode->body);
 
             if (defNode->body != nullptr && PM_NODE_TYPE_P(defNode->body, PM_BEGIN_NODE)) {
@@ -971,7 +972,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
 
             auto name = translate(moduleNode->constant_path);
             auto declLoc = translateLoc(moduleNode->module_keyword_loc).join(name->loc);
-            auto body = translate(moduleNode->body);
+            auto body = this->enterModuleContext().translate(moduleNode->body);
 
             return make_unique<parser::Module>(location, declLoc, move(name), move(body));
         }
@@ -1220,7 +1221,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             pm_location_t declLoc = classNode->class_keyword_loc;
 
             auto expr = translate(classNode->expression);
-            auto body = translate(classNode->body);
+            auto body = this->enterClassContext().translate(classNode->body);
 
             return make_unique<parser::SClass>(location, translateLoc(declLoc), move(expr), move(body));
         }
@@ -2030,7 +2031,21 @@ bool Translator::isInMethodDef() const {
 
 Translator Translator::enterMethodDef(core::LocOffsets methodLoc, core::NameRef methodName) const {
     auto resetDesugarUniqueCounter = true;
-    return Translator(*this, resetDesugarUniqueCounter, methodLoc, methodName);
+    return Translator(*this, resetDesugarUniqueCounter, methodLoc, methodName, this->isInModule);
+}
+
+Translator Translator::enterModuleContext() const {
+    auto resetDesugarUniqueCounter = true;
+    auto isInModule = true;
+    return Translator(*this, resetDesugarUniqueCounter, this->enclosingMethodLoc, this->enclosingMethodName,
+                      isInModule);
+}
+
+Translator Translator::enterClassContext() const {
+    auto resetDesugarUniqueCounter = true;
+    auto isInModule = false;
+    return Translator(*this, resetDesugarUniqueCounter, this->enclosingMethodLoc, this->enclosingMethodName,
+                      isInModule);
 }
 
 void Translator::reportError(core::LocOffsets loc, const string &message) const {

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -539,21 +539,18 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
 
             auto name = translateConstantName(defNode->name);
 
-            // These 2 need to be called on a new Translator with isInMethod set to true
-            Translator childContext = enterMethodDef();
-
-            unique_ptr<parser::Node> params;
-
             // The definition has no parameters but still has parentheses, e.g. `def foo(); end`
             // In this case, Sorbet's legacy parser will still hold an empty Args node, so we need to
             // create one here
+            unique_ptr<parser::Node> params;
             if (defNode->parameters == nullptr && rparenLoc.start != nullptr) {
                 params = make_unique<parser::Args>(location, NodeVec{});
             } else {
-                params = childContext.translate(up_cast(defNode->parameters));
+                params = translate(up_cast(defNode->parameters));
             }
 
-            auto body = childContext.translate(defNode->body);
+            Translator methodContext = this->enterMethodDef(declLoc, name);
+            auto body = methodContext.translate(defNode->body);
 
             if (defNode->body != nullptr && PM_NODE_TYPE_P(defNode->body, PM_BEGIN_NODE)) {
                 // If the body is a PM_BEGIN_NODE instead of a PM_STATEMENTS_NODE, it means the method definition
@@ -576,12 +573,11 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             }
 
             if (auto receiver = defNode->receiver; receiver != nullptr) {
-                auto sorbetReceiver = translate(receiver);
-                return make_unique<parser::DefS>(location, declLoc, move(sorbetReceiver), name, move(params),
+                return make_unique<parser::DefS>(location, declLoc, translate(defNode->receiver), name, move(params),
                                                  move(body));
+            } else {
+                return make_unique<parser::DefMethod>(location, declLoc, name, move(params), move(body));
             }
-
-            return make_unique<parser::DefMethod>(location, declLoc, name, move(params), move(body));
         }
         case PM_DEFINED_NODE: {
             auto definedNode = down_cast<pm_defined_node>(node);
@@ -1864,7 +1860,7 @@ unique_ptr<parser::Node> Translator::translateConst(PrismLhsNode *node, bool rep
     // so that the name is available for the rest of the pipeline.
     auto name = translateConstantName(node->name);
 
-    if (isInMethodDef && replaceWithDynamicConstAssign) {
+    if (this->isInMethodDef() && replaceWithDynamicConstAssign) {
         // Check if this is a dynamic constant assignment (SyntaxError at runtime)
         // This is a copy of a workaround from `Desugar.cc`, which substitues in a fake assignment,
         // so the parsing can continue. See other usages of `dynamicConstAssign` for more details.
@@ -2028,10 +2024,13 @@ template <typename PrismNode> unique_ptr<parser::Mlhs> Translator::translateMult
 }
 
 // Context management methods
-Translator Translator::enterMethodDef() const {
+bool Translator::isInMethodDef() const {
+    return enclosingMethodLoc.exists();
+}
+
+Translator Translator::enterMethodDef(core::LocOffsets methodLoc, core::NameRef methodName) const {
     auto resetDesugarUniqueCounter = true;
-    auto isInMethodDef = true;
-    return Translator(*this, resetDesugarUniqueCounter, isInMethodDef);
+    return Translator(*this, resetDesugarUniqueCounter, methodLoc, methodName);
 }
 
 void Translator::reportError(core::LocOffsets loc, const string &message) const {

--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -25,6 +25,9 @@ class Translator final {
     // Whether to directly desugar during in the Translator, or wait until the usual `Desugar.cc` code path.
     const bool directlyDesugar;
 
+    // TODO: document me
+    const bool preserveConcreteSyntax;
+
     // Unique counters used to create synthetic names via `ctx.state.freshNameUnique`.
     // - The storage integers either store an "active" count used by a translator and some of its children,
     //   or a dummy value (int min).
@@ -47,9 +50,9 @@ class Translator final {
     Translator &operator=(const Translator &) = delete; // Copy assignment
 public:
     Translator(const Parser &parser, core::MutableContext ctx, const absl::Span<const ParseError> parseErrors,
-               bool directlyDesugar)
+               bool directlyDesugar, bool preserveConcreteSyntax)
         : parser(parser), ctx(ctx), parseErrors(parseErrors), directlyDesugar(directlyDesugar),
-          parserUniqueCounterStorage(1), desugarUniqueCounterStorage(1),
+          preserveConcreteSyntax(preserveConcreteSyntax), parserUniqueCounterStorage(1), desugarUniqueCounterStorage(1),
           parserUniqueCounter(&this->parserUniqueCounterStorage),
           desugarUniqueCounter(&this->desugarUniqueCounterStorage) {}
 
@@ -62,7 +65,8 @@ private:
     Translator(const Translator &parent, bool resetDesugarUniqueCounter, core::LocOffsets enclosingMethodLoc,
                core::NameRef enclosingMethodName, bool isInModule, bool isInAnyBlock)
         : parser(parent.parser), ctx(parent.ctx), parseErrors(parent.parseErrors),
-          directlyDesugar(parent.directlyDesugar), parserUniqueCounterStorage(std::numeric_limits<uint16_t>::min()),
+          directlyDesugar(parent.directlyDesugar), preserveConcreteSyntax(parent.preserveConcreteSyntax),
+          parserUniqueCounterStorage(std::numeric_limits<uint16_t>::min()),
           desugarUniqueCounterStorage(resetDesugarUniqueCounter ? std::numeric_limits<uint32_t>::min() : 1),
           parserUniqueCounter(parent.parserUniqueCounter),
           desugarUniqueCounter(resetDesugarUniqueCounter ? &this->desugarUniqueCounterStorage

--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -38,6 +38,7 @@ class Translator final {
     // Context variables
     const core::LocOffsets enclosingMethodLoc = core::LocOffsets::none();
     const core::NameRef enclosingMethodName;
+    const bool isInModule = false;
 
     Translator(Translator &&) = delete;                 // Move constructor
     Translator(const Translator &) = delete;            // Copy constructor
@@ -58,14 +59,14 @@ private:
     // This private constructor is used for creating child translators with modified context.
     // uniqueCounterStorage is passed as the minimum integer value and is never used
     Translator(const Translator &parent, bool resetDesugarUniqueCounter, core::LocOffsets enclosingMethodLoc,
-               core::NameRef enclosingMethodName)
+               core::NameRef enclosingMethodName, bool isInModule)
         : parser(parent.parser), ctx(parent.ctx), parseErrors(parent.parseErrors),
           directlyDesugar(parent.directlyDesugar), parserUniqueCounterStorage(std::numeric_limits<uint16_t>::min()),
           desugarUniqueCounterStorage(resetDesugarUniqueCounter ? std::numeric_limits<uint32_t>::min() : 1),
           parserUniqueCounter(parent.parserUniqueCounter),
           desugarUniqueCounter(resetDesugarUniqueCounter ? &this->desugarUniqueCounterStorage
                                                          : parent.desugarUniqueCounter),
-          enclosingMethodLoc(enclosingMethodLoc), enclosingMethodName(enclosingMethodName) {}
+          enclosingMethodLoc(enclosingMethodLoc), enclosingMethodName(enclosingMethodName), isInModule(isInModule) {}
 
     template <typename SorbetNode, typename... TArgs>
     std::unique_ptr<parser::Node> make_node_with_expr(ast::ExpressionPtr desugaredExpr, TArgs &&...args) const;
@@ -123,6 +124,8 @@ private:
     // Context management helpers. These return a copy of `this` with some change to the context.
     bool isInMethodDef() const;
     Translator enterMethodDef(core::LocOffsets methodLoc, core::NameRef methodName) const;
+    Translator enterModuleContext() const;
+    Translator enterClassContext() const;
 };
 
 } // namespace sorbet::parser::Prism

--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -36,7 +36,8 @@ class Translator final {
     uint32_t *const desugarUniqueCounter; // Points to the active `desugarUniqueCounterStorage`
 
     // Context variables
-    const bool isInMethodDef = false;
+    const core::LocOffsets enclosingMethodLoc = core::LocOffsets::none();
+    const core::NameRef enclosingMethodName;
 
     Translator(Translator &&) = delete;                 // Move constructor
     Translator(const Translator &) = delete;            // Copy constructor
@@ -56,14 +57,15 @@ public:
 private:
     // This private constructor is used for creating child translators with modified context.
     // uniqueCounterStorage is passed as the minimum integer value and is never used
-    Translator(const Translator &parent, bool resetDesugarUniqueCounter, bool isInMethodDef)
+    Translator(const Translator &parent, bool resetDesugarUniqueCounter, core::LocOffsets enclosingMethodLoc,
+               core::NameRef enclosingMethodName)
         : parser(parent.parser), ctx(parent.ctx), parseErrors(parent.parseErrors),
           directlyDesugar(parent.directlyDesugar), parserUniqueCounterStorage(std::numeric_limits<uint16_t>::min()),
           desugarUniqueCounterStorage(resetDesugarUniqueCounter ? std::numeric_limits<uint32_t>::min() : 1),
           parserUniqueCounter(parent.parserUniqueCounter),
           desugarUniqueCounter(resetDesugarUniqueCounter ? &this->desugarUniqueCounterStorage
                                                          : parent.desugarUniqueCounter),
-          isInMethodDef(isInMethodDef) {}
+          enclosingMethodLoc(enclosingMethodLoc), enclosingMethodName(enclosingMethodName) {}
 
     template <typename SorbetNode, typename... TArgs>
     std::unique_ptr<parser::Node> make_node_with_expr(ast::ExpressionPtr desugaredExpr, TArgs &&...args) const;
@@ -119,7 +121,8 @@ private:
     void reportError(core::LocOffsets loc, const std::string &message) const;
 
     // Context management helpers. These return a copy of `this` with some change to the context.
-    Translator enterMethodDef() const;
+    bool isInMethodDef() const;
+    Translator enterMethodDef(core::LocOffsets methodLoc, core::NameRef methodName) const;
 };
 
 } // namespace sorbet::parser::Prism

--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -39,6 +39,7 @@ class Translator final {
     const core::LocOffsets enclosingMethodLoc = core::LocOffsets::none();
     const core::NameRef enclosingMethodName;
     const bool isInModule = false;
+    const bool isInAnyBlock = false;
 
     Translator(Translator &&) = delete;                 // Move constructor
     Translator(const Translator &) = delete;            // Copy constructor
@@ -59,14 +60,15 @@ private:
     // This private constructor is used for creating child translators with modified context.
     // uniqueCounterStorage is passed as the minimum integer value and is never used
     Translator(const Translator &parent, bool resetDesugarUniqueCounter, core::LocOffsets enclosingMethodLoc,
-               core::NameRef enclosingMethodName, bool isInModule)
+               core::NameRef enclosingMethodName, bool isInModule, bool isInAnyBlock)
         : parser(parent.parser), ctx(parent.ctx), parseErrors(parent.parseErrors),
           directlyDesugar(parent.directlyDesugar), parserUniqueCounterStorage(std::numeric_limits<uint16_t>::min()),
           desugarUniqueCounterStorage(resetDesugarUniqueCounter ? std::numeric_limits<uint32_t>::min() : 1),
           parserUniqueCounter(parent.parserUniqueCounter),
           desugarUniqueCounter(resetDesugarUniqueCounter ? &this->desugarUniqueCounterStorage
                                                          : parent.desugarUniqueCounter),
-          enclosingMethodLoc(enclosingMethodLoc), enclosingMethodName(enclosingMethodName), isInModule(isInModule) {}
+          enclosingMethodLoc(enclosingMethodLoc), enclosingMethodName(enclosingMethodName), isInModule(isInModule),
+          isInAnyBlock(isInAnyBlock) {}
 
     template <typename SorbetNode, typename... TArgs>
     std::unique_ptr<parser::Node> make_node_with_expr(ast::ExpressionPtr desugaredExpr, TArgs &&...args) const;
@@ -124,6 +126,7 @@ private:
     // Context management helpers. These return a copy of `this` with some change to the context.
     bool isInMethodDef() const;
     Translator enterMethodDef(core::LocOffsets methodLoc, core::NameRef methodName) const;
+    Translator enterBlockContext() const;
     Translator enterModuleContext() const;
     Translator enterClassContext() const;
 };


### PR DESCRIPTION
This PR implements the equivalent of [the `DesugarContext` from the main `Desugar.cc`](https://github.com/sorbet/sorbet/blob/fa0a0de2f50913552d056185347b4ee121f561d4/ast/desugar/Desugar.cc#L22-L30), with some notable improvements:

1. Our translator/desugarer is implemented as methods rather than free functions, so we can just access `this` instead of passing `DesugarContext dctx` everywhere
2. The desugaring context is changed via methods named after relevant events, like `enterMethodDef`
    * The main `Desugar.cc` achieves this by creating new `dctx1` local, passing mostly the same args, with some changed. It can be hard to read, and tell exactly what's changed.

I just put 8 fields directly into the `Translator` object itself. Arguably, I could have still kept a `DesugarContext dctx` struct, and added a `Translator(Translator &parent, DesugarContext newContext)` constructor, but I didn't find it had any benefit.