### PR TITLE
Track resolved constants during RBS rewriting

### DIFF
--- a/ast/desugar/prism/Desugar.cc
+++ b/ast/desugar/prism/Desugar.cc
@@ -5109,65 +5109,14 @@ ast::ExpressionPtr Desugarer::translateConst(pm_node_t *anyNode) {
                                     is_same_v<PrismLhsNode, pm_constant_path_write_node> ||
                                     is_same_v<PrismLhsNode, pm_constant_path_node>;
 
+    // Check if this constant was pre-resolved by the RBS rewriter.
+    if (auto symbol = parser.getResolvedSymbol(up_cast(node)); symbol.exists()) {
+        return MK::Constant(location, symbol);
+    }
+
     ast::ExpressionPtr parentExpr;
 
     if constexpr (isConstantPath) { // Handle constant paths, has a parent node that needs translation.
-        // Resolve well-known root-anchored constant paths that the RBS rewriter injects.
-        // The legacy RBS rewriter emits these as pre-resolved `parser::ResolvedConst` nodes,
-        // but the Prism RBS rewriter inserts raw constant path nodes. Resolving them here
-        // ensures the desugared AST matches the legacy parser output.
-        //
-        // Matches: ::Sorbet::Private::Static, ::T::Sig::WithoutRuntime, ::Sorbet::Private::Static::Void
-        //
-        // Only enabled when RBS is active, since these constants only appear in RBS-rewritten ASTs.
-        if (ctx.state.cacheSensitiveOptions.rbsEnabled) {
-            pm_node_t *current = up_cast(const_cast<PrismLhsNode *>(node));
-            bool isRootAnchored = false;
-            // Max size of 4, to fit the longest path we're searching for (`Sorbet::Private::Static::Void`).
-            // Segments collected innermost-first.
-            InlinedVector<std::string_view, 4> segments;
-
-            while (current != nullptr && segments.size() < 4) {
-                switch (PM_NODE_TYPE(current)) {
-                    case PM_CONSTANT_PATH_NODE: {
-                        auto *p = down_cast_nonnull<pm_constant_path_node>(current);
-                        segments.push_back(parser.resolveConstant(p->name));
-                        current = p->parent;
-                        if (current == nullptr) {
-                            isRootAnchored = true;
-                        }
-                        break;
-                    }
-                    case PM_CONSTANT_READ_NODE: {
-                        auto *r = down_cast_nonnull<pm_constant_read_node>(current);
-                        segments.push_back(parser.resolveConstant(r->name));
-                        current = nullptr;
-                        break;
-                    }
-                    default:
-                        current = nullptr;
-                        break;
-                }
-            }
-
-            // Only match root-anchored paths that were fully resolved (no remaining parent).
-            if (isRootAnchored) {
-                // segments: [innermost, ..., outermost]
-                if (segments.size() == 3 && segments[2] == "Sorbet" && segments[1] == "Private" &&
-                    segments[0] == "Static") {
-                    return MK::Constant(location, core::Symbols::Sorbet_Private_Static());
-                }
-                if (segments.size() == 3 && segments[2] == "T" && segments[1] == "Sig" &&
-                    segments[0] == "WithoutRuntime") {
-                    return MK::Constant(location, core::Symbols::T_Sig_WithoutRuntime());
-                }
-                if (segments.size() == 4 && segments[3] == "Sorbet" && segments[2] == "Private" &&
-                    segments[1] == "Static" && segments[0] == "Void") {
-                    return MK::Constant(location, core::Symbols::void_());
-                }
-            }
-        }
-
         if (auto *prismParentNode = node->parent) {
             // This constant reference is chained onto another constant reference.
             // E.g. given `A::B::C`, if `node` is pointing to the root, `A::B` is the `parent`, and `C` is the

--- a/parser/prism/Factory.cc
+++ b/parser/prism/Factory.cc
@@ -1,4 +1,5 @@
 #include "parser/prism/Factory.h"
+#include "core/Symbols.h"
 #include "parser/prism/Helpers.h"
 #include "parser/prism/Parser.h"
 #include <array>
@@ -274,19 +275,20 @@ pm_node_t *Factory::SorbetPrivateStatic(core::LocOffsets loc) const {
     // Build a root-anchored constant path ::Sorbet::Private::Static
     pm_node_t *sorbet = ConstantPathNode(loc, nullptr, "Sorbet"sv);
     pm_node_t *sorbetPrivate = ConstantPathNode(loc, sorbet, "Private"sv);
-    return ConstantPathNode(loc, sorbetPrivate, "Static"sv);
+    return parser.markResolved(ConstantPathNode(loc, sorbetPrivate, "Static"sv),
+                               core::Symbols::Sorbet_Private_Static());
 }
 
 pm_node_t *Factory::SorbetPrivateStaticVoid(core::LocOffsets loc) const {
     // Build a root-anchored constant path ::Sorbet::Private::Static::Void
-    return ConstantPathNode(loc, SorbetPrivateStatic(loc), "Void"sv);
+    return parser.markResolved(ConstantPathNode(loc, SorbetPrivateStatic(loc), "Void"sv), core::Symbols::void_());
 }
 
 pm_node_t *Factory::TSigWithoutRuntime(core::LocOffsets loc) const {
     // Build a root-anchored constant path ::T::Sig::WithoutRuntime
     pm_node_t *tConst = ConstantPathNode(loc, nullptr, "T"sv);
     pm_node_t *tSig = ConstantPathNode(loc, tConst, "Sig"sv);
-    return ConstantPathNode(loc, tSig, "WithoutRuntime"sv);
+    return parser.markResolved(ConstantPathNode(loc, tSig, "WithoutRuntime"sv), core::Symbols::T_Sig_WithoutRuntime());
 }
 
 pm_node_t *Factory::Symbol(core::LocOffsets nameLoc, string_view name) const {

--- a/parser/prism/Parser.h
+++ b/parser/prism/Parser.h
@@ -10,6 +10,7 @@ extern "C" {
 }
 
 #include "core/LocOffsets.h"
+#include "core/SymbolRef.h"
 #include "parser/Node.h" // To clarify: these are Sorbet Parser nodes, not Prism ones.
 
 namespace sorbet::parser::Prism {
@@ -34,6 +35,11 @@ class Parser final {
 
     pm_parser_t parser;
     pm_options_t options;
+
+    // Tracks Prism constant nodes (by their `node_id`) that have already been resolved to a known Sorbet symbol.
+    // The desugarer can directly emit resolved `ast::ConstantLit` nodes for these, instead of the usual
+    // `ast::UnresolvedConstantLit` nodes.
+    UnorderedMap<uint32_t, core::SymbolRef> resolvedConstants_;
 
     friend class ParseResult;
     friend class Factory;
@@ -73,6 +79,19 @@ public:
     bool isAttrAccessorCall(pm_node_t *node) const;
 
     void destroyNode(pm_node_t *node);
+
+    // Record that `node` should resolve to `symbol`. Returns the same node pointer, for convenience.
+    pm_node_t *markResolved(pm_node_t *node, core::SymbolRef symbol) {
+        ENFORCE(node != nullptr);
+        resolvedConstants_[node->node_id] = symbol;
+        return node;
+    }
+
+    // Returns the resolved Symbol for `node` (if there was one).
+    core::SymbolRef getResolvedSymbol(const pm_node_t *node) const {
+        auto it = resolvedConstants_.find(node->node_id);
+        return it != resolvedConstants_.end() ? it->second : core::Symbols::noSymbol();
+    }
 
 private:
     std::vector<ParseError> collectErrors();


### PR DESCRIPTION
### Motivation

Since https://github.com/sorbet/sorbet/pull/10008 the Prism desugarer looks for a specific set of constant nodes, and always resolves them eagerly, but only when RBS is on:

https://github.com/Shopify/sorbet/blob/561dad245e217ad4aaa026b9929ab64a0ee7874c/ast/desugar/prism/Desugar.cc#L5204-L5212

This won't work for some other cases, like rewriting `nil`, as a in `#: -> nil`. The Prism rewriter currently makes an unresolved reference:

https://github.com/Shopify/sorbet/blob/5735fdd18bac2b4e43df76827249596ecf0772a0/test/testdata/rbs/signatures_types.rb.rewrite-tree.prism.exp#L138-L140

This PR removes the hard-coded checks, and replaces them with a map from `pm_node_t *` to `core::SymbolRef`. Every time the desugarer is about to desugar a constant, it first checks the map. If it's there, it returns a resolved constant for that symbol (`MK::Constant()`), otherwise it creates an unresolved constant like normal (`MK::UnresolvedConstant()`).

### Test plan

Pure refactor.