### PR TITLE
Make parser option cache sensitive

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -1045,6 +1045,7 @@ void readOptions(Options &opts,
         opts.stopAfterPhase = extractStopAfter(raw, logger);
 
         opts.parser = extractParser(raw["parser"].as<string>(), logger).value_or(Parser::ORIGINAL);
+        opts.cacheSensitiveOptions.usePrismParser = (opts.parser == Parser::PRISM);
         opts.silenceErrors = raw["quiet"].as<bool>();
         opts.autocorrect = raw["autocorrect"].as<bool>();
         opts.didYouMean = raw["did-you-mean"].as<bool>();

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -206,13 +206,17 @@ struct Options {
 
         bool sorbetPackages : 1;
 
+        // The two parsers can produce slightly different desugar trees or
+        // error messages, which we don't want to intermix.
+        bool usePrismParser : 1;
+
         // HELLO! adding/removing MUST also change this number!!
-        constexpr static uint8_t NUMBER_OF_FLAGS = 7;
+        constexpr static uint8_t NUMBER_OF_FLAGS = 8;
 
         // In C++20 we can replace this with bit field initializers
         CacheSensitiveOptions()
             : noStdlib(false), typedSuper(true), rbsEnabled(false), requiresAncestorEnabled(false),
-              rspecRewriterEnabled(false), runningUnderAutogen(false), sorbetPackages(false) {}
+              rspecRewriterEnabled(false), runningUnderAutogen(false), sorbetPackages(false), usePrismParser(false) {}
 
         constexpr static uint8_t VALID_BITS_MASK = (1 << NUMBER_OF_FLAGS) - 1;
 


### PR DESCRIPTION
This commit ensures we do not share the cache between original and prism parser modes. I noticed while testing that running `tc` first with `--parser=prism` changed the output of `tc` when running with `--parser=original`. Given the two parsers produce ever so slightly different desugared representations of the same source code, this is not surprising.

Although we'd like for the desugared representation to be as close to identical as possible, in some cases we may opt to produce a different AST, e.g. in error recovery cases where the parsers work quite differently. At least for now, it makes sense to not share the cache between the two parser modes.