### PR TITLE
Add `LocOffsets` length helper method

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -2086,8 +2086,8 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     // In `rescue; ...; end`, we don't want the magic <rescueTemp> variable to look
                     // as if its loc is the entire `rescue; ...; end` span. Better to just point at
                     // the `rescue` keyword.
-                    varLoc = (loc.endPos() - loc.beginPos()) > 6 ? core::LocOffsets{loc.beginPos(), loc.beginPos() + 6}
-                                                                 : loc.copyWithZeroLength();
+                    varLoc = (loc.length() > 6) ? core::LocOffsets{loc.beginPos(), loc.beginPos() + 6}
+                                                : loc.copyWithZeroLength();
                 } else if (varExpr != nullptr) {
                     body = MK::InsSeq1(varLoc, MK::Assign(varLoc, move(varExpr), MK::Local(varLoc, var)), move(body));
                 }

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -1917,8 +1917,8 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     // In `rescue; ...; end`, we don't want the magic <rescueTemp> variable to look
                     // as if its loc is the entire `rescue; ...; end` span. Better to just point at
                     // the `rescue` keyword.
-                    varLoc = (loc.endPos() - loc.beginPos()) > 6 ? core::LocOffsets{loc.beginPos(), loc.beginPos() + 6}
-                                                                 : loc.copyWithZeroLength();
+                    varLoc = (loc.length() > 6) ? core::LocOffsets{loc.beginPos(), loc.beginPos() + 6}
+                                                : loc.copyWithZeroLength();
                 } else if (varExpr != nullptr) {
                     body = MK::InsSeq1(varLoc, MK::Assign(varLoc, move(varExpr), MK::Local(varLoc, var)), move(body));
                 }

--- a/cfg/builder/builder_entry.cc
+++ b/cfg/builder/builder_entry.cc
@@ -90,7 +90,7 @@ unique_ptr<CFG> CFGBuilder::buildFor(core::Context ctx, ast::MethodDef &md) {
 
     core::LocOffsets rvLoc;
     if (cont->exprs.empty() || isa_instruction<LoadArg>(cont->exprs.back().value)) {
-        auto beginAdjust = md.loc.endPos() - md.loc.beginPos() - 3;
+        auto beginAdjust = md.loc.length() - 3;
         auto endLoc = ctx.locAt(md.loc).adjust(ctx, beginAdjust, 0);
         if (endLoc.source(ctx) == "end") {
             rvLoc = endLoc.offsets();

--- a/core/Error.cc
+++ b/core/Error.cc
@@ -216,7 +216,7 @@ void ErrorBuilder::addAutocorrect(AutocorrectSuggestion &&autocorrect) {
     vector<ErrorLine> messages;
     for (auto &edit : autocorrect.edits) {
         auto isInsert = edit.replacement == "";
-        uint32_t n = edit.loc.endPos() - edit.loc.beginPos();
+        uint32_t n = edit.loc.length();
         if (gs.autocorrect) {
             auto line = isInsert ? ErrorLine::from(edit.loc, "Deleted")
                                  : ErrorLine::from(edit.loc, "{} `{}`", n == 0 ? "Inserted" : "Replaced with",

--- a/core/Loc.cc
+++ b/core/Loc.cc
@@ -328,7 +328,7 @@ optional<string_view> Loc::source(const GlobalState &gs) const {
         return nullopt;
     } else {
         auto source = this->file().data(gs).source();
-        return source.substr(beginPos(), endPos() - beginPos());
+        return source.substr(beginPos(), length());
     }
 }
 

--- a/core/Loc.h
+++ b/core/Loc.h
@@ -55,6 +55,10 @@ public:
     uint32_t endPos() const {
         return storage.offsets.endLoc;
     }
+    uint32_t length() const {
+        ENFORCE_NO_TIMER(storage.offsets.exists());
+        return storage.offsets.length();
+    }
     const LocOffsets &offsets() const {
         return storage.offsets;
     }

--- a/core/LocOffsets.h
+++ b/core/LocOffsets.h
@@ -20,6 +20,10 @@ struct LocOffsets {
     uint32_t endPos() const {
         return endLoc;
     }
+    uint32_t length() const {
+        ENFORCE_NO_TIMER(exists());
+        return endPos() - beginPos();
+    }
     bool exists() const {
         return endLoc != INVALID_POS_LOC && beginLoc != INVALID_POS_LOC;
     }

--- a/main/lsp/QueryCollector.cc
+++ b/main/lsp/QueryCollector.cc
@@ -49,8 +49,8 @@ vector<unique_ptr<core::lsp::QueryResponse>> QueryCollector::drainQueryResponses
         construction, but threading artifact might reorder them, thus we'd like to sort them */
         auto leftTermLoc = left->getLoc();
         auto rightTermLoc = right->getLoc();
-        auto leftLength = leftTermLoc.endPos() - leftTermLoc.beginPos();
-        auto rightLength = rightTermLoc.endPos() - rightTermLoc.beginPos();
+        auto leftLength = leftTermLoc.length();
+        auto rightLength = rightTermLoc.length();
         if (leftLength != rightLength) {
             return leftLength < rightLength;
         }

--- a/rbs/CommentsAssociator.cc
+++ b/rbs/CommentsAssociator.cc
@@ -719,7 +719,7 @@ CommentMap CommentsAssociator::run(unique_ptr<parser::Node> &node) {
 CommentsAssociator::CommentsAssociator(core::MutableContext ctx, vector<core::LocOffsets> commentLocations)
     : ctx(ctx), commentLocations(commentLocations), commentByLine() {
     for (auto &loc : commentLocations) {
-        auto comment_string = ctx.file.data(ctx).source().substr(loc.beginPos(), loc.endPos() - loc.beginPos());
+        auto comment_string = ctx.file.data(ctx).source().substr(loc.beginPos(), loc.length());
         auto start32 = static_cast<uint32_t>(loc.beginPos());
         auto end32 = static_cast<uint32_t>(loc.endPos());
         auto comment = CommentNode{core::LocOffsets{start32, end32}, comment_string};

--- a/rbs/MethodTypeToParserNode.cc
+++ b/rbs/MethodTypeToParserNode.cc
@@ -235,7 +235,7 @@ optional<core::AutocorrectSuggestion> autocorrectArg(core::MutableContext ctx, c
 
     string corrected;
     auto source = ctx.file.data(ctx.state).source();
-    auto typeString = source.substr(type->loc.beginPos(), type->loc.endPos() - type->loc.beginPos());
+    auto typeString = source.substr(type->loc.beginPos(), type->loc.length());
 
     typecase(
         methodParam,


### PR DESCRIPTION
Follow-up to [https://app.graphite.dev/github/pr/Shopify/sorbet/707/Desugar-`PM_RESCUE_MODIFIER_NODE`#comment-PRRC_kwDOD0qpv86PN2G9](https://app.graphite.dev/github/pr/Shopify/sorbet/707/Desugar-%60PM_RESCUE_MODIFIER_NODE%60#comment-PRRC_kwDOD0qpv86PN2G9)

This PR adds a `length()` method to the `LocOffsets` and `Loc` classes to simplify calculating the length of a location span. The implementation replaces existing `endPos() - beginPos()` calculations with the new `length()` method across the codebase.

### Test plan

Covered by existing tests