### PR TITLE
Rename `send` to `call` in Prism parser factory

### DIFF
--- a/parser/prism/Factory.h
+++ b/parser/prism/Factory.h
@@ -45,16 +45,16 @@ public:
     pm_node_t *KeywordHash(core::LocOffsets loc, const absl::Span<pm_node_t *> pairs) const;
 
     // Low-level method call creation
-    pm_call_node_t *createSendNode(pm_node_t *receiver, pm_constant_id_t method_id, pm_node_t *arguments,
+    pm_call_node_t *createCallNode(pm_node_t *receiver, pm_constant_id_t method_id, pm_node_t *arguments,
                                    pm_location_t message_loc, pm_location_t full_loc, pm_location_t tiny_loc,
                                    pm_node_t *block = nullptr) const;
 
     // High-level method call builders (similar to ast::MK)
-    pm_node_t *Send(core::LocOffsets loc, pm_node_t *receiver, std::string_view method,
+    pm_node_t *Call(core::LocOffsets loc, pm_node_t *receiver, std::string_view method,
                     const absl::Span<pm_node_t *> args, pm_node_t *block = nullptr) const;
-    pm_node_t *Send0(core::LocOffsets loc, pm_node_t *receiver, std::string_view method) const;
-    pm_node_t *Send1(core::LocOffsets loc, pm_node_t *receiver, std::string_view method, pm_node_t *arg1) const;
-    pm_node_t *Send2(core::LocOffsets loc, pm_node_t *receiver, std::string_view method, pm_node_t *arg1,
+    pm_node_t *Call0(core::LocOffsets loc, pm_node_t *receiver, std::string_view method) const;
+    pm_node_t *Call1(core::LocOffsets loc, pm_node_t *receiver, std::string_view method, pm_node_t *arg1) const;
+    pm_node_t *Call2(core::LocOffsets loc, pm_node_t *receiver, std::string_view method, pm_node_t *arg1,
                      pm_node_t *arg2) const;
 
     // Utility functions

--- a/rbs/prism/AssertionsRewriterPrism.cc
+++ b/rbs/prism/AssertionsRewriterPrism.cc
@@ -340,7 +340,7 @@ void maybeSupplyGenericTypeArguments(core::MutableContext ctx, parser::Prism::Pa
 /**
  * Save the signature from the given block so it can be used to resolve the type parameters from the method signature.
  *
- * Returns `true` if the block is a `sig` send, `false` otherwise.
+ * Returns `true` if the block is a `sig` call, `false` otherwise.
  */
 bool AssertionsRewriterPrism::saveTypeParams(pm_node_t *call) {
     if (!call || !PM_NODE_TYPE_P(call, PM_CALL_NODE)) {
@@ -867,7 +867,7 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
 
                 node = maybeInsertCast(node);
             } else {
-                // Normal call - matches whitequark's Send handling
+                // Normal call - matches Whitequark's Send handling
                 call->receiver = rewriteNode(call->receiver);
                 node = maybeInsertCast(node);
             }

--- a/rbs/prism/SigsRewriterPrism.cc
+++ b/rbs/prism/SigsRewriterPrism.cc
@@ -86,22 +86,22 @@ vector<pm_node_t *> extractHelpers(core::MutableContext ctx, const vector<Commen
     for (auto &annotation : annotations) {
         pm_node_t *helperNode = nullptr;
 
-        // TODO: Should send0 use core::NameRef?
+        // TODO: Should call0 use core::NameRef?
         if (annotation.string == "abstract") {
             pm_node_t *self = prism.Self(annotation.typeLoc);
-            helperNode = prism.Send0(annotation.typeLoc, self, "abstract!"sv);
+            helperNode = prism.Call0(annotation.typeLoc, self, "abstract!"sv);
         } else if (annotation.string == "interface") {
             pm_node_t *self = prism.Self(annotation.typeLoc);
-            helperNode = prism.Send0(annotation.typeLoc, self, "interface!"sv);
+            helperNode = prism.Call0(annotation.typeLoc, self, "interface!"sv);
         } else if (annotation.string == "final") {
             pm_node_t *self = prism.Self(annotation.typeLoc);
             if (self) {
-                helperNode = prism.Send0(annotation.typeLoc, self, "final!"sv);
+                helperNode = prism.Call0(annotation.typeLoc, self, "final!"sv);
             }
         } else if (annotation.string == "sealed") {
             pm_node_t *self = prism.Self(annotation.typeLoc);
             if (self) {
-                helperNode = prism.Send0(annotation.typeLoc, self, "sealed!"sv);
+                helperNode = prism.Call0(annotation.typeLoc, self, "sealed!"sv);
             }
         } else if (absl::StartsWith(annotation.string, "requires_ancestor:")) {
             if (auto type = extractHelperArgument(ctx, parser, annotation, 18)) {
@@ -116,9 +116,9 @@ vector<pm_node_t *> extractHelpers(core::MutableContext ctx, const vector<Commen
 
                     // Create self.requires_ancestor call
                     pm_node_t *self = prism.Self(annotation.typeLoc);
-                    pm_node_t *send = prism.Send0(annotation.typeLoc, self, "requires_ancestor"sv);
+                    pm_node_t *callNode = prism.Call0(annotation.typeLoc, self, "requires_ancestor"sv);
 
-                    if (send && self) {
+                    if (callNode && self) {
                         // Create block with the statements as body
                         pm_block_node_t *block = prism.allocateNode<pm_block_node_t>();
                         if (block) {
@@ -131,9 +131,9 @@ vector<pm_node_t *> extractHelpers(core::MutableContext ctx, const vector<Commen
                                                        .closing_loc = parser.getZeroWidthLocation()};
 
                             // Attach block to the call
-                            auto *call = down_cast<pm_call_node_t>(send);
+                            auto *call = down_cast<pm_call_node_t>(callNode);
                             call->block = up_cast(block);
-                            helperNode = send;
+                            helperNode = callNode;
                         }
                     }
                 }
@@ -262,7 +262,7 @@ void maybeInsertExtendTHelpers(pm_node_t **body, core::LocOffsets loc, const par
         return;
     }
 
-    pm_node_t *extendCall = prism.Send1(loc, selfNode, "extend"sv, tHelpers);
+    pm_node_t *extendCall = prism.Call1(loc, selfNode, "extend"sv, tHelpers);
     if (!extendCall) {
         return;
     }

--- a/rbs/prism/TypeParamsToParserNodesPrism.cc
+++ b/rbs/prism/TypeParamsToParserNodesPrism.cc
@@ -73,9 +73,9 @@ vector<pm_node_t *> TypeParamsToParserNodePrism::typeParams(const rbs_node_list_
             block = prism.Block(loc, body);
         }
 
-        auto typeSend = prism.Send(loc, prism.SorbetPrivateStatic(loc), "type_member"sv, absl::MakeSpan(args), block);
+        auto typeCall = prism.Call(loc, prism.SorbetPrivateStatic(loc), "type_member"sv, absl::MakeSpan(args), block);
 
-        auto assign = prism.ConstantWriteNode(loc, prism.addConstantToPool(nameConstant.show(ctx.state)), typeSend);
+        auto assign = prism.ConstantWriteNode(loc, prism.addConstantToPool(nameConstant.show(ctx.state)), typeCall);
         result.push_back(assign);
     }
 

--- a/rbs/prism/TypeToParserNodePrism.cc
+++ b/rbs/prism/TypeToParserNodePrism.cc
@@ -128,7 +128,7 @@ pm_node_t *TypeToParserNodePrism::classInstanceType(const rbs_types_class_instan
         }
 
         string methodName = core::Names::syntheticSquareBrackets().show(ctx.state);
-        return prism.Send(loc, typeConstant, methodName.c_str(), absl::MakeSpan(args));
+        return prism.Call(loc, typeConstant, methodName.c_str(), absl::MakeSpan(args));
     }
 
     return typeConstant;
@@ -137,7 +137,7 @@ pm_node_t *TypeToParserNodePrism::classInstanceType(const rbs_types_class_instan
 pm_node_t *TypeToParserNodePrism::classSingletonType(const rbs_types_class_singleton_t *node, core::LocOffsets loc,
                                                      const RBSDeclaration &declaration) {
     auto innerType = typeNameType(node->name, false, declaration);
-    return prism.Send1(loc, prism.T(loc), "class_of"sv, innerType);
+    return prism.Call1(loc, prism.T(loc), "class_of"sv, innerType);
 }
 
 pm_node_t *TypeToParserNodePrism::unionType(const rbs_types_union_t *node, core::LocOffsets loc,
@@ -238,7 +238,7 @@ pm_node_t *TypeToParserNodePrism::procType(const rbs_types_proc_t *node, core::L
     rbs_node_t *selfNode = node->self_type;
     if (selfNode != nullptr) {
         auto selfType = toPrismNode(selfNode, declaration);
-        function = prism.Send1(loc, function, "bind"sv, selfType);
+        function = prism.Call1(loc, function, "bind"sv, selfType);
     }
 
     return function;
@@ -272,7 +272,7 @@ pm_node_t *TypeToParserNodePrism::blockType(const rbs_types_block_t *node, core:
     if (selfNode != nullptr) {
         auto selfLoc = declaration.typeLocFromRange(selfNode->location->rg);
         auto selfType = toPrismNode(selfNode, declaration);
-        function = prism.Send1(selfLoc, function, "bind"sv, selfType);
+        function = prism.Call1(selfLoc, function, "bind"sv, selfType);
     }
 
     if (!node->required) {
@@ -367,7 +367,7 @@ pm_node_t *TypeToParserNodePrism::toPrismNode(const rbs_node_t *node, const RBSD
             if (!t_const) {
                 return nullptr;
             }
-            return prism.Send0(nodeLoc, t_const, "noreturn"sv);
+            return prism.Call0(nodeLoc, t_const, "noreturn"sv);
         }
         case RBS_TYPES_BASES_CLASS: {
             if (auto e = ctx.beginIndexerError(nodeLoc, core::errors::Rewriter::RBSUnsupported)) {


### PR DESCRIPTION
In Prism, the equivalent of whitequark send nodes are call nodes. 
Part of https://github.com/Shopify/sorbet/issues/764

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
