### PR TITLE
Remove intermediate `NodeVec` in `desugarParametersNode()`

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -2748,8 +2748,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             return make_unique<parser::ForwardedArgs>(location);
         }
         case PM_FORWARDING_PARAMETER_NODE: { // The `...` parameter in a method definition, like `def foo(...)`
-            // Desugared in desugarParametersNode().
-            return make_unique<parser::ForwardArg>(location);
+            unreachable("PM_FORWARDING_PARAMETER_NODE is handled separately in `desugarParametersNode()`.");
         }
         case PM_FORWARDING_SUPER_NODE: { // A `super` with no explicit arguments
             // It might have a literal block argument, though.
@@ -4213,16 +4212,17 @@ Translator::desugarParametersNode(pm_parameters_node *paramsNode, core::LocOffse
     auto keywords = absl::MakeSpan(paramsNode->keywords.nodes, paramsNode->keywords.size);
     auto posts = absl::MakeSpan(paramsNode->posts.nodes, paramsNode->posts.size);
 
-    parser::NodeVec params;
-
     auto restSize = paramsNode->rest == nullptr ? 0 : 1;
     auto kwrestSize = paramsNode->keyword_rest == nullptr ? 0 : 1;
     auto blockSize = paramsNode->block == nullptr ? 0 : 1;
 
-    params.reserve(requireds.size() + optionals.size() + restSize + posts.size() + keywords.size() + kwrestSize +
-                   blockSize + blockLocalVariables.size());
+    ast::MethodDef::PARAMS_store paramsStore;
+    ast::InsSeq::STATS_store statsStore;
 
-    for (auto &n : requireds) {
+    paramsStore.reserve(requireds.size() + optionals.size() + restSize + posts.size() + keywords.size() + kwrestSize +
+                        blockSize + blockLocalVariables.size());
+
+    for (auto *n : requireds) {
         if (PM_NODE_TYPE_P(n, PM_MULTI_TARGET_NODE)) {
             auto multiTargetNode = down_cast<pm_multi_target_node>(n);
 
@@ -4231,50 +4231,92 @@ Translator::desugarParametersNode(pm_parameters_node *paramsNode, core::LocOffse
             ENFORCE(multiTargetNode->rparen_loc.start);
             ENFORCE(multiTargetNode->rparen_loc.end);
 
-            // The legacy parser doesn't usually include the parens in the location of a multi-target node,
-            // *except* in a block's parameter list.
-            auto mlhsLoc = translateLoc(multiTargetNode->lparen_loc.start, multiTargetNode->rparen_loc.end);
+            // // The legacy parser doesn't usually include the parens in the location of a multi-target node,
+            // // *except* in a block's parameter list.
+            // auto mlhsLoc = translateLoc(multiTargetNode->lparen_loc.start, multiTargetNode->rparen_loc.end);
 
-            auto multiLhsNode = translateMultiTargetLhs(multiTargetNode, mlhsLoc);
+            // auto multiLhsNode = translateMultiTargetLhs(multiTargetNode, mlhsLoc);
 
-            params.emplace_back(move(multiLhsNode));
+            // params.emplace_back(move(multiLhsNode));
+
+            // TODO: Implement once `translateMultiTargetLhs` is migrated.
+            unreachable("Support for Mlhs is not implemented yet!");
         } else {
-            params.emplace_back(translate(n));
+            paramsStore.emplace_back(desugar(n));
         }
     }
 
-    translateMultiInto(params, optionals);
+    for (auto *n : optionals) {
+        if (PM_NODE_TYPE_P(n, PM_MULTI_TARGET_NODE)) {
+            auto multiTargetNode = down_cast<pm_multi_target_node>(n);
 
-    if (paramsNode->rest != nullptr) {
-        params.emplace_back(translate(paramsNode->rest));
+            ENFORCE(multiTargetNode->lparen_loc.start);
+            ENFORCE(multiTargetNode->lparen_loc.end);
+            ENFORCE(multiTargetNode->rparen_loc.start);
+            ENFORCE(multiTargetNode->rparen_loc.end);
+
+            // // The legacy parser doesn't usually include the parens in the location of a multi-target node,
+            // // *except* in a block's parameter list.
+            // auto mlhsLoc = translateLoc(multiTargetNode->lparen_loc.start, multiTargetNode->rparen_loc.end);
+
+            // auto multiLhsNode = translateMultiTargetLhs(multiTargetNode, mlhsLoc);
+
+            // params.emplace_back(move(multiLhsNode));
+
+            // TODO: Implement once `translateMultiTargetLhs` is migrated.
+            unreachable("Support for Mlhs is not implemented yet!");
+        } else {
+            paramsStore.emplace_back(desugar(n));
+        }
     }
 
-    for (auto &prismNode : posts) {
+    if (paramsNode->rest != nullptr) {
+        paramsStore.emplace_back(desugar(paramsNode->rest));
+    }
+
+    for (auto *prismNode : posts) {
         // Valid Ruby can only have `**nil` once in the parameter list, which is modelled with a
         // `NoKeywordsParameterNode` in the `keyword_rest` field.
         // If invalid code tries to use more than one `**nil` (like `def foo(**nil, **nil)`),
         // Prism will report an error, but still place the excess `**nil` nodes in `posts` list (never the others like
         // `requireds` or `optionals`), which we need to skip here.
         if (!PM_NODE_TYPE_P(prismNode, PM_NO_KEYWORDS_PARAMETER_NODE)) {
-            params.emplace_back(translate(prismNode));
+            paramsStore.emplace_back(desugar(prismNode));
         }
     }
 
-    translateMultiInto(params, keywords);
+    for (auto *kwarg : keywords) {
+        paramsStore.emplace_back(desugar(kwarg));
+    }
 
     bool hasForwardingParameter = false;
     if (auto *prismKwRestNode = paramsNode->keyword_rest) {
+        auto loc = translateLoc(prismKwRestNode->location);
+
         switch (PM_NODE_TYPE(prismKwRestNode)) {
             case PM_KEYWORD_REST_PARAMETER_NODE: // `def foo(**kwargs)`
-                params.emplace_back(translate(prismKwRestNode));
+                paramsStore.emplace_back(desugar(prismKwRestNode));
+                // TODO: Inline `case PM_KEYWORD_REST_PARAMETER_NODE` logic here.
                 break;
             case PM_FORWARDING_PARAMETER_NODE: { // `def foo(...)`
                 hasForwardingParameter = true;
-                params.emplace_back(translate(prismKwRestNode));
+
+                // Desugar `def foo(m, n, ...)` into:
+                // `def foo(m, n, *<fwd-args>, **<fwd-kwargs>, &<fwd-block>)`
+
+                // add `*<fwd-args>`
+                paramsStore.emplace_back(MK::RestParam(loc, MK::Local(loc, core::Names::fwdArgs())));
+
+                // add `**<fwd-kwargs>`
+                paramsStore.emplace_back(MK::RestParam(loc, MK::KeywordArg(loc, core::Names::fwdKwargs())));
+
+                // add `&<fwd-block>`
+                paramsStore.emplace_back(MK::BlockParam(loc, MK::Local(loc, core::Names::fwdBlock())));
+
                 break;
             }
             case PM_NO_KEYWORDS_PARAMETER_NODE: { // `def foo(**nil)`
-                params.emplace_back(make_unique<parser::Kwnilarg>(translateLoc(prismKwRestNode->location)));
+                // TODO: implement logic for `**nil` args
                 break;
             }
             default:
@@ -4301,54 +4343,11 @@ Translator::desugarParametersNode(pm_parameters_node *paramsNode, core::LocOffse
         }
 
         auto blockParamExpr = MK::BlockParam(blockParamLoc, MK::Local(blockParamLoc, enclosingBlockParamName));
-        auto blockParamNode =
-            make_node_with_expr<parser::BlockParam>(move(blockParamExpr), blockParamLoc, enclosingBlockParamName);
-
-        params.emplace_back(move(blockParamNode));
+        paramsStore.emplace_back(move(blockParamExpr));
     } else {
         // Desugaring a method def like `def foo(a, b)` should behave like `def foo(a, b, &<blk>)`,
         // so we set a synthetic name here for `yield` to use.
         enclosingBlockParamName = core::Names::blkArg();
-    }
-
-    for (auto &param : params) {
-        if (!(param->hasDesugaredExpr() ||
-              // These other block types don't have their own dedicated desugared
-              // representation, so they won't be directly translated.
-              // Instead, they have special desugar logic below.
-              parser::NodeWithExpr::isa_node<parser::Kwnilarg>(param.get()) ||         // `def f(**nil)`
-              parser::NodeWithExpr::isa_node<parser::ForwardArg>(param.get()) ||       // `def f(...)`
-              parser::NodeWithExpr::isa_node<parser::ForwardedRestArg>(param.get()) || // a splat like `def foo(*)`
-              parser::NodeWithExpr::isa_node<parser::Splat>(param.get()))) {           // a splat like `def foo(*a)`)
-            throw PrismFallback{};
-        }
-    };
-
-    ast::MethodDef::PARAMS_store paramsStore;
-    ast::InsSeq::STATS_store statsStore;
-
-    for (auto &param : params) {
-        auto loc = param->loc;
-
-        if (parser::NodeWithExpr::isa_node<parser::Mlhs>(param.get())) { // `def f((a, b))`
-            unreachable("Support for Mlhs is not implemented yet!");
-        } else if (parser::NodeWithExpr::isa_node<parser::Kwnilarg>(param.get())) { // `def foo(**nil)`
-            // TODO: implement logic for `**nil` args
-        } else if (parser::NodeWithExpr::isa_node<parser::ForwardArg>(param.get())) { // `def foo(...)`
-            // Desugar `def foo(m, n, ...)` into:
-            // `def foo(m, n, *<fwd-args>, **<fwd-kwargs>, &<fwd-block>)`
-
-            // add `*<fwd-args>`
-            paramsStore.emplace_back(MK::RestParam(loc, MK::Local(loc, core::Names::fwdArgs())));
-
-            // add `**<fwd-kwargs>`
-            paramsStore.emplace_back(MK::RestParam(loc, MK::KeywordArg(loc, core::Names::fwdKwargs())));
-
-            // add `&<fwd-block>`
-            paramsStore.emplace_back(MK::BlockParam(loc, MK::Local(loc, core::Names::fwdBlock())));
-        } else {
-            paramsStore.emplace_back(param->takeDesugaredExpr());
-        }
     }
 
     // Add in the block-local variables, if any.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
