### PR TITLE
Fix Prism crash with missing class/module name

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -136,6 +136,8 @@ prism_location_test_suite(
             "prism_regression/call_kw_nil_args.rb",
             "prism_regression/call_block_param_and_forwarding.rb",
             "prism_regression/constants_invalid.rb",
+            "prism_regression/class_missing_name.rb",
+            "prism_regression/module_missing_name.rb",
         ],
     ),
 )

--- a/test/prism_regression/class_missing_name.rb
+++ b/test/prism_regression/class_missing_name.rb
@@ -1,0 +1,16 @@
+# typed: false
+
+# Missing constant path
+class
+end
+
+# Invalid constant path without body
+class
+  def foo; end # Parsed as constant path
+end
+
+# Invalid constant path with body
+class
+  def foo; end # Parsed as constant path
+  def bar; end # Parsed as body
+end

--- a/test/prism_regression/class_missing_name.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/class_missing_name.rb.desugar-tree-raw.exp
@@ -1,0 +1,66 @@
+ClassDef{
+  kind = class
+  name = EmptyTree
+  symbol = <C <U <root>>>
+  ancestors = [ConstantLit{
+      symbol = (class ::<todo sym>)
+      orig = nullptr
+    }]
+  rhs = [
+    ClassDef{
+      kind = class
+      name = UnresolvedConstantLit{
+        cnst = <C <U <ConstantNameMissing>>>
+        scope = EmptyTree
+      }
+      symbol = <C <U <todo sym>>>
+      ancestors = [ConstantLit{
+          symbol = (class ::<todo sym>)
+          orig = nullptr
+        }]
+      rhs = [
+        EmptyTree
+      ]
+    }
+
+    ClassDef{
+      kind = class
+      name = UnresolvedConstantLit{
+        cnst = <C <U <ConstantNameMissing>>>
+        scope = EmptyTree
+      }
+      symbol = <C <U <todo sym>>>
+      ancestors = [ConstantLit{
+          symbol = (class ::<todo sym>)
+          orig = nullptr
+        }]
+      rhs = [
+        EmptyTree
+      ]
+    }
+
+    ClassDef{
+      kind = class
+      name = UnresolvedConstantLit{
+        cnst = <C <U <ConstantNameMissing>>>
+        scope = EmptyTree
+      }
+      symbol = <C <U <todo sym>>>
+      ancestors = [ConstantLit{
+          symbol = (class ::<todo sym>)
+          orig = nullptr
+        }]
+      rhs = [
+        MethodDef{
+          flags = {}
+          name = <U bar><<U <todo method>>>
+          params = [BlockParam{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
+            } }]
+          rhs = EmptyTree
+        }
+      ]
+    }
+  ]
+}

--- a/test/prism_regression/class_missing_name.rb.parse-tree.exp
+++ b/test/prism_regression/class_missing_name.rb.parse-tree.exp
@@ -1,0 +1,32 @@
+Begin {
+  stmts = [
+    Class {
+      name = Const {
+        scope = NULL
+        name = <C <U <ConstantNameMissing>>>
+      }
+      superclass = NULL
+      body = NULL
+    }
+    Class {
+      name = Const {
+        scope = NULL
+        name = <C <U <ConstantNameMissing>>>
+      }
+      superclass = NULL
+      body = NULL
+    }
+    Class {
+      name = Const {
+        scope = NULL
+        name = <C <U <ConstantNameMissing>>>
+      }
+      superclass = NULL
+      body = DefMethod {
+        name = <U bar>
+        params = NULL
+        body = NULL
+      }
+    }
+  ]
+}

--- a/test/prism_regression/module_missing_name.rb
+++ b/test/prism_regression/module_missing_name.rb
@@ -1,0 +1,16 @@
+# typed: false
+
+# Missing constant path
+module
+end
+
+# Invalid constant path without body
+module
+  def foo; end # Parsed as constant path
+end
+
+# Invalid constant path with body
+module
+  def foo; end # Parsed as constant path
+  def bar; end # Parsed as body
+end

--- a/test/prism_regression/module_missing_name.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/module_missing_name.rb.desugar-tree-raw.exp
@@ -1,0 +1,62 @@
+ClassDef{
+  kind = class
+  name = EmptyTree
+  symbol = <C <U <root>>>
+  ancestors = [ConstantLit{
+      symbol = (class ::<todo sym>)
+      orig = nullptr
+    }]
+  rhs = [
+    ClassDef{
+      kind = module
+      name = UnresolvedConstantLit{
+        cnst = <C <U <ConstantNameMissing>>>
+        scope = EmptyTree
+      }
+      symbol = <C <U <todo sym>>>
+      ancestors = []
+      rhs = [
+        EmptyTree
+      ]
+    }
+
+    UnresolvedConstantLit{
+      cnst = <C <U <ErrorNode>>>
+      scope = EmptyTree
+    }
+
+    ClassDef{
+      kind = module
+      name = UnresolvedConstantLit{
+        cnst = <C <U <ConstantNameMissing>>>
+        scope = EmptyTree
+      }
+      symbol = <C <U <todo sym>>>
+      ancestors = []
+      rhs = [
+        EmptyTree
+      ]
+    }
+
+    ClassDef{
+      kind = module
+      name = UnresolvedConstantLit{
+        cnst = <C <U <ConstantNameMissing>>>
+        scope = EmptyTree
+      }
+      symbol = <C <U <todo sym>>>
+      ancestors = []
+      rhs = [
+        MethodDef{
+          flags = {}
+          name = <U bar><<U <todo method>>>
+          params = [BlockParam{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
+            } }]
+          rhs = EmptyTree
+        }
+      ]
+    }
+  ]
+}

--- a/test/prism_regression/module_missing_name.rb.parse-tree.exp
+++ b/test/prism_regression/module_missing_name.rb.parse-tree.exp
@@ -1,0 +1,33 @@
+Begin {
+  stmts = [
+    Module {
+      name = Const {
+        scope = NULL
+        name = <C <U <ConstantNameMissing>>>
+      }
+      body = NULL
+    }
+    Const {
+      scope = NULL
+      name = <C <U <ErrorNode>>>
+    }
+    Module {
+      name = Const {
+        scope = NULL
+        name = <C <U <ConstantNameMissing>>>
+      }
+      body = NULL
+    }
+    Module {
+      name = Const {
+        scope = NULL
+        name = <C <U <ConstantNameMissing>>>
+      }
+      body = DefMethod {
+        name = <U bar>
+        params = NULL
+        body = NULL
+      }
+    }
+  ]
+}

--- a/tools/scripts/verify_prism_regression_tests.sh
+++ b/tools/scripts/verify_prism_regression_tests.sh
@@ -11,6 +11,8 @@ skip_files=(
   "call_kw_nil_args"
   "call_block_param_and_forwarding"
   "constants_invalid"
+  "class_missing_name"
+  "module_missing_name"
 )
 
 mismatched_parse_tree_files=()


### PR DESCRIPTION
Sorbet was crashing in Prism parser mode was when encountering malformed class or module definitions where the constant path is missing or invalid, such as:

```ruby
class
end
```

or

```ruby
class
  def foo; end
end
```

or

```ruby
class
  def foo; end
  def bar; end
end
```

For the first example, Prism generates a ClassNode with constant_path set to a MissingNode and a null body.

For the second example, Prism generates a ClassNode with the constant_path set as the first DefNode and a null body.

For the third example, Prism generates a ClassNode with the constant_path set as the first DefNode and the body is a StatementsNode containing the second DefNode.

The original parser throws away the class/module node and only includes the body node (if present) in the tree. So in the third example it would just be the `bar` DefNode. With the Prism parser it's fairly straightforward (easier?) for us to always return the class/module node, filling in a missing constant for the name, and the same body (e.g. the `bar` DefNode), so only the invalid constant path node is discarded.

We considered changing how Prism parses these examples to always return a class/module node with a MissingNode for the constant_path and all children in the body, but it's not always obvious that that's the right way to parse it. For example:

```rb
class (return)::A; end

class 0.X end
```

In these examples it wouldn't make sense to parse them as class nodes with a body containing `(return)::A` or `0.X`—it's more likely the intention was that these are constant paths, not body nodes. As such, I think it makes sense to just work with the existing Prism behavior and do the best we can with it.

Another option was to copy the mimic parser behavior exactly (throwing away the outer class/module) but since it's easier for us to keep it, I went with the approach in this commit.
