### PR TITLE
Count desugar nodes

### DIFF
--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -665,11 +665,13 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
             // add entries here, without consulting the "node.*" counters from a
             // run over a representative code base.
             [&](parser::Const *const_) {
+                categoryCounterInc("PrismDesugar.cc node", "Const");
                 auto scope = node2TreeImpl(dctx, const_->scope);
                 ExpressionPtr res = MK::UnresolvedConstant(loc, move(scope), const_->name);
                 result = move(res);
             },
             [&](parser::Send *send) {
+                categoryCounterInc("PrismDesugar.cc node", "Send");
                 Send::Flags flags;
                 auto rec = node2TreeImpl(dctx, send->receiver);
                 if (isa_tree<EmptyTree>(rec)) {
@@ -902,18 +904,22 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 }
             },
             [&](parser::String *string) {
+                categoryCounterInc("PrismDesugar.cc node", "String");
                 ExpressionPtr res = MK::String(loc, string->val);
                 result = move(res);
             },
             [&](parser::Symbol *symbol) {
+                categoryCounterInc("PrismDesugar.cc node", "Symbol");
                 ExpressionPtr res = MK::Symbol(loc, symbol->val);
                 result = move(res);
             },
             [&](parser::LVar *var) {
+                categoryCounterInc("PrismDesugar.cc node", "LVar");
                 ExpressionPtr res = MK::Local(loc, var->name);
                 result = move(res);
             },
             [&](parser::Hash *hash) {
+                categoryCounterInc("PrismDesugar.cc node", "Hash");
                 InsSeq::STATS_store updateStmts;
                 updateStmts.reserve(hash->pairs.size());
 
@@ -1039,10 +1045,15 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 }
             },
             [&](parser::Block *block) {
+                categoryCounterInc("PrismDesugar.cc node", "Block");
                 result = desugarBlock(dctx, loc, block->loc, block->send, block->args.get(), block->body);
             },
-            [&](parser::Begin *begin) { result = desugarBegin(dctx, loc, begin->stmts); },
+            [&](parser::Begin *begin) {
+                categoryCounterInc("PrismDesugar.cc node", "Begin");
+                result = desugarBegin(dctx, loc, begin->stmts);
+            },
             [&](parser::Assign *asgn) {
+                categoryCounterInc("PrismDesugar.cc node", "Assign");
                 auto lhs = node2TreeImpl(dctx, asgn->lhs);
                 auto rhs = node2TreeImpl(dctx, asgn->rhs);
                 // Ensure that X = <ErrorNode> always looks like a proper static field, rather
@@ -1062,6 +1073,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
             },
             // END hand-ordered clauses
             [&](parser::And *and_) {
+                categoryCounterInc("PrismDesugar.cc node", "And");
                 auto lhs = node2TreeImpl(dctx, and_->left);
                 auto rhs = node2TreeImpl(dctx, and_->right);
                 if (dctx.preserveConcreteSyntax) {
@@ -1112,6 +1124,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 }
             },
             [&](parser::Or *or_) {
+                categoryCounterInc("PrismDesugar.cc node", "Or");
                 auto lhs = node2TreeImpl(dctx, or_->left);
                 auto rhs = node2TreeImpl(dctx, or_->right);
                 if (dctx.preserveConcreteSyntax) {
@@ -1136,6 +1149,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 }
             },
             [&](parser::AndAsgn *andAsgn) {
+                categoryCounterInc("PrismDesugar.cc node", "AndAsgn");
                 if (dctx.preserveConcreteSyntax) {
                     result = MK::Send2(loc, MK::Magic(locZeroLen), core::Names::andAsgn(), locZeroLen,
                                        node2TreeImpl(dctx, andAsgn->left), node2TreeImpl(dctx, andAsgn->right));
@@ -1206,6 +1220,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 }
             },
             [&](parser::OrAsgn *orAsgn) {
+                categoryCounterInc("PrismDesugar.cc node", "OrAsgn");
                 if (dctx.preserveConcreteSyntax) {
                     result = MK::Send2(loc, MK::Magic(locZeroLen), core::Names::orAsgn(), locZeroLen,
                                        node2TreeImpl(dctx, orAsgn->left), node2TreeImpl(dctx, orAsgn->right));
@@ -1300,6 +1315,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 }
             },
             [&](parser::OpAsgn *opAsgn) {
+                categoryCounterInc("PrismDesugar.cc node", "OpAsgn");
                 if (dctx.preserveConcreteSyntax) {
                     result = MK::Send2(loc, MK::Magic(locZeroLen), core::Names::opAsgn(), locZeroLen,
                                        node2TreeImpl(dctx, opAsgn->left), node2TreeImpl(dctx, opAsgn->right));
@@ -1370,6 +1386,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 }
             },
             [&](parser::CSend *csend) {
+                categoryCounterInc("PrismDesugar.cc node", "CSend");
                 if (dctx.preserveConcreteSyntax) {
                     // Desugaring to a InsSeq + If causes a problem for Extract to Variable; the fake If will be where
                     // the new variable is inserted, which is incorrect. Instead, desugar to a regular send, so that the
@@ -1422,6 +1439,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
             },
             [&](parser::Self *self) { desugaredByPrismTranslator(self); },
             [&](parser::DSymbol *dsymbol) {
+                categoryCounterInc("PrismDesugar.cc node", "DSymbol");
                 if (dsymbol->nodes.empty()) {
                     ExpressionPtr res = MK::Symbol(loc, core::Names::empty());
                     result = move(res);
@@ -1435,13 +1453,18 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
             },
             [&](parser::FileLiteral *fileLiteral) { desugaredByPrismTranslator(fileLiteral); },
             [&](parser::ConstLhs *constLhs) {
+                categoryCounterInc("PrismDesugar.cc node", "ConstLhs");
                 auto scope = node2TreeImpl(dctx, constLhs->scope);
                 ExpressionPtr res = MK::UnresolvedConstant(loc, move(scope), constLhs->name);
                 result = move(res);
             },
             [&](parser::Cbase *cbase) { desugaredByPrismTranslator(cbase); },
-            [&](parser::Kwbegin *kwbegin) { result = desugarBegin(dctx, loc, kwbegin->stmts); },
+            [&](parser::Kwbegin *kwbegin) {
+                categoryCounterInc("PrismDesugar.cc node", "Kwbegin");
+                result = desugarBegin(dctx, loc, kwbegin->stmts);
+            },
             [&](parser::Module *module) {
+                categoryCounterInc("PrismDesugar.cc node", "Module");
                 DesugarContext dctx1(dctx.ctx, dctx.uniqueCounter, dctx.enclosingBlockArg, dctx.enclosingMethodLoc,
                                      dctx.enclosingMethodName, dctx.inAnyBlock, true, dctx.preserveConcreteSyntax);
                 ClassDef::RHS_store body = scopeNodeToBody(dctx1, move(module->body));
@@ -1451,6 +1474,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 result = move(res);
             },
             [&](parser::Class *klass) {
+                categoryCounterInc("PrismDesugar.cc node", "Class");
                 DesugarContext dctx1(dctx.ctx, dctx.uniqueCounter, dctx.enclosingBlockArg, dctx.enclosingMethodLoc,
                                      dctx.enclosingMethodName, dctx.inAnyBlock, false, dctx.preserveConcreteSyntax);
                 ClassDef::RHS_store body = scopeNodeToBody(dctx1, move(klass->body));
@@ -1466,36 +1490,43 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
             },
             [&](parser::Arg *arg) { desugaredByPrismTranslator(arg); },
             [&](parser::Restarg *arg) {
+                categoryCounterInc("PrismDesugar.cc node", "Restarg");
                 ExpressionPtr res = MK::RestArg(loc, MK::Local(arg->nameLoc, arg->name));
                 result = move(res);
             },
             [&](parser::Kwrestarg *arg) {
+                categoryCounterInc("PrismDesugar.cc node", "Kwrestarg");
                 ExpressionPtr res = MK::RestArg(loc, MK::KeywordArg(loc, arg->name));
                 result = move(res);
             },
             [&](parser::Kwarg *arg) { desugaredByPrismTranslator(arg); },
             [&](parser::Blockarg *arg) {
+                categoryCounterInc("PrismDesugar.cc node", "Blockarg");
                 ExpressionPtr res = MK::BlockArg(loc, MK::Local(loc, arg->name));
                 result = move(res);
             },
             [&](parser::Kwoptarg *arg) {
+                categoryCounterInc("PrismDesugar.cc node", "Kwoptarg");
                 ExpressionPtr res =
                     MK::OptionalArg(loc, MK::KeywordArg(arg->nameLoc, arg->name), node2TreeImpl(dctx, arg->default_));
                 result = move(res);
             },
             [&](parser::Optarg *arg) {
+                categoryCounterInc("PrismDesugar.cc node", "Optarg");
                 ExpressionPtr res =
                     MK::OptionalArg(loc, MK::Local(arg->nameLoc, arg->name), node2TreeImpl(dctx, arg->default_));
                 result = move(res);
             },
             [&](parser::Shadowarg *arg) { desugaredByPrismTranslator(arg); },
             [&](parser::DefMethod *method) {
+                categoryCounterInc("PrismDesugar.cc node", "DefMethod");
                 bool isSelf = false;
                 ExpressionPtr res = buildMethod(dctx, method->loc, method->declLoc, method->name, method->args.get(),
                                                 method->body, isSelf);
                 result = move(res);
             },
             [&](parser::DefS *method) {
+                categoryCounterInc("PrismDesugar.cc node", "DefS");
                 auto *self = parser::NodeWithExpr::cast_node<parser::Self>(method->singleton.get());
                 if (self == nullptr) {
                     if (auto e = dctx.ctx.beginIndexerError(method->singleton->loc,
@@ -1513,6 +1544,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 result = move(res);
             },
             [&](parser::SClass *sclass) {
+                categoryCounterInc("PrismDesugar.cc node", "SClass");
                 // This will be a nested ClassDef which we leave in the tree
                 // which will get the symbol of `class.singleton_class`
                 auto *self = parser::NodeWithExpr::cast_node<parser::Self>(sclass->expr.get());
@@ -1538,17 +1570,20 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 result = move(res);
             },
             [&](parser::NumBlock *block) {
+                categoryCounterInc("PrismDesugar.cc node", "NumBlock");
                 DesugarContext dctx1(dctx.ctx, dctx.uniqueCounter, dctx.enclosingBlockArg, dctx.enclosingMethodLoc,
                                      dctx.enclosingMethodName, true, dctx.inModule, dctx.preserveConcreteSyntax);
                 result = desugarBlock(dctx1, loc, block->loc, block->send, block->args.get(), block->body);
             },
             [&](parser::While *wl) {
+                categoryCounterInc("PrismDesugar.cc node", "While");
                 auto cond = node2TreeImpl(dctx, wl->cond);
                 auto body = node2TreeImpl(dctx, wl->body);
                 ExpressionPtr res = MK::While(loc, move(cond), move(body));
                 result = move(res);
             },
             [&](parser::WhilePost *wl) {
+                categoryCounterInc("PrismDesugar.cc node", "WhilePost");
                 bool isKwbegin = parser::NodeWithExpr::isa_node<parser::Kwbegin>(wl->body.get());
                 auto cond = node2TreeImpl(dctx, wl->cond);
                 auto body = node2TreeImpl(dctx, wl->body);
@@ -1560,6 +1595,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 result = move(res);
             },
             [&](parser::Until *wl) {
+                categoryCounterInc("PrismDesugar.cc node", "Until");
                 auto cond = node2TreeImpl(dctx, wl->cond);
                 auto body = node2TreeImpl(dctx, wl->body);
                 ExpressionPtr res =
@@ -1568,6 +1604,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
             },
             // This is the same as WhilePost, but the cond negation is in the other branch.
             [&](parser::UntilPost *wl) {
+                categoryCounterInc("PrismDesugar.cc node", "UntilPost");
                 bool isKwbegin = parser::NodeWithExpr::isa_node<parser::Kwbegin>(wl->body.get());
                 auto cond = node2TreeImpl(dctx, wl->cond);
                 auto body = node2TreeImpl(dctx, wl->body);
@@ -1576,31 +1613,33 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                               : MK::While(loc, MK::Send0(loc, move(cond), core::Names::bang(), locZeroLen), move(body));
                 result = move(res);
             },
-            [&](parser::Nil *wl) {
-                ExpressionPtr res = MK::Nil(loc);
-                result = move(res);
-            },
+            [&](parser::Nil *nil) { desugaredByPrismTranslator(nil); },
             [&](parser::IVar *var) { desugaredByPrismTranslator(var); },
             [&](parser::GVar *var) { desugaredByPrismTranslator(var); },
             [&](parser::CVar *var) { desugaredByPrismTranslator(var); },
             [&](parser::LVarLhs *var) {
+                categoryCounterInc("PrismDesugar.cc node", "LVarLhs");
                 ExpressionPtr res = MK::Local(loc, var->name);
                 result = move(res);
             },
             [&](parser::GVarLhs *var) {
+                categoryCounterInc("PrismDesugar.cc node", "GVarLhs");
                 ExpressionPtr res = make_expression<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Global, var->name);
                 result = move(res);
             },
             [&](parser::CVarLhs *var) {
+                categoryCounterInc("PrismDesugar.cc node", "CVarLhs");
                 ExpressionPtr res = make_expression<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Class, var->name);
                 result = move(res);
             },
             [&](parser::IVarLhs *var) {
+                categoryCounterInc("PrismDesugar.cc node", "IVarLhs");
                 ExpressionPtr res = make_expression<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Instance, var->name);
                 result = move(res);
             },
             [&](parser::NthRef *var) { desugaredByPrismTranslator(var); },
             [&](parser::Super *super) {
+                categoryCounterInc("PrismDesugar.cc node", "Super");
                 // Desugar super into a call to a normal method named `super`;
                 // Do this by synthesizing a `Send` parse node and letting our
                 // Send desugar handle it.
@@ -1610,8 +1649,12 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 auto res = node2TreeImpl(dctx, send);
                 result = move(res);
             },
-            [&](parser::ZSuper *zuper) { result = MK::ZSuper(loc, maybeTypedSuper(dctx)); },
+            [&](parser::ZSuper *zuper) {
+                categoryCounterInc("PrismDesugar.cc node", "ZSuper");
+                result = MK::ZSuper(loc, maybeTypedSuper(dctx));
+            },
             [&](parser::For *for_) {
+                categoryCounterInc("PrismDesugar.cc node", "For");
                 MethodDef::ARGS_store args;
                 bool canProvideNiceDesugar = true;
                 auto mlhsNode = move(for_->vars);
@@ -1660,6 +1703,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
             },
             [&](parser::Integer *integer) { desugaredByPrismTranslator(integer); },
             [&](parser::DString *dstring) {
+                categoryCounterInc("PrismDesugar.cc node", "DString");
                 ExpressionPtr res = desugarDString(dctx, loc, move(dstring->nodes));
                 result = move(res);
             },
@@ -1667,6 +1711,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
             [&](parser::Complex *complex) { desugaredByPrismTranslator(complex); },
             [&](parser::Rational *rational) { desugaredByPrismTranslator(rational); },
             [&](parser::Array *array) {
+                categoryCounterInc("PrismDesugar.cc node", "Array");
                 Array::ENTRY_store elems;
                 elems.reserve(array->elts.size());
                 ExpressionPtr lastMerge;
@@ -1723,6 +1768,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 result = move(res);
             },
             [&](parser::IRange *ret) {
+                categoryCounterInc("PrismDesugar.cc node", "IRange");
                 auto recv = MK::Magic(loc);
                 auto from = node2TreeImpl(dctx, ret->from);
                 auto to = node2TreeImpl(dctx, ret->to);
@@ -1732,6 +1778,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 result = move(send);
             },
             [&](parser::ERange *ret) {
+                categoryCounterInc("PrismDesugar.cc node", "ERange");
                 auto recv = MK::Magic(loc);
                 auto from = node2TreeImpl(dctx, ret->from);
                 auto to = node2TreeImpl(dctx, ret->to);
@@ -1741,6 +1788,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 result = move(send);
             },
             [&](parser::Regexp *regexpNode) {
+                categoryCounterInc("PrismDesugar.cc node", "Regexp");
                 ExpressionPtr cnst = MK::Constant(loc, core::Symbols::Regexp());
                 auto pattern = desugarDString(dctx, loc, move(regexpNode->regex));
                 auto opts = node2TreeImpl(dctx, regexpNode->opts);
@@ -1748,6 +1796,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 result = move(send);
             },
             [&](parser::Regopt *regopt) {
+                categoryCounterInc("PrismDesugar.cc node", "Regopt");
                 int flags = 0;
                 for (auto &chr : regopt->opts) {
                     int flag = 0;
@@ -1776,6 +1825,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 result = MK::Int(loc, flags);
             },
             [&](parser::Return *ret) {
+                categoryCounterInc("PrismDesugar.cc node", "Return");
                 if (ret->exprs.size() > 1) {
                     auto arrayLoc = ret->exprs.front()->loc.join(ret->exprs.back()->loc);
                     Array::ENTRY_store elems;
@@ -1809,6 +1859,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 }
             },
             [&](parser::Break *ret) {
+                categoryCounterInc("PrismDesugar.cc node", "Break");
                 if (ret->exprs.size() > 1) {
                     auto arrayLoc = ret->exprs.front()->loc.join(ret->exprs.back()->loc);
                     Array::ENTRY_store elems;
@@ -1842,6 +1893,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 }
             },
             [&](parser::Next *ret) {
+                categoryCounterInc("PrismDesugar.cc node", "Next");
                 if (ret->exprs.size() > 1) {
                     auto arrayLoc = ret->exprs.front()->loc.join(ret->exprs.back()->loc);
                     Array::ENTRY_store elems;
@@ -1876,6 +1928,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
             },
             [&](parser::Retry *ret) { desugaredByPrismTranslator(ret); },
             [&](parser::Yield *ret) {
+                categoryCounterInc("PrismDesugar.cc node", "Yield");
                 Send::ARGS_store args;
                 args.reserve(ret->exprs.size());
                 for (auto &stat : ret->exprs) {
@@ -1905,6 +1958,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 result = move(res);
             },
             [&](parser::Rescue *rescue) {
+                categoryCounterInc("PrismDesugar.cc node", "Rescue");
                 Rescue::RESCUE_CASE_store cases;
                 cases.reserve(rescue->rescue.size());
                 for (auto &node : rescue->rescue) {
@@ -1916,6 +1970,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 result = move(res);
             },
             [&](parser::Resbody *resbody) {
+                categoryCounterInc("PrismDesugar.cc node", "Resbody");
                 RescueCase::EXCEPTION_store exceptions;
                 auto exceptionsExpr = node2TreeImpl(dctx, resbody->exception);
                 if (isa_tree<EmptyTree>(exceptionsExpr)) {
@@ -1966,6 +2021,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 result = move(res);
             },
             [&](parser::Ensure *ensure) {
+                categoryCounterInc("PrismDesugar.cc node", "Ensure");
                 auto bodyExpr = node2TreeImpl(dctx, ensure->body);
                 auto ensureExpr = node2TreeImpl(dctx, ensure->ensure);
                 auto rescue = cast_tree<Rescue>(bodyExpr);
@@ -1980,6 +2036,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 }
             },
             [&](parser::If *if_) {
+                categoryCounterInc("PrismDesugar.cc node", "If");
                 auto cond = node2TreeImpl(dctx, if_->condition);
                 auto thenp = node2TreeImpl(dctx, if_->then_);
                 auto elsep = node2TreeImpl(dctx, if_->else_);
@@ -1987,6 +2044,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 result = move(iff);
             },
             [&](parser::Masgn *masgn) {
+                categoryCounterInc("PrismDesugar.cc node", "Masgn");
                 auto *lhs = parser::NodeWithExpr::cast_node<parser::Mlhs>(masgn->lhs.get());
                 ENFORCE(lhs != nullptr, "Failed to get lhs of Masgn");
 
@@ -1997,6 +2055,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
             [&](parser::True *t) { desugaredByPrismTranslator(t); },
             [&](parser::False *t) { desugaredByPrismTranslator(t); },
             [&](parser::Case *case_) {
+                categoryCounterInc("PrismDesugar.cc node", "Case");
                 if (dctx.preserveConcreteSyntax) {
                     // Desugar to:
                     //   Magic.caseWhen(condition, numPatterns, <pattern 1>, ..., <pattern N>, <body 1>, ..., <body M>)
@@ -2079,19 +2138,23 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 result = move(res);
             },
             [&](parser::Splat *splat) {
+                categoryCounterInc("PrismDesugar.cc node", "Splat");
                 auto res = MK::Splat(loc, node2TreeImpl(dctx, splat->var));
                 result = move(res);
             },
             [&](parser::ForwardedRestArg *fra) {
+                categoryCounterInc("PrismDesugar.cc node", "ForwardedRestArg");
                 auto var = ast::MK::Local(loc, core::Names::star());
                 result = MK::Splat(loc, move(var));
             },
             [&](parser::Alias *alias) {
+                categoryCounterInc("PrismDesugar.cc node", "Alias");
                 auto res = MK::Send2(loc, MK::Self(loc), core::Names::aliasMethod(), locZeroLen,
                                      node2TreeImpl(dctx, alias->from), node2TreeImpl(dctx, alias->to));
                 result = move(res);
             },
             [&](parser::Defined *defined) {
+                categoryCounterInc("PrismDesugar.cc node", "Defined");
                 auto value = node2TreeImpl(dctx, defined->value);
                 auto loc = value.loc();
                 auto ident = cast_tree<UnresolvedIdent>(value);
@@ -2123,6 +2186,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
             },
             [&](parser::LineLiteral *line) { desugaredByPrismTranslator(line); },
             [&](parser::XString *xstring) {
+                categoryCounterInc("PrismDesugar.cc node", "XString");
                 auto res = MK::Send1(loc, MK::Self(loc), core::Names::backtick(), locZeroLen,
                                      desugarDString(dctx, loc, move(xstring->nodes)));
                 result = move(res);
@@ -2131,6 +2195,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
             [&](parser::Postexe *postexe) { desugaredByPrismTranslator(postexe); },
             [&](parser::Undef *undef) { desugaredByPrismTranslator(undef); },
             [&](parser::CaseMatch *caseMatch) {
+                categoryCounterInc("PrismDesugar.cc node", "CaseMatch");
                 // Create a local var to store the expression used in each match clause
                 auto exprLoc = caseMatch->expr->loc;
                 auto exprName = dctx.freshNameUnique(core::Names::assignTemp());
@@ -2170,19 +2235,26 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
             [&](parser::Redo *redo) { desugaredByPrismTranslator(redo); },
             [&](parser::EncodingLiteral *encodingLiteral) { desugaredByPrismTranslator(encodingLiteral); },
             [&](parser::MatchPattern *pattern) {
+                categoryCounterInc("PrismDesugar.cc node", "MatchPattern");
                 auto res = desugarOnelinePattern(dctx, pattern->loc, pattern->rhs.get());
                 result = move(res);
             },
             [&](parser::MatchPatternP *pattern) {
+                categoryCounterInc("PrismDesugar.cc node", "MatchPatternP");
                 auto res = desugarOnelinePattern(dctx, pattern->loc, pattern->rhs.get());
                 result = move(res);
             },
-            [&](parser::EmptyElse *else_) { result = MK::EmptyTree(); },
+            [&](parser::EmptyElse *else_) {
+                categoryCounterInc("PrismDesugar.cc node", "EmptyElse");
+                result = MK::EmptyTree();
+            },
             [&](parser::ResolvedConst *resolvedConst) {
+                categoryCounterInc("PrismDesugar.cc node", "ResolvedConst");
                 result = make_expression<ConstantLit>(resolvedConst->loc, move(resolvedConst->symbol));
             },
 
             [&](parser::NodeWithExpr *nodeWithExpr) {
+                categoryCounterInc("PrismDesugar.cc node", "NodeWithExpr");
                 result = nodeWithExpr->takeDesugaredExpr();
                 ENFORCE(result != nullptr, "NodeWithExpr has no cached desugared expr");
             },

--- a/parse_stats.rb
+++ b/parse_stats.rb
@@ -1,0 +1,169 @@
+#!/usr/bin/env ruby
+
+# Script to compare statistics between before.txt and after.txt files
+# Format: "         If :           3831, 0.1%"
+
+def format_number(num)
+  num.to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1,').reverse
+end
+
+def parse_stats_file(filename)
+  results = {}
+
+  File.readlines(filename, chomp: true).each_with_index do |line, index|
+    # Skip empty lines
+    next if line.strip.empty?
+
+    # Regex to match the pattern: whitespace + label + : + whitespace + number + , + percentage
+    match = line.match(/^\s*(\w+)\s*:\s*(\d+),?\s*([\d.]+)?%?/)
+
+    if match
+      label = match[1]
+      count = match[2].to_i
+      percentage = match[3] ? match[3].to_f : 0.0
+
+      results[label] = {
+        line_number: index + 1,
+        label: label,
+        count: count,
+        percentage: percentage,
+        raw_line: line
+      }
+    elsif line.match(/^\s*\w+\s*:\s*\d+/) # Try to catch lines without percentages
+      puts "Warning: Could not fully parse line #{index + 1}: #{line}"
+    end
+  end
+
+  results
+end
+
+def compare_stats(before_stats, after_stats)
+  all_labels = (before_stats.keys + after_stats.keys).uniq.sort
+  comparisons = []
+
+  all_labels.each do |label|
+    before_entry = before_stats[label]
+    after_entry = after_stats[label]
+
+    if before_entry && after_entry
+      # Both exist - calculate handling percentage
+      before_count = before_entry[:count]
+      after_count = after_entry[:count]
+      not_handled_pct = (after_count.to_f / before_count * 100).round(1)
+      handled_pct = (100.0 - not_handled_pct).round(1)
+
+      comparisons << {
+        label: label,
+        before_count: before_count,
+        after_count: after_count,
+        handled_pct: handled_pct,
+        not_handled_pct: not_handled_pct,
+        status: :both
+      }
+    elsif before_entry && !after_entry
+      # Only in before - completely handled
+      comparisons << {
+        label: label,
+        before_count: before_entry[:count],
+        after_count: 0,
+        handled_pct: 100.0,
+        not_handled_pct: 0.0,
+        status: :eliminated
+      }
+    elsif !before_entry && after_entry
+      # Only in after - newly introduced (not handled)
+      comparisons << {
+        label: label,
+        before_count: 0,
+        after_count: after_entry[:count],
+        handled_pct: -Float::INFINITY,
+        not_handled_pct: Float::INFINITY,
+        status: :new
+      }
+    end
+  end
+
+  comparisons
+end
+
+# Main execution
+if __FILE__ == $0
+  before_file = ARGV[0] || 'before.txt'
+  after_file = ARGV[1] || 'after.txt'
+
+  unless File.exist?(before_file)
+    puts "Error: File '#{before_file}' not found!"
+    exit 1
+  end
+
+  unless File.exist?(after_file)
+    puts "Error: File '#{after_file}' not found!"
+    exit 1
+  end
+
+  before_stats = parse_stats_file(before_file)
+  after_stats = parse_stats_file(after_file)
+
+  comparisons = compare_stats(before_stats, after_stats)
+
+
+  # Summary first
+  both_entries = comparisons.select { |c| c[:status] == :both }
+  eliminated_entries = comparisons.select { |c| c[:status] == :eliminated }
+  all_entries = both_entries + eliminated_entries
+
+  total_nodes_in_repo = all_entries.sum { |c| c[:before_count] }
+  total_nodes_handled = all_entries.sum { |c| c[:after_count] }
+
+  formatted_repo_count = format_number(total_nodes_in_repo)
+  formatted_handled_count = format_number(total_nodes_handled)
+
+  puts "Direct desugaring summary:"
+  puts "    Total nodes in repo: #{formatted_repo_count}"
+  puts "    Total nodes handled: %#{formatted_repo_count.length}s" % formatted_handled_count
+  puts "    Completed node types: #{eliminated_entries.length}"
+
+  if both_entries.any?
+    total_before = both_entries.sum { |c| c[:before_count] }
+    total_after = both_entries.sum { |c| c[:after_count] }
+    overall_not_handled = (total_after.to_f / total_before * 100).round(1)
+    overall_handled = (100 - overall_not_handled).round(1)
+    puts "    Directly desugared rate: #{overall_handled}%"
+    puts "    Fallback desugared rate: #{overall_not_handled}%"
+  end
+
+  puts
+  puts "%-15s %10s %10s %10s %10s %s" % ["Node type", "Count", "Fallbacks", "Direct", "Fallback", "Status"]
+  puts "-" * 80
+
+  # Sort by handling percentage (highest handling first), then by before_count for ties
+  sorted_comparisons = comparisons.sort_by { |c| [-c[:handled_pct], -c[:before_count]] }
+
+  sorted_comparisons.each do |comp|
+    status_symbol = case comp[:status]
+                   when :eliminated then "Done!"
+                   when :new then "NEW"
+                   when :both then ""
+                   end
+
+    if comp[:status] == :new
+      puts "%-15s %10s %10s %10s %10s %s" % [
+        comp[:label],
+        "-",
+        format_number(comp[:after_count]),
+        "NEW",
+        "∞",
+        status_symbol
+      ]
+    else
+      puts "%-15s %10s %10s %9.1f%% %9.1f%% %s" % [
+        comp[:label],
+        format_number(comp[:before_count]),
+        format_number(comp[:after_count]),
+        comp[:handled_pct],
+        comp[:not_handled_pct],
+        status_symbol
+      ]
+    end
+  end
+end

--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -110,7 +110,7 @@ private:
     template <typename PrismNode> std::unique_ptr<parser::Mlhs> translateMultiTargetLhs(PrismNode *);
 
     template <typename PrismAssignmentNode, typename SorbetLHSNode>
-    std::unique_ptr<parser::Assign> translateAssignment(pm_node_t *node);
+    std::unique_ptr<parser::Node> translateAssignment(pm_node_t *node);
 
     template <typename PrismAssignmentNode, typename SorbetAssignmentNode, typename SorbetLHSNode>
     std::unique_ptr<SorbetAssignmentNode> translateOpAssignment(pm_node_t *node);


### PR DESCRIPTION
### Motivation

Using these counters, we can see how much of a repo can be directly desugared.

Generate `legacy.txt` and `prism.txt` by copying the relevant counters from:

```
./bazel run //main:sorbet --config=dbg -- --stop-after desugarer --counters --parser=prism /your/repo
./bazel run //main:sorbet --config=dbg -- --stop-after desugarer --counters --parser=original /your/repo
```

Compare with this script the chat gippity wrote for me:

```txt
Direct desugaring summary:
    Total nodes in repo:    2,682,519
    Total direct desugared: 1,893,539
    Total fallbacks:          788,980
    Completed node types: 20
    Directly desugared rate: 63.2%
    Fallback desugared rate: 36.8%

Node type            Count  Fallbacks     Direct   Fallback Status
--------------------------------------------------------------------------------
Symbol             189,633          0     100.0%       0.0% Done!
Arg                 94,821          0     100.0%       0.0% Done!
Cbase               86,434          0     100.0%       0.0% Done!
Nil                 62,821          0     100.0%       0.0% Done!
Restarg             31,607          0     100.0%       0.0% Done!
Blockarg            30,626          0     100.0%       0.0% Done!
ConstLhs            16,356          0     100.0%       0.0% Done!
Integer              7,879          0     100.0%       0.0% Done!
Kwarg                5,023          0     100.0%       0.0% Done!
Kwrestarg            4,997          0     100.0%       0.0% Done!
IVar                 4,006          0     100.0%       0.0% Done!
True                 2,897          0     100.0%       0.0% Done!
False                2,461          0     100.0%       0.0% Done!
Float                  793          0     100.0%       0.0% Done!
Self                   648          0     100.0%       0.0% Done!
Next                   242          0     100.0%       0.0% Done!
Retry                   21          0     100.0%       0.0% Done!
Break                   21          0     100.0%       0.0% Done!
GVar                    14          0     100.0%       0.0% Done!
FileLiteral              1          0     100.0%       0.0% Done!
Const              754,739        699      99.9%       0.1%
Kwoptarg            37,305         66      99.8%       0.2%
Optarg              14,909         72      99.5%       0.5%
LVar                51,285        760      98.5%       1.5%
String              51,456      1,083      97.9%       2.1%
LVarLhs             19,270        684      96.5%       3.5%
IVarLhs              1,767        142      92.0%       8.0%
Return               1,361        178      86.9%      13.1%
Assign              36,567      9,761      73.3%      26.7%
Until                   13          5      61.5%      38.5%
Send               721,996    326,827      54.7%      45.3%
If                   3,831      1,987      48.1%      51.9%
DString              3,036      2,976       2.0%      98.0%
DefMethod          224,578    224,578       0.0%     100.0%
Block              137,583    137,583       0.0%     100.0%
Class               21,432     21,432       0.0%     100.0%
Begin               17,788     17,788       0.0%     100.0%
Array               14,170     14,170       0.0%     100.0%
Module               9,594      9,594       0.0%     100.0%
Hash                 7,341      7,341       0.0%     100.0%
SClass               4,690      4,689       0.0%     100.0%
Regopt               1,143      1,143       0.0%     100.0%
Regexp               1,143      1,143       0.0%     100.0%
CSend                  744        744       0.0%     100.0%
Or                     689        689       0.0%     100.0%
And                    474        474       0.0%     100.0%
Resbody                443        443       0.0%     100.0%
Rescue                 370        370       0.0%     100.0%
OrAsgn                 217        217       0.0%     100.0%
Case                   172        172       0.0%     100.0%
DefS                   154        154       0.0%     100.0%
Masgn                  146        146       0.0%     100.0%
Super                  124        124       0.0%     100.0%
OpAsgn                 114        114       0.0%     100.0%
NumBlock               105        105       0.0%     100.0%
ZSuper                  98         98       0.0%     100.0%
IRange                  82         82       0.0%     100.0%
Splat                   66         66       0.0%     100.0%
Yield                   55         55       0.0%     100.0%
Ensure                  32         32       0.0%     100.0%
While                   14         14       0.0%     100.0%
Defined                 12         12       0.0%     100.0%
ERange                  10         10       0.0%     100.0%
DSymbol                  9          9       0.0%     100.0%
XString                  1          1       0.0%     100.0%
Kwbegin                 90        148     -64.4%     164.4%
```

