### PR TITLE
Move RBS Prism rewriter to dedicated file

### DIFF
--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -118,12 +118,6 @@ void printUntypedBlames(const core::GlobalState &gs, const UnorderedMap<long, lo
 // Create a copy of `from` that has its symbol table reset to the payload.
 std::unique_ptr<core::GlobalState> copyForSlowPath(const core::GlobalState &from, const options::Options &opts);
 
-// RBS Prism rewriter function
-pm_node_t *runPrismRBSRewrite(sorbet::core::GlobalState &gs, sorbet::core::FileRef file, pm_node_t *node,
-                              const std::vector<sorbet::core::LocOffsets> &commentLocations,
-                              const sorbet::realmain::options::Printers &print, sorbet::core::MutableContext &ctx,
-                              parser::Prism::Parser &parser);
-
 } // namespace sorbet::realmain::pipeline
 
 #endif // RUBY_TYPER_PIPELINE_H

--- a/rbs/BUILD
+++ b/rbs/BUILD
@@ -15,6 +15,7 @@ cc_library(
         "//ast",
         "//common",
         "//core",
+        "//main/options",
         "//parser",
         "//parser/prism",
         "//rewriter/util",

--- a/rbs/prism/RBSRewriterPrism.cc
+++ b/rbs/prism/RBSRewriterPrism.cc
@@ -1,0 +1,34 @@
+#include "rbs/prism/RBSRewriterPrism.h"
+
+#include "common/timers/Timer.h"
+#include "rbs/prism/AssertionsRewriterPrism.h"
+#include "rbs/prism/CommentsAssociatorPrism.h"
+#include "rbs/prism/SigsRewriterPrism.h"
+
+using namespace std;
+
+namespace sorbet::rbs {
+
+pm_node_t *runPrismRBSRewrite(core::GlobalState &gs, core::FileRef file, pm_node_t *node,
+                              const vector<core::LocOffsets> &commentLocations,
+                              const realmain::options::Printers &print, core::MutableContext &ctx,
+                              parser::Prism::Parser &parser) {
+    Timer timeit(gs.tracer(), "runPrismRBSRewrite", {{"file", string(file.data(gs).path())}});
+
+    auto associator = CommentsAssociatorPrism(ctx, parser, commentLocations);
+    auto commentMap = associator.run(node);
+
+    auto sigsRewriter = SigsRewriterPrism(ctx, parser, commentMap.signaturesForNode);
+    node = sigsRewriter.run(node);
+
+    auto assertionsRewriter = AssertionsRewriterPrism(ctx, parser, commentMap.assertionsForNode);
+    node = assertionsRewriter.run(node);
+
+    if (print.RBSRewriteTree.enabled) {
+        print.RBSRewriteTree.fmt("{}\n", parser.prettyPrint(node));
+    }
+
+    return node;
+}
+
+} // namespace sorbet::rbs

--- a/rbs/prism/RBSRewriterPrism.h
+++ b/rbs/prism/RBSRewriterPrism.h
@@ -1,0 +1,23 @@
+#ifndef SORBET_RBS_RBS_REWRITER_PRISM_H
+#define SORBET_RBS_RBS_REWRITER_PRISM_H
+
+#include "core/Context.h"
+#include "core/LocOffsets.h"
+#include "main/options/options.h"
+#include "parser/prism/Parser.h"
+#include <vector>
+
+extern "C" {
+#include "prism.h"
+}
+
+namespace sorbet::rbs {
+
+pm_node_t *runPrismRBSRewrite(core::GlobalState &gs, core::FileRef file, pm_node_t *node,
+                              const std::vector<core::LocOffsets> &commentLocations,
+                              const realmain::options::Printers &print, core::MutableContext &ctx,
+                              parser::Prism::Parser &parser);
+
+} // namespace sorbet::rbs
+
+#endif // SORBET_RBS_RBS_REWRITER_PRISM_H

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -44,6 +44,7 @@
 #include "payload/payload.h"
 #include "rbs/AssertionsRewriter.h"
 #include "rbs/SigsRewriter.h"
+#include "rbs/prism/RBSRewriterPrism.h"
 #include "resolver/resolver.h"
 #include "rewriter/rewriter.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
@@ -257,9 +258,9 @@ vector<ast::ParsedFile> index(core::GlobalState &gs, absl::Span<core::FileRef> f
 
                         auto prismParseResult = prismParser.parseWithoutTranslation(collectComments);
 
-                        pm_node_t *rewrittenNode = realmain::pipeline::runPrismRBSRewrite(
-                            gs, file, prismParseResult.getRawNodePointer(), prismParseResult.getCommentLocations(),
-                            print, ctx, prismParser);
+                        pm_node_t *rewrittenNode =
+                            rbs::runPrismRBSRewrite(gs, file, prismParseResult.getRawNodePointer(),
+                                                    prismParseResult.getCommentLocations(), print, ctx, prismParser);
 
                         auto translatedTree =
                             parser::Prism::Translator(prismParser, ctx, prismParseResult.getParseErrors(), false, false)
@@ -792,9 +793,9 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 
                     auto prismParseResult = prismParser.parseWithoutTranslation(collectComments);
 
-                    pm_node_t *rewrittenNode = realmain::pipeline::runPrismRBSRewrite(
-                        *gs, f.file, prismParseResult.getRawNodePointer(), prismParseResult.getCommentLocations(),
-                        print, ctx, prismParser);
+                    pm_node_t *rewrittenNode =
+                        rbs::runPrismRBSRewrite(*gs, f.file, prismParseResult.getRawNodePointer(),
+                                                prismParseResult.getCommentLocations(), print, ctx, prismParser);
 
                     auto translatedTree =
                         parser::Prism::Translator(prismParser, ctx, prismParseResult.getParseErrors(), false, false)


### PR DESCRIPTION
This exposes the prism RBS rewriter and allows it to be called from the test runner. Pipeline test runner works now. Addresses https://github.com/Shopify/sorbet/pull/791#discussion_r2598995828

