### PR TITLE
Early return optimizations to RBS rewriter pipeline

### DIFF
--- a/rbs/AssertionsRewriter.h
+++ b/rbs/AssertionsRewriter.h
@@ -33,6 +33,7 @@ private:
     std::map<parser::Node *, std::vector<CommentNode>> &commentsByNode;
     std::vector<std::pair<core::LocOffsets, core::NameRef>> typeParams = {};
     std::set<std::pair<uint32_t, uint32_t>> consumedComments = {};
+    size_t totalComments = 0;
 
     void consumeComment(core::LocOffsets loc);
     bool hasConsumedComment(core::LocOffsets loc);

--- a/rbs/CommentsAssociator.cc
+++ b/rbs/CommentsAssociator.cc
@@ -354,6 +354,11 @@ void CommentsAssociator::walkNode(parser::Node *node) {
         return;
     }
 
+    // If all RBS comments have been processed and associated with nodes, we can skip walking the rest of the tree.
+    if (commentByLine.empty()) {
+        return;
+    }
+
     typecase(
         node,
 

--- a/rbs/SigsRewriter.cc
+++ b/rbs/SigsRewriter.cc
@@ -590,6 +590,10 @@ unique_ptr<parser::Node> SigsRewriter::rewriteNode(unique_ptr<parser::Node> node
 }
 
 unique_ptr<parser::Node> SigsRewriter::run(unique_ptr<parser::Node> node) {
+    // If there are no signature comments to process, we can skip the entire tree walk.
+    if (commentsByNode.empty()) {
+        return node;
+    }
     return rewriteBody(move(node));
 }
 


### PR DESCRIPTION

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Locally seems to result in a 10% speedup in our monolith. Not tested extensively.

```
λ hyperfine "/Users/kaanozkan/src/github.com/Shopify/sorbet/bazel-bin/main/sorbet ." "bundle exec srb tc" --warmup 2 --prepare "rm -rf tmp/sorbet_cache"
Benchmark 1: /Users/kaanozkan/src/github.com/Shopify/sorbet/bazel-bin/main/sorbet .
  Time (mean ± σ):     17.985 s ±  0.240 s    [User: 109.901 s, System: 22.752 s]
  Range (min … max):   17.536 s … 18.309 s    10 runs

Benchmark 2: bundle exec srb tc
  Time (mean ± σ):     19.862 s ±  0.659 s    [User: 124.295 s, System: 20.532 s]
  Range (min … max):   19.181 s … 21.315 s    10 runs

Summary
  /Users/kaanozkan/src/github.com/Shopify/sorbet/bazel-bin/main/sorbet . ran
    1.10 ± 0.04 times faster than bundle exec srb tc

```

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
