### PR TITLE
Test directly dusugared results against original

### DIFF
--- a/parser/prism/Parser.cc
+++ b/parser/prism/Parser.cc
@@ -7,12 +7,13 @@ using namespace std;
 
 namespace sorbet::parser::Prism {
 
-unique_ptr<parser::Node> Parser::run(core::GlobalState &gs, core::FileRef file) {
+unique_ptr<parser::Node> Parser::run(core::GlobalState &gs, core::FileRef file, bool directlyDesugar) {
     auto source = file.data(gs).source();
     Prism::Parser parser{source};
     Prism::ParseResult parseResult = parser.parse();
 
-    return Prism::Translator(parser, gs, file, parseResult.parseErrors).translate(parseResult.getRawNodePointer());
+    return Prism::Translator(parser, gs, file, parseResult.parseErrors, directlyDesugar)
+        .translate(parseResult.getRawNodePointer());
 }
 
 pm_parser_t *Parser::getRawParserPointer() {

--- a/parser/prism/Parser.h
+++ b/parser/prism/Parser.h
@@ -54,7 +54,7 @@ public:
     Parser(Parser &&) = delete;
     Parser &operator=(Parser &&) = delete;
 
-    static std::unique_ptr<parser::Node> run(core::GlobalState &gs, core::FileRef file);
+    static std::unique_ptr<parser::Node> run(core::GlobalState &gs, core::FileRef file, bool directlyDesugar = true);
 
     ParseResult parse();
     core::LocOffsets translateLocation(pm_location_t location) const;

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -31,9 +31,13 @@ bool hasExpr(const parser::NodeVec &nodes) {
 
 // Allocates a new `NodeWithExpr` with a pre-computed `ExpressionPtr` AST.
 template <typename SorbetNode, typename... TArgs>
-unique_ptr<NodeWithExpr> make_node_with_expr(ast::ExpressionPtr desugaredExpr, TArgs &&...args) {
+unique_ptr<parser::Node> Translator::make_node_with_expr(ast::ExpressionPtr desugaredExpr, TArgs &&...args) {
     auto whiteQuarkNode = make_unique<SorbetNode>(std::forward<TArgs>(args)...);
-    return make_unique<NodeWithExpr>(move(whiteQuarkNode), move(desugaredExpr));
+    if (directlyDesugar) {
+        return make_unique<NodeWithExpr>(move(whiteQuarkNode), move(desugaredExpr));
+    } else {
+        return whiteQuarkNode;
+    }
 }
 
 // Indicates that a particular code path should never be reached, with an explanation of why.
@@ -1961,7 +1965,7 @@ template <typename PrismNode> unique_ptr<parser::Mlhs> Translator::translateMult
 // Context management methods
 Translator Translator::enterMethodDef() {
     auto isInMethodDef = true;
-    return Translator(parser, gs, file, parseErrors, isInMethodDef, uniqueCounter);
+    return Translator(parser, gs, file, parseErrors, directlyDesugar, isInMethodDef, uniqueCounter);
 }
 
 void Translator::reportError(core::LocOffsets loc, const string &message) {


### PR DESCRIPTION
This PR explores an alternative approach for testing "direct desugaring" (in `Translator.cc`) against the old codepath in `Desugar.cc`. #627 runs two separate Sorbet pipelines, and compares the desugar tree's string representation.

This PR runs both pipelines anytime we're parsing with Prism, and compares the results in-memory via `ast::Expression.structurallyEqual()`. It only has to pay the price of rendering the desugar trees for printing the diff when a difference is detected.

It's about ~2.5x faster