### PR TITLE
Pipeline improvements for RBS rewriting

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -57,33 +57,6 @@ using namespace std;
 
 namespace sorbet::realmain::pipeline {
 
-pm_node_t *runRBSRewritePrism(sorbet::core::GlobalState &gs, sorbet::core::FileRef file, pm_node_t *node,
-                              const std::vector<sorbet::core::LocOffsets> &commentLocations,
-                              const sorbet::realmain::options::Printers &print, sorbet::core::MutableContext &ctx,
-                              const parser::Prism::Parser &parser) {
-    if (gs.cacheSensitiveOptions.rbsEnabled) {
-        Timer timeit(gs.tracer(), "runRBSRewritePrism", {{"file", string(file.data(gs).path())}});
-
-        // fmt::print("TRIGGERING COMMENTS ASSOCIATOR PRISM\n");
-        auto associator = rbs::CommentsAssociatorPrism(
-            ctx, parser, const_cast<std::vector<core::LocOffsets> &>(commentLocations));
-        auto commentMap = associator.run(node);
-
-        // fmt::print("TRIGGERING SIGS REWRITER PRISM\n");
-        auto sigsRewriter = rbs::SigsRewriterPrism(ctx, parser, commentMap.signaturesForNode);
-        node = sigsRewriter.run(node);
-
-        auto assertionsRewriter = rbs::AssertionsRewriterPrism(ctx, parser, commentMap.assertionsForNode);
-        node = assertionsRewriter.run(node);
-
-        if (print.RBSRewriteTree.enabled) {
-            // TODO: Implement prism node to string conversion for debug output
-            // print.RBSRewriteTree.fmt("{}\n", node->toStringWithTabs(gs, 0));
-        }
-    }
-    return node;
-}
-
 void setGlobalStateOptions(core::GlobalState &gs, const options::Options &opts) {
     gs.pathPrefix = opts.pathPrefix;
     gs.errorUrlBase = opts.errorUrlBase;
@@ -254,6 +227,32 @@ ast::ExpressionPtr fetchTreeFromCache(core::GlobalState &gs, core::FileRef fref,
     return core::serialize::Serializer::loadTree(gs, file, maybeCached.data);
 }
 
+unique_ptr<parser::Node> runRBSRewrite(core::GlobalState &gs, core::FileRef file, parser::ParseResult &&parseResult,
+                                       const options::Printers &print) {
+    auto node = move(parseResult.tree);
+    auto commentLocations = move(parseResult.commentLocations);
+
+    fmt::print("NOOOOO RUNNING RBS REWRITE WITHOUT PRISM\n");
+    Timer timeit(gs.tracer(), "runRBSRewrite", {{"file", string(file.data(gs).path())}});
+    core::MutableContext ctx(gs, core::Symbols::root(), file);
+    core::UnfreezeNameTable nameTableAccess(gs);
+
+    auto associator = rbs::CommentsAssociator(ctx, commentLocations);
+    auto commentMap = associator.run(node);
+
+    auto sigsRewriter = rbs::SigsRewriter(ctx, commentMap.signaturesForNode);
+    node = sigsRewriter.run(move(node));
+
+    auto assertionsRewriter = rbs::AssertionsRewriter(ctx, commentMap.assertionsForNode);
+    node = assertionsRewriter.run(move(node));
+
+    if (print.RBSRewriteTree.enabled) {
+        print.RBSRewriteTree.fmt("{}\n", node->toStringWithTabs(gs, 0));
+    }
+
+    return node;
+}
+
 parser::ParseResult runParser(core::GlobalState &gs, core::FileRef file, const options::Printers &print,
                               bool traceLexer, bool traceParser) {
     Timer timeit(gs.tracer(), "runParser", {{"file", string(file.data(gs).path())}});
@@ -281,55 +280,30 @@ parser::ParseResult runParser(core::GlobalState &gs, core::FileRef file, const o
     return result;
 }
 
-unique_ptr<parser::Node> runRBSRewrite(core::GlobalState &gs, core::FileRef file, parser::ParseResult &&parseResult,
-                                       const options::Printers &print) {
-    auto node = move(parseResult.tree);
-    auto commentLocations = move(parseResult.commentLocations);
-
-    if (gs.cacheSensitiveOptions.rbsEnabled) {
-        fmt::print("NOOOOO RUNNING RBS REWRITE WITHOUT PRISM\n");
-        Timer timeit(gs.tracer(), "runRBSRewrite", {{"file", string(file.data(gs).path())}});
-        core::MutableContext ctx(gs, core::Symbols::root(), file);
-        core::UnfreezeNameTable nameTableAccess(gs);
-
-        auto associator = rbs::CommentsAssociator(ctx, commentLocations);
-        auto commentMap = associator.run(node);
-
-        auto sigsRewriter = rbs::SigsRewriter(ctx, commentMap.signaturesForNode);
-        node = sigsRewriter.run(move(node));
-
-        auto assertionsRewriter = rbs::AssertionsRewriter(ctx, commentMap.assertionsForNode);
-        node = assertionsRewriter.run(move(node));
-
-        if (print.RBSRewriteTree.enabled) {
-            print.RBSRewriteTree.fmt("{}\n", node->toStringWithTabs(gs, 0));
-        }
-    }
-    return node;
-}
-
-parser::ParseResult runPrismParserPrism(core::GlobalState &gs, core::FileRef file, const options::Printers &print) {
+parser::ParseResult runPrismParser(core::GlobalState &gs, core::FileRef file, const options::Printers &print,
+                                   bool preserveConcreteSyntax = false) {
     Timer timeit(gs.tracer(), "runParser", {{"file", string(file.data(gs).path())}});
 
     parser::ParseResult parseResult;
     {
         core::MutableContext ctx(gs, core::Symbols::root(), file);
         core::UnfreezeNameTable nameTableAccess(gs); // enters strings from source code as names
-
-        // Step 1: Parse with Prism to get raw Prism nodes (keep Parser alive for translate step)
-        auto source = ctx.file.data(ctx).source();
+        // The RBS rewriter produces plain Whitequark nodes and not `NodeWithExpr` which causes errors in
+        // `PrismDesugar.cc`. For now, disable all direct translation, and fallback to `Desugar.cc`.
+        auto source = file.data(ctx).source();
         parser::Prism::Parser parser{source};
-        bool collectComments = ctx.state.cacheSensitiveOptions.rbsEnabled;
-        auto prismParseResult = parser.parse(collectComments);
+        bool collectComments = gs.cacheSensitiveOptions.rbsEnabled;
+        parser::Prism::ParseResult prismResult = parser.parseWithoutTranslation(collectComments);
 
-        // Step 2: Run RBS rewrite on the raw Prism nodes
-        pm_node_t *rewrittenNode = runRBSRewritePrism(gs, file, prismParseResult.getRawNodePointer(),
-                                                      prismParseResult.getCommentLocations(), print, ctx, parser);
+        auto node = prismResult.getRawNodePointer();
+        if (gs.cacheSensitiveOptions.rbsEnabled) {
+            node = runPrismRBSRewrite(gs, file, node, prismResult.getCommentLocations(), print, ctx, parser);
+        }
 
-        // Step 3: Translate the (possibly RBS-rewritten) Prism nodes to Sorbet nodes
-        parseResult =
-            parser::Prism::Parser::translateOnly(ctx, parser, rewrittenNode, prismParseResult.getParseErrors(),
-                                                 prismParseResult.getCommentLocations(), false); // TODO: false
+        auto translatedTree =
+            parser::Prism::Translator(parser, ctx, prismResult.getParseErrors(), false, false).translate(node);
+
+        parseResult = parser::ParseResult{move(translatedTree), prismResult.getCommentLocations()};
     }
 
     if (print.ParseTree.enabled) {
@@ -351,36 +325,6 @@ parser::ParseResult runPrismParserPrism(core::GlobalState &gs, core::FileRef fil
         if (parseResult.tree) {
             print.ParseTreeWhitequark.fmt("{}\n", parseResult.tree->toWhitequark(gs, 0));
         }
-    }
-
-    return parseResult;
-}
-
-parser::ParseResult runPrismParser(core::GlobalState &gs, core::FileRef file, const options::Printers &print,
-                                   bool preserveConcreteSyntax = false) {
-    Timer timeit(gs.tracer(), "runParser", {{"file", string(file.data(gs).path())}});
-
-    parser::ParseResult parseResult;
-    {
-        core::MutableContext ctx(gs, core::Symbols::root(), file);
-        core::UnfreezeNameTable nameTableAccess(gs); // enters strings from source code as names
-        // The RBS rewriter produces plain Whitequark nodes and not `NodeWithExpr` which causes errors in
-        // `PrismDesugar.cc`. For now, disable all direct translation, and fallback to `Desugar.cc`.
-        auto directlyTranslate = !gs.cacheSensitiveOptions.rbsEnabled;
-        parseResult = parser::Prism::Parser::run(ctx, directlyTranslate);
-    }
-
-    if (print.ParseTree.enabled) {
-        print.ParseTree.fmt("{}\n", parseResult.tree->toStringWithTabs(gs, 0));
-    }
-    if (print.ParseTreeJson.enabled) {
-        print.ParseTreeJson.fmt("{}\n", parseResult.tree->toJSON(gs, 0));
-    }
-    if (print.ParseTreeJsonWithLocs.enabled) {
-        print.ParseTreeJson.fmt("{}\n", parseResult.tree->toJSONWithLocs(gs, file, 0));
-    }
-    if (print.ParseTreeWhitequark.enabled) {
-        print.ParseTreeWhitequark.fmt("{}\n", parseResult.tree->toWhitequark(gs, 0));
     }
 
     return parseResult;
@@ -431,6 +375,31 @@ ast::ParsedFile emptyParsedFile(core::FileRef file) {
 
 } // namespace
 
+pm_node_t *runPrismRBSRewrite(sorbet::core::GlobalState &gs, sorbet::core::FileRef file, pm_node_t *node,
+                              const std::vector<sorbet::core::LocOffsets> &commentLocations,
+                              const sorbet::realmain::options::Printers &print, sorbet::core::MutableContext &ctx,
+                              const parser::Prism::Parser &parser) {
+    Timer timeit(gs.tracer(), "runPrismRBSRewrite", {{"file", string(file.data(gs).path())}});
+
+    // fmt::print("TRIGGERING COMMENTS ASSOCIATOR PRISM\n");
+    auto associator = rbs::CommentsAssociatorPrism(ctx, parser, commentLocations);
+    auto commentMap = associator.run(node);
+
+    // fmt::print("TRIGGERING SIGS REWRITER PRISM\n");
+    auto sigsRewriter = rbs::SigsRewriterPrism(ctx, parser, commentMap.signaturesForNode);
+    node = sigsRewriter.run(node);
+
+    auto assertionsRewriter = rbs::AssertionsRewriterPrism(ctx, parser, commentMap.assertionsForNode);
+    node = assertionsRewriter.run(node);
+
+    if (print.RBSRewriteTree.enabled) {
+        // TODO: Implement prism node to string conversion for debug output
+        // print.RBSRewriteTree.fmt("{}\n", node->toStringWithTabs(gs, 0));
+    }
+
+    return node;
+}
+
 ast::ExpressionPtr desugarOne(const options::Options &opts, core::GlobalState &gs, core::FileRef file,
                               bool preserveConcreteSyntax) {
     auto &print = opts.print;
@@ -442,7 +411,12 @@ ast::ExpressionPtr desugarOne(const options::Options &opts, core::GlobalState &g
         }
         auto parseResult = runParser(gs, file, print, opts.traceLexer, opts.traceParser);
 
-        auto parseTree = runRBSRewrite(gs, file, move(parseResult), print);
+        unique_ptr<parser::Node> parseTree;
+        if (gs.cacheSensitiveOptions.rbsEnabled) {
+            parseTree = runRBSRewrite(gs, file, move(parseResult), print);
+        } else {
+            parseTree = move(parseResult.tree);
+        }
 
         return runDesugar(gs, file, move(parseTree), print, preserveConcreteSyntax);
     } catch (SorbetException &) {
@@ -478,7 +452,12 @@ ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, c
                         return emptyParsedFile(file);
                     }
 
-                    parseTree = runRBSRewrite(lgs, file, move(parseResult), print);
+                    if (lgs.cacheSensitiveOptions.rbsEnabled) {
+                        parseTree = runRBSRewrite(lgs, file, move(parseResult), print);
+                    } else {
+                        parseTree = move(parseResult.tree);
+                    }
+
                     if (opts.stopAfterPhase == options::Phase::RBS_REWRITER) {
                         return emptyParsedFile(file);
                     }
@@ -486,15 +465,8 @@ ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, c
                     break;
                 }
                 case options::Parser::PRISM: {
-                    if (lgs.cacheSensitiveOptions.rbsEnabled) {
-                        auto parseResult = runPrismParserPrism(lgs, file, print);
-                        parseTree = move(parseResult.tree);
-                        // parseTree = runRBSRewrite(lgs, file, move(parseResult), print);
-                    } else {
-                        auto parseResult = runPrismParser(lgs, file, print);
-                        parseTree = move(parseResult.tree);
-                        // parseTree = runRBSRewrite(lgs, file, move(parseResult), print);
-                    }
+                    auto parseResult = runPrismParser(lgs, file, print);
+                    parseTree = move(parseResult.tree);
 
                     if (opts.stopAfterPhase == options::Phase::PARSER) {
                         return emptyParsedFile(file);

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -126,7 +126,7 @@ void printUntypedBlames(const core::GlobalState &gs, const UnorderedMap<long, lo
 std::unique_ptr<core::GlobalState> copyForSlowPath(const core::GlobalState &from, const options::Options &opts);
 
 // RBS Prism rewriter function
-pm_node_t *runRBSRewritePrism(sorbet::core::GlobalState &gs, sorbet::core::FileRef file, pm_node_t *node,
+pm_node_t *runPrismRBSRewrite(sorbet::core::GlobalState &gs, sorbet::core::FileRef file, pm_node_t *node,
                               const std::vector<sorbet::core::LocOffsets> &commentLocations,
                               const sorbet::realmain::options::Printers &print, sorbet::core::MutableContext &ctx,
                               const parser::Prism::Parser& parser);

--- a/parser/prism/Parser.h
+++ b/parser/prism/Parser.h
@@ -65,19 +65,14 @@ public:
 
     static parser::ParseResult run(core::MutableContext ctx, bool directlyDesugar = true,
                                    bool preserveConcreteSyntax = false);
-    static ParseResult parseOnly(core::MutableContext &ctx);
-    static parser::ParseResult translateOnly(core::MutableContext &ctx, const Parser &parser, pm_node_t *node,
-                                             const std::vector<ParseError> &parseErrors,
-                                             const std::vector<core::LocOffsets> &commentLocations,
-                                             bool preserveConcreteSyntax);
 
-    ParseResult parse(bool collectComments = false);
+    ParseResult parseWithoutTranslation(bool collectComments = false);
     core::LocOffsets translateLocation(pm_location_t location) const;
     std::string_view resolveConstant(pm_constant_id_t constantId) const;
     std::string_view extractString(pm_string_t *string) const;
 
     // Access to internal parser for node creation
-    pm_parser_t* getInternalParser() const { return const_cast<pm_parser_t*>(&parser); }
+    pm_parser_t *getInternalParser() const { return const_cast<pm_parser_t *>(&parser); }
 
 private:
     std::vector<ParseError> collectErrors();
@@ -102,6 +97,7 @@ class ParseResult final {
     const std::vector<ParseError> parseErrors;
     std::vector<core::LocOffsets> commentLocations;
 
+public:
     ParseResult(Parser &parser, pm_node_t *node, std::vector<ParseError> parseErrors,
                 std::vector<core::LocOffsets> commentLocations)
         : parser{parser}, node{node, NodeDeleter{parser}}, parseErrors{parseErrors}, commentLocations{
@@ -112,7 +108,6 @@ class ParseResult final {
     ParseResult(ParseResult &&) = delete;                 // Move constructor
     ParseResult &operator=(ParseResult &&) = delete;      // Move assignment
 
-public:
     pm_node_t *getRawNodePointer() const {
         return node.get();
     }

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -39,6 +39,7 @@
 #include "packager/packager.h"
 #include "parser/parser.h"
 #include "parser/prism/Parser.h"
+#include "parser/prism/Translator.h"
 #include "payload/binary/binary.h"
 #include "payload/payload.h"
 #include "rbs/AssertionsRewriter.h"
@@ -247,15 +248,21 @@ vector<ast::ParsedFile> index(core::GlobalState &gs, absl::Span<core::FileRef> f
                         realmain::options::Printers print{};
                         auto source = ctx.file.data(ctx).source();
                         parser::Prism::Parser prismParser{source};
+
                         bool collectComments = ctx.state.cacheSensitiveOptions.rbsEnabled;
-                        auto prismParseResult = prismParser.parse(collectComments);
-                        pm_node_t *rewrittenNode =
-                            realmain::pipeline::runRBSRewritePrism(gs, file, prismParseResult.getRawNodePointer(),
-                                                                   prismParseResult.getCommentLocations(), print, ctx, prismParser);
-                        parseResult = parser::Prism::Parser::translateOnly(
-                            ctx, prismParser, rewrittenNode, prismParseResult.getParseErrors(),
-                            prismParseResult.getCommentLocations(),
-                            false); // TODO: preserveConcreteSyntax set to false
+
+                        auto prismParseResult = prismParser.parseWithoutTranslation(collectComments);
+
+                        pm_node_t *rewrittenNode = realmain::pipeline::runPrismRBSRewrite(
+                            gs, file, prismParseResult.getRawNodePointer(), prismParseResult.getCommentLocations(),
+                            print, ctx, prismParser);
+
+                        auto translatedTree =
+                            parser::Prism::Translator(prismParser, ctx, prismParseResult.getParseErrors(), false, false)
+                                .translate(rewrittenNode);
+
+                        parseResult = parser::ParseResult{move(translatedTree), prismParseResult.getCommentLocations()};
+
                         directlyDesugaredTree = nullptr;
                     } else {
                         parseResult = parser::Prism::Parser::run(ctx, false);
@@ -753,14 +760,20 @@ TEST_CASE("PerPhaseTest") { // NOLINT
                     realmain::options::Printers print{};
                     auto source = ctx.file.data(ctx).source();
                     parser::Prism::Parser prismParser{source};
+
                     bool collectComments = ctx.state.cacheSensitiveOptions.rbsEnabled;
-                    auto prismParseResult = prismParser.parse(collectComments);
-                    pm_node_t *rewrittenNode =
-                        realmain::pipeline::runRBSRewritePrism(*gs, f.file, prismParseResult.getRawNodePointer(),
-                                                               prismParseResult.getCommentLocations(), print, ctx, prismParser);
-                    parseResult = parser::Prism::Parser::translateOnly(
-                        ctx, prismParser, rewrittenNode, prismParseResult.getParseErrors(),
-                        prismParseResult.getCommentLocations(), false); // TODO: preserveConcreteSyntax set to false
+
+                    auto prismParseResult = prismParser.parseWithoutTranslation(collectComments);
+
+                    pm_node_t *rewrittenNode = realmain::pipeline::runPrismRBSRewrite(
+                        *gs, f.file, prismParseResult.getRawNodePointer(), prismParseResult.getCommentLocations(),
+                        print, ctx, prismParser);
+
+                    auto translatedTree =
+                        parser::Prism::Translator(prismParser, ctx, prismParseResult.getParseErrors(), false, false)
+                            .translate(rewrittenNode);
+
+                    parseResult = parser::ParseResult{move(translatedTree), prismParseResult.getCommentLocations()};
                 } else {
                     parseResult = parser::Prism::Parser::run(ctx, false);
                 }


### PR DESCRIPTION
part of https://github.com/Shopify/sorbet/issues/712

This PR cleans up the RBS pipeline code by removing unnecessary abstractions and improving the organization of parsing/translation methods.

### Changes

- Merged `runPrismParserPrism` into `runPrismParser` to eliminate code duplication
  - The combined function now handles both RBS-enabled and non-RBS cases. This is cleaner in my opinion and removes duplicated code.
- Moved `isRbsEnabled` checks from inside `runRBSRewrite` functions to their call sites so they are conditionally called
- Removed `translateOnly` abstraction since it was not valuable in my opinion
  - Inlined `Parser::translateOnly()` at its two call sites by constructing `Translator` and calling `Translator.translate()` instead
- Removed unused static `parseOnly(ctx)` method
- Renamed instance method `parse()` → `parseWithoutTranslation()` for clarity, since it does not do any translation 
- Renamed `runRBSRewritePrism` → `runPrismRBSRewrite` to follow `runPrism*` naming pattern
- Reordered functions to group related methods together

### Test plan
`signatures_defs_prism` tests run as expected
