### PR TITLE
Support typed Data.define members via RBS comment

### DIFF
--- a/rbs/CommentsAssociator.cc
+++ b/rbs/CommentsAssociator.cc
@@ -254,6 +254,98 @@ bool CommentsAssociator::typeAliasAllowedInContext() const {
     return !contextAllowingTypeAlias.empty() && contextAllowingTypeAlias.back().first;
 }
 
+bool CommentsAssociator::isDataDefineCall(pm_call_node_t *call) {
+    if (parser.resolveConstant(call->name) != "define"sv || call->receiver == nullptr) {
+        return false;
+    }
+
+    if (auto *constantRead = down_cast<pm_constant_read_node_t>(call->receiver)) {
+        return parser.resolveConstant(constantRead->name) == "Data"sv;
+    }
+
+    if (auto *constantPath = down_cast<pm_constant_path_node_t>(call->receiver)) {
+        return constantPath->parent == nullptr && parser.resolveConstant(constantPath->name) == "Data"sv;
+    }
+
+    return false;
+}
+
+void CommentsAssociator::maybeExtractDataDefineOrphanComments(pm_node_t *blockNode, int beginLine) {
+    ENFORCE(blockNode != nullptr && PM_NODE_TYPE_P(blockNode, PM_BLOCK_NODE));
+    auto *block = down_cast_nonnull<pm_block_node_t>(blockNode);
+
+    auto checkInit = [&](pm_node_t *node) {
+        auto *def = down_cast<pm_def_node_t>(node);
+        return def != nullptr && parser.resolveConstant(def->name) == "initialize"sv;
+    };
+
+    if (block->body != nullptr) {
+        if (checkInit(block->body)) {
+            return;
+        }
+        if (auto *statements = down_cast<pm_statements_node_t>(block->body)) {
+            for (size_t i = 0; i < statements->body.size; i++) {
+                if (checkInit(statements->body.nodes[i])) {
+                    return;
+                }
+            }
+        }
+    }
+
+    auto endLine = posToLine(translateLocation(blockNode->location).endPos());
+
+    int firstDefLine = endLine;
+    if (block->body != nullptr) {
+        auto checkDef = [&](pm_node_t *node) -> int {
+            if (isa_node<pm_def_node_t>(node)) {
+                return posToLine(translateLocation(node->location).beginPos());
+            }
+            return endLine;
+        };
+        if (auto *statements = down_cast<pm_statements_node_t>(block->body)) {
+            for (size_t i = 0; i < statements->body.size; i++) {
+                int line = checkDef(statements->body.nodes[i]);
+                if (line < firstDefLine) {
+                    firstDefLine = line;
+                    break;
+                }
+            }
+        } else {
+            firstDefLine = checkDef(block->body);
+        }
+    }
+
+    // Extract orphan RBS comments for Data.define's virtual initialize. Comments
+    // adjacent to a method are left alone so the normal signature associator can
+    // attach them to that method; comments with a blank-line gap before the first
+    // method are considered virtual-initialize comments.
+    vector<CommentNode> comments;
+    for (auto it = commentByLine.begin(); it != commentByLine.end();) {
+        if (it->first <= beginLine) {
+            ++it;
+            continue;
+        }
+        if (it->first >= endLine) {
+            break;
+        }
+        if (absl::StartsWith(it->second.string, RBS_PREFIX) ||
+            absl::StartsWith(it->second.string, MULTILINE_RBS_PREFIX)) {
+            bool isOrphan = (block->body == nullptr) || (it->first + 1 < firstDefLine);
+            if (isOrphan) {
+                comments.emplace_back(it->second);
+                it = commentByLine.erase(it);
+                continue;
+            }
+            break;
+        }
+        ++it;
+    }
+
+    if (!comments.empty()) {
+        signaturesForNode[blockNode] = move(comments);
+    }
+}
+
 // Finds standalone RBS comments (not attached to any Ruby code) between lastLine and currentLine,
 // and inserts synthetic placeholder nodes into the AST. 2 types of placeholders are created:
 // 1. Bind comments (#: self as Type): placeholders later replaced with T.bind(self, Type)
@@ -749,6 +841,11 @@ void CommentsAssociator::walkNode(pm_node_t *node) {
                 associateAssertionCommentsToNode(node);
                 walkNode(call->receiver);
                 walkArgumentsNode(call->arguments);
+                if (call->block && PM_NODE_TYPE_P(call->block, PM_BLOCK_NODE) && isDataDefineCall(call)) {
+                    auto blockLoc = translateLocation(call->block->location);
+                    auto beginLine = posToLine(blockLoc.beginPos());
+                    maybeExtractDataDefineOrphanComments(call->block, beginLine);
+                }
                 walkNode(call->block);
             }
             break;

--- a/rbs/CommentsAssociator.h
+++ b/rbs/CommentsAssociator.h
@@ -71,6 +71,8 @@ private:
     void consumeCommentsBetweenLines(int startLine, int endLine, std::string_view kind);
     void consumeOrphanedSignatureComments(int startLine, int endLine);
     void consumeCommentsUntilLine(int line);
+    bool isDataDefineCall(pm_call_node_t *call);
+    void maybeExtractDataDefineOrphanComments(pm_node_t *blockNode, int beginLine);
     std::optional<uint32_t> locateTargetLine(pm_node_t *node);
     core::LocOffsets translateLocation(pm_location_t location);
     uint32_t posToLine(uint32_t pos);

--- a/rbs/SigsRewriter.cc
+++ b/rbs/SigsRewriter.cc
@@ -19,6 +19,22 @@ namespace sorbet::rbs {
 
 namespace {
 
+bool isDataDefineCall(pm_call_node_t *call, const parser::Prism::Parser &parser) {
+    if (parser.resolveConstant(call->name) != "define"sv || call->receiver == nullptr) {
+        return false;
+    }
+
+    if (auto *constantRead = down_cast<pm_constant_read_node_t>(call->receiver)) {
+        return parser.resolveConstant(constantRead->name) == "Data"sv;
+    }
+
+    if (auto *constantPath = down_cast<pm_constant_path_node_t>(call->receiver)) {
+        return constantPath->parent == nullptr && parser.resolveConstant(constantPath->name) == "Data"sv;
+    }
+
+    return false;
+}
+
 bool canHaveSignature(pm_node_t *node, const parser::Prism::Parser &parser, const core::GlobalState &gs) {
     if (node == nullptr) {
         return false;
@@ -669,8 +685,11 @@ void SigsRewriter::rewriteNode(pm_node_t *node) {
         }
         case PM_CALL_NODE: {
             auto *call = down_cast_nonnull<pm_call_node_t>(node);
-            if (auto *block = call->block) {
-                rewriteNode(block);
+            if (auto *block = down_cast<pm_block_node_t>(call->block)) {
+                if (isDataDefineCall(call, parser)) {
+                    maybeSynthesizeDataDefineVirtualInit(block, call);
+                }
+                rewriteNode(up_cast(block));
             }
             rewriteArgumentsNode(call->arguments);
             break;
@@ -726,6 +745,105 @@ void SigsRewriter::rewriteNode(pm_node_t *node) {
         default:
             break;
     }
+}
+
+// For Data.define blocks with an orphan RBS signature associated with the
+// PM_BLOCK_NODE, synthesize a virtual `def initialize(x:, y:) = super` with
+// keyword args matching the Data.define members, then translate the RBS comment
+// into the sig node that will attach to that synthetic method during desugaring.
+void SigsRewriter::maybeSynthesizeDataDefineVirtualInit(pm_block_node_t *block, pm_call_node_t *call) {
+    auto comments = commentsForNode(up_cast(block));
+    if (comments.signatures.empty() || call->arguments == nullptr) {
+        return;
+    }
+
+    auto synthLoc = comments.signatures[0].commentLoc();
+    if (!synthLoc.exists()) {
+        synthLoc = parser.translateLocation(call->message_loc);
+    }
+    auto pmSynthLoc = parser.convertLocOffsets(synthLoc);
+    auto pmZeroLoc = parser.convertLocOffsets(synthLoc.copyWithZeroLength());
+
+    pm_node_list_t keywords = prism.emptyNodeList();
+    for (size_t i = 0; i < call->arguments->arguments.size; i++) {
+        auto *arg = call->arguments->arguments.nodes[i];
+        auto *symbol = down_cast<pm_symbol_node_t>(arg);
+        if (symbol == nullptr) {
+            continue;
+        }
+
+        auto symbolName = string_view(reinterpret_cast<const char *>(symbol->unescaped.source), symbol->unescaped.length);
+        auto nameId = prism.addConstantToPool(symbolName);
+
+        auto *kwarg = prism.allocateNode<pm_required_keyword_parameter_node_t>();
+        *kwarg = (pm_required_keyword_parameter_node_t){
+            .base = prism.initializeBaseNode(PM_REQUIRED_KEYWORD_PARAMETER_NODE, symbol->base.location),
+            .name = nameId,
+            .name_loc = symbol->base.location,
+        };
+        pm_node_list_append(&keywords, up_cast(kwarg));
+    }
+
+    auto *params = prism.allocateNode<pm_parameters_node_t>();
+    *params = (pm_parameters_node_t){
+        .base = prism.initializeBaseNode(PM_PARAMETERS_NODE, pmSynthLoc),
+        .requireds = prism.emptyNodeList(),
+        .optionals = prism.emptyNodeList(),
+        .rest = nullptr,
+        .posts = prism.emptyNodeList(),
+        .keywords = keywords,
+        .keyword_rest = nullptr,
+        .block = nullptr,
+    };
+
+    auto *superNode = prism.allocateNode<pm_forwarding_super_node_t>();
+    *superNode = (pm_forwarding_super_node_t){
+        .base = prism.initializeBaseNode(PM_FORWARDING_SUPER_NODE, pmSynthLoc),
+        .block = nullptr,
+    };
+
+    pm_node_t *superStmt = up_cast(superNode);
+    auto *bodyStmts = down_cast_nonnull<pm_statements_node_t>(prism.StatementsNode(synthLoc, absl::MakeSpan(&superStmt, 1)));
+
+    auto *defNode = prism.allocateNode<pm_def_node_t>();
+    *defNode = (pm_def_node_t){
+        .base = prism.initializeBaseNode(PM_DEF_NODE, pmSynthLoc),
+        .name = prism.addConstantToPool("initialize"sv),
+        .name_loc = pmSynthLoc,
+        .receiver = nullptr,
+        .parameters = params,
+        .body = up_cast(bodyStmts),
+        .locals = {.size = 0, .capacity = 0, .ids = nullptr},
+        .def_keyword_loc = pmSynthLoc,
+        .operator_loc = pmZeroLoc,
+        .lparen_loc = pmZeroLoc,
+        .rparen_loc = pmZeroLoc,
+        .equal_loc = pmZeroLoc,
+        .end_keyword_loc = pmZeroLoc,
+    };
+
+    auto signatureTranslator = rbs::SignatureTranslator{ctx, parser};
+    auto *sig = signatureTranslator.translateMethodSignature(up_cast(defNode), comments.signatures[0], comments.annotations);
+    if (sig == nullptr) {
+        return;
+    }
+
+    vector<pm_node_t *> newBody;
+    newBody.push_back(sig);
+    newBody.push_back(up_cast(defNode));
+
+    if (block->body != nullptr) {
+        if (auto *statements = down_cast<pm_statements_node_t>(block->body)) {
+            newBody.reserve(newBody.size() + statements->body.size);
+            for (size_t i = 0; i < statements->body.size; i++) {
+                newBody.push_back(statements->body.nodes[i]);
+            }
+        } else {
+            newBody.push_back(block->body);
+        }
+    }
+
+    block->body = prism.StatementsNode(synthLoc, absl::MakeSpan(newBody));
 }
 
 void SigsRewriter::run(pm_node_t *node) {

--- a/rbs/SigsRewriter.h
+++ b/rbs/SigsRewriter.h
@@ -56,6 +56,7 @@ private:
     void rewriteNodes(pm_node_list_t &nodes);
     void rewriteArgumentsNode(pm_arguments_node_t *args);
     void rewriteClass(pm_node_t *node);
+    void maybeSynthesizeDataDefineVirtualInit(pm_block_node_t *block, pm_call_node_t *call);
     std::unique_ptr<std::vector<pm_node_t *>> signaturesForNode(pm_node_t *node);
     Comments commentsForNode(pm_node_t *node);
     void insertTypeParams(pm_node_t *node, pm_node_t *body);

--- a/rewriter/Data.cc
+++ b/rewriter/Data.cc
@@ -39,6 +39,137 @@ bool isMissingInitialize(const core::GlobalState &gs, const ast::Send *send) {
     return true;
 }
 
+// Find the params Send inside a sig block body. Navigates through the
+// method chain like: self.params(...).void() or self.params(...).returns(...)
+//
+// Returns a non-owning pointer into the sig's AST. The returned pointer borrows
+// from the ExpressionPtr tree rooted at `sigBlockBody`; it remains valid as long
+// as that tree is alive (i.e., until the block body is move()'d later in Data::run).
+const ast::Send *findSigParamsCall(const ast::ExpressionPtr &sigBlockBody) {
+    auto current = ast::cast_tree<ast::Send>(sigBlockBody);
+    while (current) {
+        if (current->fun == core::Names::params()) {
+            return current;
+        }
+        current = ast::cast_tree<ast::Send>(current->recv);
+    }
+    return nullptr;
+}
+
+// Check whether a MethodDef body is exactly a bare `super` call (i.e.,
+// `def initialize(...) = super` which desugars to `send(untypedSuper, [ZSuperArgs])`).
+// Only when the body is bare super can we reliably propagate sig types to readers,
+// because the values are forwarded to Data's internal storage unchanged.
+//
+// `methodDef` is a non-owning pointer borrowed from the block body's InsSeq.
+bool isBareSuper(const ast::MethodDef *methodDef) {
+    auto send = ast::cast_tree<ast::Send>(methodDef->rhs);
+    if (!send || send->fun != core::Names::untypedSuper()) {
+        return false;
+    }
+    return send->numPosArgs() == 1 && ast::isa_tree<ast::ZSuperArgs>(send->getPosArg(0));
+}
+
+// Find the sig Send that immediately precedes a def initialize in an InsSeq,
+// but only if the initialize body is bare `super`. Returns nullptr otherwise.
+//
+// Returns a non-owning pointer into the InsSeq's statement list. The pointer
+// borrows from the Data.define block body and remains valid until that body is
+// move()'d into the synthesized class definition later in Data::run.
+//
+// We intentionally restrict typed readers to bare-super initializers because
+// if the user transforms values (e.g. `super(x: x.to_i)`), the reader types
+// would not match the sig's parameter types. This conservative approach follows
+// the principle that "Sorbet doesn't do anything" unless precise constraints
+// are met, keeping our options open for smarter analysis in the future.
+const ast::Send *findSigBeforeInitialize(const ast::InsSeq &insSeq) {
+    for (size_t i = 0; i < insSeq.stats.size(); i++) {
+        auto candidateSig = ast::cast_tree<ast::Send>(insSeq.stats[i]);
+        if (!candidateSig || candidateSig->fun != core::Names::sig()) {
+            continue;
+        }
+
+        // Check if the next statement is def initialize with bare super
+        const ast::MethodDef *initDef = nullptr;
+        if (i + 1 < insSeq.stats.size()) {
+            initDef = ast::cast_tree<ast::MethodDef>(insSeq.stats[i + 1]);
+        }
+        if (!initDef && i + 1 == insSeq.stats.size()) {
+            initDef = ast::cast_tree<ast::MethodDef>(insSeq.expr);
+        }
+
+        if (initDef && initDef->name == core::Names::initialize() && isBareSuper(initDef)) {
+            return candidateSig;
+        }
+    }
+    return nullptr;
+}
+
+// Extract parameter name -> type mappings from a sig's params(...) call.
+// `paramsCall` is a non-owning pointer borrowed from the sig's block body.
+// Type expressions are deep-copied into `types` so the output is independent
+// of the original AST's lifetime.
+//
+// Handles two formats:
+//   - Keyword args (from RBS-created sigs via desugaring): params(x: Integer, y: String)
+//     → numPosArgs=0, kwargs flattened as alternating key/value pairs
+//   - Positional pairs (from rewriter-synthesized sigs): params(:x, Integer, :y, String)
+//     → numPosArgs=N, all args positional
+void extractTypesFromParams(const ast::Send *paramsCall,
+                            UnorderedMap<core::NameRef, ast::ExpressionPtr> &types) {
+    if (paramsCall->numKwArgs() > 0) {
+        for (uint16_t i = 0; i < paramsCall->numKwArgs(); i++) {
+            auto key = ast::cast_tree<ast::Literal>(paramsCall->getKwKey(i));
+            if (key && key->isSymbol()) {
+                types[key->asSymbol()] = paramsCall->getKwValue(i).deepCopy();
+            }
+        }
+    } else if (paramsCall->numPosArgs() >= 2) {
+        for (uint16_t i = 0; i + 1 < paramsCall->numPosArgs(); i += 2) {
+            auto key = ast::cast_tree<ast::Literal>(paramsCall->getPosArg(i));
+            if (key && key->isSymbol()) {
+                types[key->asSymbol()] = paramsCall->getPosArg(i + 1).deepCopy();
+            }
+        }
+    }
+}
+
+// Extract parameter name -> type mappings from a sig preceding def initialize
+// in the block body. Returns a map from member name to deep-copied type expressions.
+//
+// The `send` parameter is a non-owning pointer to the Data.define Send node,
+// borrowed from the Assign node in Data::run. We read from it (to find the sig
+// and extract types) before the block body is move()'d into the synthesized class.
+// The returned map contains deep copies of the type expressions, so it is safe to
+// use after the original AST nodes have been moved.
+UnorderedMap<core::NameRef, ast::ExpressionPtr> extractInitializeTypes(const ast::Send *send) {
+    UnorderedMap<core::NameRef, ast::ExpressionPtr> types;
+
+    if (!send->hasBlock()) {
+        return types;
+    }
+
+    auto block = send->block();
+    auto insSeq = ast::cast_tree<ast::InsSeq>(block->body);
+    if (!insSeq) {
+        return types;
+    }
+
+    auto sigSend = findSigBeforeInitialize(*insSeq);
+    if (!sigSend || !sigSend->hasBlock()) {
+        return types;
+    }
+
+    auto sigBlock = sigSend->block();
+    auto paramsCall = findSigParamsCall(sigBlock->body);
+    if (!paramsCall) {
+        return types;
+    }
+
+    extractTypesFromParams(paramsCall, types);
+    return types;
+}
+
 } // namespace
 
 vector<ast::ExpressionPtr> Data::run(core::MutableContext ctx, ast::Assign *asgn) {
@@ -81,6 +212,13 @@ vector<ast::ExpressionPtr> Data::run(core::MutableContext ctx, ast::Assign *asgn
         return empty;
     }
 
+    // If the block contains a typed def initialize (with a sig and bare super),
+    // extract the parameter types so we can create typed reader stubs.
+    // This must happen BEFORE the block body is move()'d below — the extraction
+    // reads from the block's AST and deep-copies the type expressions into
+    // `memberTypes`, which is then safe to use after the move.
+    auto memberTypes = extractInitializeTypes(send);
+
     for (auto &arg : send->posArgs()) {
         auto sym = ast::cast_tree<ast::Literal>(arg);
         if (!sym || !sym->isName()) {
@@ -105,6 +243,12 @@ vector<ast::ExpressionPtr> Data::run(core::MutableContext ctx, ast::Assign *asgn
         auto argName = ast::MK::Local(symLoc, name);
         newArgs.emplace_back(ast::MK::OptionalParam(symLoc, move(argName), ast::MK::Nil(symLoc)));
 
+        // If we have a typed initialize, create a typed reader with a sig.
+        // Otherwise, create an untyped reader (existing behavior).
+        auto it = memberTypes.find(name);
+        if (it != memberTypes.end()) {
+            body.emplace_back(ast::MK::Sig0(symLoc.copyWithZeroLength(), move(it->second)));
+        }
         body.emplace_back(ast::MK::SyntheticMethod0(symLoc, symLoc, name, ast::MK::RaiseUnimplemented(loc)));
     }
 

--- a/test/testdata/rbs/signatures_data_define.rb
+++ b/test/testdata/rbs/signatures_data_define.rb
@@ -1,0 +1,140 @@
+# typed: true
+# enable-experimental-rbs-comments: true
+
+# Basic typed members via virtual initialize
+TypedPoint = Data.define(:x, :y) do
+  #: (x: Integer, y: String) -> void
+end
+
+TypedPoint.new(x: 1, y: "hello")
+TypedPoint.new(x: "bad", y: "hello") # error: Expected `Integer` but found `String("bad")` for argument `x`
+T.reveal_type(TypedPoint.new(x: 1, y: "hi").x) # error: Revealed type: `Integer`
+T.reveal_type(TypedPoint.new(x: 1, y: "hi").y) # error: Revealed type: `String`
+
+# With explicit initialize and defaults
+Money = Data.define(:amount, :currency) do
+  #: (amount: Numeric, ?currency: String) -> void
+  def initialize(amount:, currency: "USD") = super
+end
+T.reveal_type(Money.new(amount: 10).currency) # error: Revealed type: `String`
+T.reveal_type(Money.new(amount: 10).amount) # error: Revealed type: `Numeric`
+Money.new(amount: "bad") # error: Expected `Numeric` but found `String("bad")` for argument `amount`
+
+# With additional methods in block
+DataWithMethods = Data.define(:user) do
+  #: (user: String) -> void
+
+  #: -> T::Boolean
+  def active?
+    !user.empty?
+  end
+end
+
+T.reveal_type(DataWithMethods.new(user: "alice").user) # error: Revealed type: `String`
+
+# Fully qualified ::Data
+QualifiedData = ::Data.define(:a, :b) do
+  #: (a: Integer, b: Float) -> void
+end
+T.reveal_type(QualifiedData.new(a: 1, b: 2.0).a) # error: Revealed type: `Integer`
+T.reveal_type(QualifiedData.new(a: 1, b: 2.0).b) # error: Revealed type: `Float`
+
+# Untyped fallback (no sig) - existing behavior
+PlainData = Data.define(:x, :y)
+T.reveal_type(PlainData.new(1, 2).x) # error: Revealed type: `T.untyped`
+
+# Block with no sig - existing behavior
+BlockNoSig = Data.define(:x) do
+  #: -> String
+  def to_s
+    "BlockNoSig"
+  end
+end
+T.reveal_type(BlockNoSig.new(1).x) # error: Revealed type: `T.untyped`
+
+# Mismatched sig param names vs Data.define members - falls back to untyped.
+# The synthesized def initialize(x:) doesn't match the sig param (a:),
+# so the RBS translator produces parameter mismatch errors and the sig is discarded.
+MismatchedSingle = Data.define(:x) do # error: Malformed `sig`. Type not specified for parameter `x`
+  #: (a: Integer) -> void
+  #   ^ error: Unknown parameter name `a`
+end
+T.reveal_type(MismatchedSingle.new(x: 1).x) # error: Revealed type: `T.untyped`
+
+# Partial member typing - only some members have types
+PartialData = Data.define(:x, :y, :z) do
+  #: (x: Integer, y: String, z: Float) -> void
+end
+T.reveal_type(PartialData.new(x: 1, y: "hi", z: 2.0).x) # error: Revealed type: `Integer`
+T.reveal_type(PartialData.new(x: 1, y: "hi", z: 2.0).y) # error: Revealed type: `String`
+T.reveal_type(PartialData.new(x: 1, y: "hi", z: 2.0).z) # error: Revealed type: `Float`
+
+# Block with non-method statements and orphan sig (e.g. include)
+module Printable; end
+IncludeData = Data.define(:val) do
+  #: (val: Integer) -> void
+
+  include Printable
+end
+T.reveal_type(IncludeData.new(val: 42).val) # error: Revealed type: `Integer`
+
+# Complex types: T.nilable
+NilableData = Data.define(:name, :email) do
+  #: (name: String, email: String?) -> void
+end
+T.reveal_type(NilableData.new(name: "alice", email: nil).name) # error: Revealed type: `String`
+T.reveal_type(NilableData.new(name: "alice", email: nil).email) # error: Revealed type: `T.nilable(String)`
+
+# Complex types: T.any union
+UnionData = Data.define(:value) do
+  #: (value: String | Integer | Symbol) -> void
+end
+T.reveal_type(UnionData.new(value: "hi").value) # error: Revealed type: `T.any(String, Integer, Symbol)`
+
+# Complex types: generic collections
+CollectionData = Data.define(:items, :meta) do
+  #: (items: Array[String], meta: Hash[Symbol, Integer]) -> void
+end
+T.reveal_type(CollectionData.new(items: ["a"], meta: {x: 1}).items) # error: Revealed type: `T::Array[String]`
+T.reveal_type(CollectionData.new(items: ["a"], meta: {x: 1}).meta) # error: Revealed type: `T::Hash[Symbol, Integer]`
+
+# Many members (5+)
+ManyMembers = Data.define(:a, :b, :c, :d, :e) do
+  #: (a: Integer, b: String, c: Float, d: Symbol, e: bool) -> void
+end
+T.reveal_type(ManyMembers.new(a: 1, b: "x", c: 1.0, d: :y, e: true).a) # error: Revealed type: `Integer`
+T.reveal_type(ManyMembers.new(a: 1, b: "x", c: 1.0, d: :y, e: true).e) # error: Revealed type: `T::Boolean`
+
+# Nested in module
+module Predicates
+  UserCheck = Data.define(:user) do
+    #: (user: String) -> void
+
+    #: -> bool
+    def qualifies?
+      !user.empty?
+    end
+  end
+end
+T.reveal_type(Predicates::UserCheck.new(user: "alice").user) # error: Revealed type: `String`
+
+# Type checking: wrong type produces error
+WrongType = Data.define(:x) do
+  #: (x: Integer) -> void
+end
+WrongType.new(x: "bad") # error: Expected `Integer` but found `String("bad")` for argument `x`
+
+# Type checking: missing kwarg produces error
+MissingKwarg = Data.define(:x, :y) do
+  #: (x: Integer, y: String) -> void
+end
+MissingKwarg.new(x: 1) # error: Missing required keyword argument `y` for method `MissingKwarg#initialize`
+
+# Explicit initialize with RBS sig (not virtual — sig attaches to the def directly)
+RbsExplicit = Data.define(:amount, :currency) do
+  #: (amount: Numeric, currency: String) -> void
+  def initialize(amount:, currency:) = super
+end
+T.assert_type!(RbsExplicit.new(amount: 10, currency: "CAD").amount, Numeric)
+T.assert_type!(RbsExplicit.new(amount: 10, currency: "CAD").currency, String)
+RbsExplicit.new(amount: "bad", currency: "CAD") # error: Expected `Numeric` but found `String("bad")` for argument `amount`

--- a/test/testdata/rbs/signatures_data_define.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_data_define.rb.rewrite-tree.exp
@@ -1,0 +1,596 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C TypedPoint><<C <todo sym>>> < (::<root>::<C Data>)
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.returns(<emptyTree>::<C Integer>)
+    end
+
+    def x<<todo method>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.returns(<emptyTree>::<C String>)
+    end
+
+    def y<<todo method>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params(:x, <emptyTree>::<C Integer>, :y, <emptyTree>::<C String>).void()
+    end
+
+    def initialize<<todo method>>(x:, y:, &<blk>)
+      <self>.<untypedSuper>(ZSuperArgs)
+    end
+
+    <runtime method definition of x>
+
+    <runtime method definition of y>
+
+    <runtime method definition of initialize>
+  end
+
+  <emptyTree>::<C TypedPoint>.new(:x, 1, :y, "hello")
+
+  <emptyTree>::<C TypedPoint>.new(:x, "bad", :y, "hello")
+
+  <emptyTree>::<C T>.reveal_type(<emptyTree>::<C TypedPoint>.new(:x, 1, :y, "hi").x())
+
+  <emptyTree>::<C T>.reveal_type(<emptyTree>::<C TypedPoint>.new(:x, 1, :y, "hi").y())
+
+  class <emptyTree>::<C Money><<C <todo sym>>> < (::<root>::<C Data>)
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.returns(<emptyTree>::<C Numeric>)
+    end
+
+    def amount<<todo method>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.returns(<emptyTree>::<C String>)
+    end
+
+    def currency<<todo method>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params(:amount, <emptyTree>::<C Numeric>, :currency, <emptyTree>::<C String>).void()
+    end
+
+    def initialize<<todo method>>(amount:, currency: = "USD", &<blk>)
+      <self>.<untypedSuper>(ZSuperArgs)
+    end
+
+    <runtime method definition of amount>
+
+    <runtime method definition of currency>
+
+    <runtime method definition of initialize>
+  end
+
+  <emptyTree>::<C T>.reveal_type(<emptyTree>::<C Money>.new(:amount, 10).currency())
+
+  <emptyTree>::<C T>.reveal_type(<emptyTree>::<C Money>.new(:amount, 10).amount())
+
+  <emptyTree>::<C Money>.new(:amount, "bad")
+
+  class <emptyTree>::<C DataWithMethods><<C <todo sym>>> < (::<root>::<C Data>)
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.returns(<emptyTree>::<C String>)
+    end
+
+    def user<<todo method>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params(:user, <emptyTree>::<C String>).void()
+    end
+
+    def initialize<<todo method>>(user:, &<blk>)
+      <self>.<untypedSuper>(ZSuperArgs)
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.returns(<emptyTree>::<C T>::<C Boolean>)
+    end
+
+    def active?<<todo method>>(&<blk>)
+      <self>.user().empty?().!()
+    end
+
+    <runtime method definition of user>
+
+    <runtime method definition of initialize>
+
+    <runtime method definition of active?>
+  end
+
+  <emptyTree>::<C T>.reveal_type(<emptyTree>::<C DataWithMethods>.new(:user, "alice").user())
+
+  class <emptyTree>::<C QualifiedData><<C <todo sym>>> < (::<root>::<C Data>)
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.returns(<emptyTree>::<C Integer>)
+    end
+
+    def a<<todo method>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.returns(<emptyTree>::<C Float>)
+    end
+
+    def b<<todo method>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params(:a, <emptyTree>::<C Integer>, :b, <emptyTree>::<C Float>).void()
+    end
+
+    def initialize<<todo method>>(a:, b:, &<blk>)
+      <self>.<untypedSuper>(ZSuperArgs)
+    end
+
+    <runtime method definition of a>
+
+    <runtime method definition of b>
+
+    <runtime method definition of initialize>
+  end
+
+  <emptyTree>::<C T>.reveal_type(<emptyTree>::<C QualifiedData>.new(:a, 1, :b, 2.000000).a())
+
+  <emptyTree>::<C T>.reveal_type(<emptyTree>::<C QualifiedData>.new(:a, 1, :b, 2.000000).b())
+
+  class <emptyTree>::<C PlainData><<C <todo sym>>> < (::<root>::<C Data>)
+    def x<<todo method>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    def y<<todo method>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params(:x, ::BasicObject, :y, ::BasicObject).void()
+    end
+
+    def initialize<<todo method>>(x = nil, y = nil, &<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    <runtime method definition of x>
+
+    <runtime method definition of y>
+
+    <runtime method definition of initialize>
+  end
+
+  <emptyTree>::<C T>.reveal_type(<emptyTree>::<C PlainData>.new(1, 2).x())
+
+  class <emptyTree>::<C BlockNoSig><<C <todo sym>>> < (::<root>::<C Data>)
+    def x<<todo method>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params(:x, ::BasicObject).void()
+    end
+
+    def initialize<<todo method>>(x = nil, &<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.returns(<emptyTree>::<C String>)
+    end
+
+    def to_s<<todo method>>(&<blk>)
+      "BlockNoSig"
+    end
+
+    <runtime method definition of x>
+
+    <runtime method definition of initialize>
+
+    <runtime method definition of to_s>
+  end
+
+  <emptyTree>::<C T>.reveal_type(<emptyTree>::<C BlockNoSig>.new(1).x())
+
+  class <emptyTree>::<C MismatchedSingle><<C <todo sym>>> < (::<root>::<C Data>)
+    def x<<todo method>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params(:a, <emptyTree>::<C Integer>).void()
+    end
+
+    def initialize<<todo method>>(x:, &<blk>)
+      <self>.<untypedSuper>(ZSuperArgs)
+    end
+
+    <runtime method definition of x>
+
+    <runtime method definition of initialize>
+  end
+
+  <emptyTree>::<C T>.reveal_type(<emptyTree>::<C MismatchedSingle>.new(:x, 1).x())
+
+  class <emptyTree>::<C PartialData><<C <todo sym>>> < (::<root>::<C Data>)
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.returns(<emptyTree>::<C Integer>)
+    end
+
+    def x<<todo method>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.returns(<emptyTree>::<C String>)
+    end
+
+    def y<<todo method>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.returns(<emptyTree>::<C Float>)
+    end
+
+    def z<<todo method>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params(:x, <emptyTree>::<C Integer>, :y, <emptyTree>::<C String>, :z, <emptyTree>::<C Float>).void()
+    end
+
+    def initialize<<todo method>>(x:, y:, z:, &<blk>)
+      <self>.<untypedSuper>(ZSuperArgs)
+    end
+
+    <runtime method definition of x>
+
+    <runtime method definition of y>
+
+    <runtime method definition of z>
+
+    <runtime method definition of initialize>
+  end
+
+  <emptyTree>::<C T>.reveal_type(<emptyTree>::<C PartialData>.new(:x, 1, :y, "hi", :z, 2.000000).x())
+
+  <emptyTree>::<C T>.reveal_type(<emptyTree>::<C PartialData>.new(:x, 1, :y, "hi", :z, 2.000000).y())
+
+  <emptyTree>::<C T>.reveal_type(<emptyTree>::<C PartialData>.new(:x, 1, :y, "hi", :z, 2.000000).z())
+
+  module <emptyTree>::<C Printable><<C <todo sym>>> < ()
+  end
+
+  class <emptyTree>::<C IncludeData><<C <todo sym>>> < (::<root>::<C Data>)
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.returns(<emptyTree>::<C Integer>)
+    end
+
+    def val<<todo method>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params(:val, <emptyTree>::<C Integer>).void()
+    end
+
+    def initialize<<todo method>>(val:, &<blk>)
+      <self>.<untypedSuper>(ZSuperArgs)
+    end
+
+    <runtime method definition of val>
+
+    <runtime method definition of initialize>
+
+    <self>.include(<emptyTree>::<C Printable>)
+  end
+
+  <emptyTree>::<C T>.reveal_type(<emptyTree>::<C IncludeData>.new(:val, 42).val())
+
+  class <emptyTree>::<C NilableData><<C <todo sym>>> < (::<root>::<C Data>)
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.returns(<emptyTree>::<C String>)
+    end
+
+    def name<<todo method>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.returns(::<root>::<C T>.nilable(<emptyTree>::<C String>))
+    end
+
+    def email<<todo method>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params(:name, <emptyTree>::<C String>, :email, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).void()
+    end
+
+    def initialize<<todo method>>(name:, email:, &<blk>)
+      <self>.<untypedSuper>(ZSuperArgs)
+    end
+
+    <runtime method definition of name>
+
+    <runtime method definition of email>
+
+    <runtime method definition of initialize>
+  end
+
+  <emptyTree>::<C T>.reveal_type(<emptyTree>::<C NilableData>.new(:name, "alice", :email, nil).name())
+
+  <emptyTree>::<C T>.reveal_type(<emptyTree>::<C NilableData>.new(:name, "alice", :email, nil).email())
+
+  class <emptyTree>::<C UnionData><<C <todo sym>>> < (::<root>::<C Data>)
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.returns(::<root>::<C T>.any(<emptyTree>::<C String>, <emptyTree>::<C Integer>, <emptyTree>::<C Symbol>))
+    end
+
+    def value<<todo method>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params(:value, ::<root>::<C T>.any(<emptyTree>::<C String>, <emptyTree>::<C Integer>, <emptyTree>::<C Symbol>)).void()
+    end
+
+    def initialize<<todo method>>(value:, &<blk>)
+      <self>.<untypedSuper>(ZSuperArgs)
+    end
+
+    <runtime method definition of value>
+
+    <runtime method definition of initialize>
+  end
+
+  <emptyTree>::<C T>.reveal_type(<emptyTree>::<C UnionData>.new(:value, "hi").value())
+
+  class <emptyTree>::<C CollectionData><<C <todo sym>>> < (::<root>::<C Data>)
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.returns(::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C String>))
+    end
+
+    def items<<todo method>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.returns(::<root>::<C T>::<C Hash>.<syntheticSquareBrackets>(<emptyTree>::<C Symbol>, <emptyTree>::<C Integer>))
+    end
+
+    def meta<<todo method>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params(:items, ::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C String>), :meta, ::<root>::<C T>::<C Hash>.<syntheticSquareBrackets>(<emptyTree>::<C Symbol>, <emptyTree>::<C Integer>)).void()
+    end
+
+    def initialize<<todo method>>(items:, meta:, &<blk>)
+      <self>.<untypedSuper>(ZSuperArgs)
+    end
+
+    <runtime method definition of items>
+
+    <runtime method definition of meta>
+
+    <runtime method definition of initialize>
+  end
+
+  <emptyTree>::<C T>.reveal_type(<emptyTree>::<C CollectionData>.new(:items, ["a"], :meta, {:x => 1}).items())
+
+  <emptyTree>::<C T>.reveal_type(<emptyTree>::<C CollectionData>.new(:items, ["a"], :meta, {:x => 1}).meta())
+
+  class <emptyTree>::<C ManyMembers><<C <todo sym>>> < (::<root>::<C Data>)
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.returns(<emptyTree>::<C Integer>)
+    end
+
+    def a<<todo method>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.returns(<emptyTree>::<C String>)
+    end
+
+    def b<<todo method>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.returns(<emptyTree>::<C Float>)
+    end
+
+    def c<<todo method>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.returns(<emptyTree>::<C Symbol>)
+    end
+
+    def d<<todo method>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.returns(::<root>::<C T>::<C Boolean>)
+    end
+
+    def e<<todo method>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params(:a, <emptyTree>::<C Integer>, :b, <emptyTree>::<C String>, :c, <emptyTree>::<C Float>, :d, <emptyTree>::<C Symbol>, :e, ::<root>::<C T>::<C Boolean>).void()
+    end
+
+    def initialize<<todo method>>(a:, b:, c:, d:, e:, &<blk>)
+      <self>.<untypedSuper>(ZSuperArgs)
+    end
+
+    <runtime method definition of a>
+
+    <runtime method definition of b>
+
+    <runtime method definition of c>
+
+    <runtime method definition of d>
+
+    <runtime method definition of e>
+
+    <runtime method definition of initialize>
+  end
+
+  <emptyTree>::<C T>.reveal_type(<emptyTree>::<C ManyMembers>.new(:a, 1, :b, "x", :c, 1.000000, :d, :y, :e, true).a())
+
+  <emptyTree>::<C T>.reveal_type(<emptyTree>::<C ManyMembers>.new(:a, 1, :b, "x", :c, 1.000000, :d, :y, :e, true).e())
+
+  module <emptyTree>::<C Predicates><<C <todo sym>>> < ()
+    class <emptyTree>::<C UserCheck><<C <todo sym>>> < (::<root>::<C Data>)
+      ::T::Sig::WithoutRuntime.sig() do ||
+        <self>.returns(<emptyTree>::<C String>)
+      end
+
+      def user<<todo method>>(&<blk>)
+        ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      end
+
+      ::T::Sig::WithoutRuntime.sig() do ||
+        <self>.params(:user, <emptyTree>::<C String>).void()
+      end
+
+      def initialize<<todo method>>(user:, &<blk>)
+        <self>.<untypedSuper>(ZSuperArgs)
+      end
+
+      ::T::Sig::WithoutRuntime.sig() do ||
+        <self>.returns(::<root>::<C T>::<C Boolean>)
+      end
+
+      def qualifies?<<todo method>>(&<blk>)
+        <self>.user().empty?().!()
+      end
+
+      <runtime method definition of user>
+
+      <runtime method definition of initialize>
+
+      <runtime method definition of qualifies?>
+    end
+  end
+
+  <emptyTree>::<C T>.reveal_type(<emptyTree>::<C Predicates>::<C UserCheck>.new(:user, "alice").user())
+
+  class <emptyTree>::<C WrongType><<C <todo sym>>> < (::<root>::<C Data>)
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.returns(<emptyTree>::<C Integer>)
+    end
+
+    def x<<todo method>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params(:x, <emptyTree>::<C Integer>).void()
+    end
+
+    def initialize<<todo method>>(x:, &<blk>)
+      <self>.<untypedSuper>(ZSuperArgs)
+    end
+
+    <runtime method definition of x>
+
+    <runtime method definition of initialize>
+  end
+
+  <emptyTree>::<C WrongType>.new(:x, "bad")
+
+  class <emptyTree>::<C MissingKwarg><<C <todo sym>>> < (::<root>::<C Data>)
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.returns(<emptyTree>::<C Integer>)
+    end
+
+    def x<<todo method>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.returns(<emptyTree>::<C String>)
+    end
+
+    def y<<todo method>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params(:x, <emptyTree>::<C Integer>, :y, <emptyTree>::<C String>).void()
+    end
+
+    def initialize<<todo method>>(x:, y:, &<blk>)
+      <self>.<untypedSuper>(ZSuperArgs)
+    end
+
+    <runtime method definition of x>
+
+    <runtime method definition of y>
+
+    <runtime method definition of initialize>
+  end
+
+  <emptyTree>::<C MissingKwarg>.new(:x, 1)
+
+  class <emptyTree>::<C RbsExplicit><<C <todo sym>>> < (::<root>::<C Data>)
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.returns(<emptyTree>::<C Numeric>)
+    end
+
+    def amount<<todo method>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.returns(<emptyTree>::<C String>)
+    end
+
+    def currency<<todo method>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params(:amount, <emptyTree>::<C Numeric>, :currency, <emptyTree>::<C String>).void()
+    end
+
+    def initialize<<todo method>>(amount:, currency:, &<blk>)
+      <self>.<untypedSuper>(ZSuperArgs)
+    end
+
+    <runtime method definition of amount>
+
+    <runtime method definition of currency>
+
+    <runtime method definition of initialize>
+  end
+
+  <cast:assert_type!>(<emptyTree>::<C RbsExplicit>.new(:amount, 10, :currency, "CAD").amount(), <todo sym>, <emptyTree>::<C Numeric>)
+
+  <cast:assert_type!>(<emptyTree>::<C RbsExplicit>.new(:amount, 10, :currency, "CAD").currency(), <todo sym>, <emptyTree>::<C String>)
+
+  <emptyTree>::<C RbsExplicit>.new(:amount, "bad", :currency, "CAD")
+end

--- a/test/testdata/rewriter/data.rb
+++ b/test/testdata/rewriter/data.rb
@@ -105,3 +105,56 @@ class FullyQualifiedDataUsages
   Bar.new(1).a
   Quux.new()
 end
+
+# ============================================================================
+# Typed Data.define with Sorbet sig { } blocks
+# ============================================================================
+
+# Basic typed members with sig + def initialize(...) = super
+TypedWithSorbetSig = Data.define(:amount, :currency) do
+  extend T::Sig
+
+  sig { params(amount: Numeric, currency: String).void }
+  def initialize(amount:, currency:) = super
+end
+T.reveal_type(TypedWithSorbetSig.new(amount: 10, currency: "USD").amount) # error: Revealed type: `Numeric`
+T.reveal_type(TypedWithSorbetSig.new(amount: 10, currency: "USD").currency) # error: Revealed type: `String`
+TypedWithSorbetSig.new(amount: "bad", currency: "USD") # error: Expected `Numeric` but found `String("bad")` for argument `amount`
+
+# Complex types with Sorbet sig
+SorbetSigComplex = Data.define(:items, :label) do
+  extend T::Sig
+
+  sig { params(items: T::Array[Integer], label: T.nilable(String)).void }
+  def initialize(items:, label:) = super
+end
+T.reveal_type(SorbetSigComplex.new(items: [1], label: nil).items) # error: Revealed type: `T::Array[Integer]`
+T.reveal_type(SorbetSigComplex.new(items: [1], label: nil).label) # error: Revealed type: `T.nilable(String)`
+
+# Sorbet sig with additional methods
+SorbetSigWithMethods = Data.define(:name) do
+  extend T::Sig
+
+  sig { params(name: String).void }
+  def initialize(name:) = super
+
+  sig { returns(String) }
+  def greeting
+    "Hello, #{name}!"
+  end
+end
+T.reveal_type(SorbetSigWithMethods.new(name: "alice").name) # error: Revealed type: `String`
+
+# Sorbet sig: initialize without bare super — readers stay untyped.
+# When the initialize body transforms values (not bare `super`), we can't
+# reliably propagate sig types to readers, so Sorbet conservatively falls
+# back to untyped.
+SorbetSigNoBareSuper = Data.define(:x) do
+  extend T::Sig
+
+  sig { params(x: Integer).void }
+  def initialize(x:)
+    super(x: x * 2)
+  end
+end
+T.reveal_type(SorbetSigNoBareSuper.new(x: 1).x) # error: Revealed type: `T.untyped`


### PR DESCRIPTION
## Summary

Add support for typing `Data.define` members by propagating types from a sig on `initialize` to the member reader methods. This works with **both** RBS `#:` comments and traditional `sig { }` blocks.

Based on the typed Data.define approach originally designed by @cbothner in [sorbet/sorbet#8079](https://github.com/sorbet/sorbet/pull/8079). This PR adds the RBS virtual initialize (zero runtime cost) and incorporates the conservative bare-super check from @jez's review feedback on that PR.

Addresses https://github.com/sorbet/sorbet/issues/10055

## Two ways to type Data.define members

### RBS comment (zero runtime cost — recommended)

The `#:` comment annotates a "virtual initialize" — no method is defined at runtime:

```ruby
TypedPoint = Data.define(:x, :y) do
  #: (x: Integer, y: String) -> void
end

TypedPoint.new(x: 1, y: "hi").x  # => Integer (was T.untyped)
```

### Traditional Sorbet sig (requires explicit initialize)

An explicit `def initialize(...) = super` is needed, which adds a small runtime cost (one extra method dispatch per construction):

```ruby
TypedPoint = Data.define(:x, :y) do
  extend T::Sig
  sig { params(x: Integer, y: String).void }
  def initialize(x:, y:) = super
end
```

Both produce identical type checking. The RBS form is preferred because it has zero runtime overhead.

### Ambiguity with methods in the block

When the block also contains methods, a `#:` comment could be ambiguous — is it a virtual initialize signature or a signature for the method below it?

```ruby
Point = Data.define(:x, :y) do
  #: (x: Integer, y: String) -> void  # virtual init? or sig for advance?

  def advance(x, y); end
end
```

The implementation resolves this using a **gap heuristic**: a `#:` comment is treated as a virtual initialize only if there is at least one blank line between it and the first method definition. If the comment is immediately above a `def`, it's treated as that method's signature.

However, for clarity, **when a block contains both typed members and additional methods, we recommend using an explicit `def initialize`** to remove all ambiguity:

```ruby
Point = Data.define(:x, :y) do
  #: (x: Integer, y: String) -> void
  def initialize(x:, y:) = super

  #: (Integer, Integer) -> void
  def advance(x, y); end
end
```

This way each `#:` unambiguously attaches to the `def` below it. The virtual initialize (no explicit `def`) is best suited for simple Data classes with no additional methods.

## Design decisions (informed by [#8079 review](https://github.com/sorbet/sorbet/pull/8079#pullrequestreview-2242849268))

Following @jez's principle that *"the default assumption should be 'Sorbet doesn't do anything' and only if a certain set of very precise constraints are met should Sorbet do something"*:

- **Bare super required**: Typed readers are only created when the `initialize` body is exactly bare `super` (i.e., `def initialize(x:, y:) = super`). When the user transforms values (e.g., `super(x: x.to_i)`), readers conservatively fall back to `T.untyped`. This keeps our options open for smarter analysis in the future.

- **`self.[]` left untyped**: Sorbet cannot overload a method to accept both positional and keyword arguments, so only `new`/`initialize` is typed.

- **No partial typing**: If the sig's param names don't match the `Data.define` members, standard RBS/sig parameter mismatch errors fire and readers fall back to `T.untyped`.

## Approach

- **`rbs/CommentsAssociator.cc`**: `maybeExtractDataDefineOrphanComments` — for Data.define blocks without an explicit `def initialize`, extracts leading orphan `#:` comments and associates them with the Prism block node. Uses a gap heuristic: a comment is "orphan" (for virtual init) only if there's at least one blank line before the first `def` in the body, or the body is empty.

- **`rbs/SigsRewriter.cc`**: `maybeSynthesizeDataDefineVirtualInit` — for Data.define blocks with an associated orphan signature, synthesizes a Prism `pm_def_node_t` for `initialize` (with keyword args + bare super body) and translates the RBS comment into a sig node.

- **`rewriter/Data.cc`**: `isBareSuper` + `findSigBeforeInitialize` + `extractTypesFromParams` + `extractInitializeTypes` — when the block contains a sig preceding a bare-super `def initialize`, extracts the parameter types and creates typed reader stubs with `sig { returns(Type) }`.

## Test coverage

**RBS tests** (`test/testdata/rbs/signatures_data_define.rb`):
- Virtual initialize (zero-cost), explicit initialize with defaults
- Additional methods alongside virtual init, non-method stmts (include)
- `::Data.define`, untyped fallback, mismatched param names
- Complex types: `T.nilable`, `T.any`, `T::Array`, `T::Hash`, `T::Boolean`
- Many members (5+), nested in modules
- Wrong type / missing kwarg error validation, `T.assert_type!`

**Sorbet sig tests** (`test/testdata/rewriter/data.rb`):
- Basic typed members, complex types (`T::Array`, `T.nilable`)
- Additional methods, non-bare-super → untyped fallback

## Limitations

- **Multiline `#|` continuation**: Supported in code (the orphan extraction collects both `#:` and `#|` prefixed comments) but not tested — Sorbet's test assertion parser interprets `#|` lines containing colons as test annotations (e.g., `#|  name: String` is parsed as assertion type `name`).

Co-authored-by: Cameron Bothner <cbothner@users.noreply.github.com>
Co-authored-by: GPT-5.5 <noreply@openai.com>
Orchestrated-by: ae <noreply@shopify.com>
