### PR TITLE
Support typed Data.define members via inline RBS comments

### DIFF
--- a/rbs/prism/CommentsAssociatorPrism.cc
+++ b/rbs/prism/CommentsAssociatorPrism.cc
@@ -250,6 +250,64 @@ void CommentsAssociatorPrism::associateSignatureCommentsToNode(pm_node_t *node) 
     signaturesForNode[node] = move(comments);
 }
 
+bool CommentsAssociatorPrism::isDataDefineCall(pm_call_node_t *call) {
+    if (call == nullptr || parser.resolveConstant(call->name) != "define"sv || call->receiver == nullptr) {
+        return false;
+    }
+
+    // Keep this in sync with the Data rewriter's root-only Data.define handling:
+    // accept `Data.define` and `::Data.define`, but reject scoped `Foo::Data.define`.
+    if (auto *constant = down_cast<pm_constant_read_node_t>(call->receiver)) {
+        return parser.resolveConstant(constant->name) == "Data"sv;
+    }
+
+    if (auto *constantPath = down_cast<pm_constant_path_node_t>(call->receiver)) {
+        return constantPath->parent == nullptr && parser.resolveConstant(constantPath->name) == "Data"sv;
+    }
+
+    return false;
+}
+
+void CommentsAssociatorPrism::associateDataDefineMemberTypes(pm_call_node_t *call) {
+    if (call == nullptr || call->arguments == nullptr) {
+        return;
+    }
+
+    vector<CommentMapPrism::DataDefineMember> members;
+    bool hasTypedMember = false;
+    auto &args = call->arguments->arguments;
+    members.reserve(args.size);
+
+    for (size_t i = 0; i < args.size; i++) {
+        auto *arg = args.nodes[i];
+        auto *symbol = down_cast<pm_symbol_node_t>(arg);
+        if (symbol == nullptr) {
+            walkNode(arg);
+            continue;
+        }
+
+        auto name = parser.extractString(&symbol->unescaped);
+        auto nameLoc = translateLocation(symbol->value_loc);
+        auto argLoc = translateLocation(arg->location);
+        auto line = posToLine(argLoc.endPos());
+
+        optional<CommentNodePrism> typeComment;
+        auto it = commentByLine.find(line);
+        if (it != commentByLine.end() && absl::StartsWith(it->second.string, RBS_PREFIX)) {
+            typeComment = it->second;
+            hasTypedMember = true;
+            commentByLine.erase(it);
+        }
+
+        members.emplace_back(CommentMapPrism::DataDefineMember{ctx.state.enterNameUTF8(name), nameLoc, typeComment});
+        walkNode(arg);
+    }
+
+    if (hasTypedMember) {
+        dataDefineMembersForNode[up_cast(call)] = move(members);
+    }
+}
+
 bool CommentsAssociatorPrism::typeAliasAllowedInContext() const {
     return !contextAllowingTypeAlias.empty() && contextAllowingTypeAlias.back().first;
 }
@@ -725,6 +783,11 @@ void CommentsAssociatorPrism::walkNode(pm_node_t *node) {
                 walkNode(call->receiver);
                 walkArgumentsNode(call->arguments);
                 consumeCommentsInsideNode(node, "call");
+            } else if (isDataDefineCall(call)) {
+                associateAssertionCommentsToNode(node);
+                walkNode(call->receiver);
+                associateDataDefineMemberTypes(call);
+                walkNode(call->block);
             } else if (call->arguments != nullptr && call->arguments->arguments.size == 1 &&
                        parser.isSafeNavigationCall(node) && parser.isSetterCall(node)) {
                 // Handle safe navigation setter calls: `foo&.bar = val #: Type`
@@ -1189,7 +1252,7 @@ CommentMapPrism CommentsAssociatorPrism::run(pm_node_t *node) {
         }
     }
 
-    return CommentMapPrism{signaturesForNode, assertionsForNode};
+    return CommentMapPrism{move(signaturesForNode), move(assertionsForNode), move(dataDefineMembersForNode)};
 }
 
 pm_node_t *CommentsAssociatorPrism::createSyntheticPlaceholder(const CommentNodePrism &comment,

--- a/rbs/prism/CommentsAssociatorPrism.h
+++ b/rbs/prism/CommentsAssociatorPrism.h
@@ -7,6 +7,7 @@
 #include "parser/prism/Helpers.h"
 #include "parser/prism/Parser.h"
 #include <memory>
+#include <optional>
 #include <regex>
 #include <string_view>
 
@@ -27,8 +28,22 @@ struct CommentNodePrism {
 };
 
 struct CommentMapPrism {
+    // A member of a Data.define call, optionally annotated with an inline `#:` type.
+    // The `typeComment` field, when present, contains a CommentNodePrism whose `string`
+    // is a string_view into the file source buffer (owned by GlobalState). It remains
+    // valid for the lifetime of the file data.
+    struct DataDefineMember {
+        core::NameRef name;
+        core::LocOffsets nameLoc;
+        std::optional<CommentNodePrism> typeComment;
+    };
+
     UnorderedMap<pm_node_t *, std::vector<CommentNodePrism>> signaturesForNode;
     UnorderedMap<pm_node_t *, std::vector<CommentNodePrism>> assertionsForNode;
+    // Non-owning keys into the Prism parser tree passed to CommentsAssociatorPrism::run().
+    // Maps Data.define Call nodes to their members when at least one symbol argument
+    // has an inline `#:` type comment.
+    UnorderedMap<pm_node_t *, std::vector<DataDefineMember>> dataDefineMembersForNode;
 };
 
 class CommentsAssociatorPrism {
@@ -51,6 +66,7 @@ private:
     std::map<int, CommentNodePrism> commentByLine;
     UnorderedMap<pm_node_t *, std::vector<CommentNodePrism>> signaturesForNode;
     UnorderedMap<pm_node_t *, std::vector<CommentNodePrism>> assertionsForNode;
+    UnorderedMap<pm_node_t *, std::vector<CommentMapPrism::DataDefineMember>> dataDefineMembersForNode;
     std::vector<std::pair<bool, core::LocOffsets>> contextAllowingTypeAlias;
     int lastLine;
 
@@ -67,6 +83,8 @@ private:
                              pm_node_t *&elsePart, std::string_view kind);
     void associateAssertionCommentsToNode(pm_node_t *node, bool adjustLocForHeredoc = false);
     void associateSignatureCommentsToNode(pm_node_t *node);
+    bool isDataDefineCall(pm_call_node_t *call);
+    void associateDataDefineMemberTypes(pm_call_node_t *call);
     void consumeCommentsInsideNode(pm_node_t *node, std::string_view kind);
     void consumeCommentsBetweenLines(int startLine, int endLine, std::string_view kind);
     void consumeOrphanedSignatureComments(int startLine, int endLine);

--- a/rbs/prism/RBSRewriterPrism.cc
+++ b/rbs/prism/RBSRewriterPrism.cc
@@ -17,7 +17,8 @@ void runPrismRBSRewrite(core::GlobalState &gs, core::FileRef file, pm_node_t *no
     auto associator = CommentsAssociatorPrism(ctx, parser, commentLocations);
     auto commentMap = associator.run(node);
 
-    auto sigsRewriter = SigsRewriterPrism(ctx, parser, commentMap.signaturesForNode);
+    auto sigsRewriter =
+        SigsRewriterPrism(ctx, parser, commentMap.signaturesForNode, commentMap.dataDefineMembersForNode);
     sigsRewriter.run(node);
 
     auto assertionsRewriter = AssertionsRewriterPrism(ctx, parser, commentMap.assertionsForNode);

--- a/rbs/prism/SigsRewriterPrism.cc
+++ b/rbs/prism/SigsRewriterPrism.cc
@@ -401,6 +401,174 @@ pm_node_t *SigsRewriterPrism::replaceSyntheticTypeAlias(pm_node_t *node) {
     return prism.TTypeAlias(loc, type);
 }
 
+bool SigsRewriterPrism::blockHasInitialize(pm_block_node_t *block) {
+    if (block == nullptr || block->body == nullptr) {
+        return false;
+    }
+
+    auto hasInitialize = [&](pm_node_t *node) {
+        auto *def = down_cast<pm_def_node_t>(node);
+        return def != nullptr && parser.resolveConstant(def->name) == "initialize"sv;
+    };
+
+    if (hasInitialize(block->body)) {
+        return true;
+    }
+
+    if (auto *statements = down_cast<pm_statements_node_t>(block->body)) {
+        for (size_t i = 0; i < statements->body.size; i++) {
+            if (hasInitialize(statements->body.nodes[i])) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+vector<pm_node_t *> SigsRewriterPrism::synthesizeDataDefineMembers(
+    pm_call_node_t *call, vector<CommentMapPrism::DataDefineMember> &members) {
+    auto loc = parser.translateLocation(call->base.location);
+    auto tinyLoc = loc.copyWithZeroLength();
+    auto signatureTranslator = rbs::SignatureTranslatorPrism{ctx, parser};
+    vector<pm_node_t *> synthesized;
+    synthesized.reserve(2);
+
+    vector<pm_node_t *> sigParams;
+    sigParams.reserve(members.size());
+
+    for (auto &member : members) {
+        auto memberLoc = member.nameLoc.exists() ? member.nameLoc : tinyLoc;
+        pm_node_t *typeNode = nullptr;
+
+        if (member.typeComment) {
+            auto &comment = *member.typeComment;
+            auto typeComment = Comment{
+                .commentLoc = comment.loc,
+                .typeLoc = core::LocOffsets{comment.loc.beginPos() + 2, comment.loc.endPos()},
+                .string = comment.string.substr(2),
+            };
+            auto declaration = RBSDeclaration{RBSDeclaration::CommentsVector{typeComment}};
+            typeNode = signatureTranslator.translateType(declaration);
+        }
+
+        if (typeNode == nullptr) {
+            typeNode = prism.TUntyped(memberLoc);
+        }
+
+        auto name = member.name.shortName(ctx.state);
+        sigParams.emplace_back(prism.AssocNode(memberLoc, prism.Symbol(memberLoc, name), typeNode));
+    }
+
+    // Synthesize initialize sig: sig { params(x: Type, y: Type).void }
+    pm_node_t *sigBuilder = prism.Self(loc);
+    if (!sigParams.empty()) {
+        sigBuilder = prism.Call1(loc, sigBuilder, "params"sv, prism.KeywordHash(loc, absl::MakeSpan(sigParams)));
+    }
+    sigBuilder = prism.Call0(loc, sigBuilder, "void"sv);
+    auto *sigBlock = prism.Block(loc, sigBuilder);
+    synthesized.emplace_back(prism.Call(loc, prism.TSigWithoutRuntime(loc), "sig"sv, absl::Span<pm_node_t *>{}, sigBlock));
+
+    // Synthesize initialize method: def initialize(member:, ...) = super
+    // This MUST be forwarding/bare super for Data.cc's canCreateTypedAccessors() to
+    // propagate types to member readers.
+    pm_node_list_t keywords = prism.nodeListWithCapacity(members.size());
+    for (auto &member : members) {
+        auto memberLoc = member.nameLoc.exists() ? member.nameLoc : tinyLoc;
+        auto name = member.name.shortName(ctx.state);
+        auto nameId = prism.addConstantToPool(name);
+        auto *keyword = prism.allocateNode<pm_required_keyword_parameter_node_t>();
+        auto pmLoc = parser.convertLocOffsets(memberLoc);
+        *keyword = (pm_required_keyword_parameter_node_t){
+            .base = prism.initializeBaseNode(PM_REQUIRED_KEYWORD_PARAMETER_NODE, pmLoc),
+            .name = nameId,
+            .name_loc = pmLoc,
+        };
+        pm_node_list_append(&keywords, up_cast(keyword));
+    }
+
+    auto *params = prism.allocateNode<pm_parameters_node_t>();
+    *params = (pm_parameters_node_t){
+        .base = prism.initializeBaseNode(PM_PARAMETERS_NODE, parser.convertLocOffsets(loc)),
+        .requireds = prism.emptyNodeList(),
+        .optionals = prism.emptyNodeList(),
+        .rest = nullptr,
+        .posts = prism.emptyNodeList(),
+        .keywords = keywords,
+        .keyword_rest = nullptr,
+        .block = nullptr,
+    };
+
+    auto *superNode = prism.allocateNode<pm_forwarding_super_node_t>();
+    *superNode = (pm_forwarding_super_node_t){
+        .base = prism.initializeBaseNode(PM_FORWARDING_SUPER_NODE, parser.convertLocOffsets(loc)),
+        .block = nullptr,
+    };
+
+    auto *def = prism.allocateNode<pm_def_node_t>();
+    auto zeroLoc = parser.getZeroWidthLocation();
+    *def = (pm_def_node_t){
+        .base = prism.initializeBaseNode(PM_DEF_NODE, parser.convertLocOffsets(loc)),
+        .name = prism.addConstantToPool("initialize"sv),
+        .name_loc = parser.convertLocOffsets(loc),
+        .receiver = nullptr,
+        .parameters = params,
+        .body = up_cast(superNode),
+        .locals = {.size = 0, .capacity = 0, .ids = nullptr},
+        .def_keyword_loc = zeroLoc,
+        .operator_loc = zeroLoc,
+        .lparen_loc = zeroLoc,
+        .rparen_loc = zeroLoc,
+        .equal_loc = zeroLoc,
+        .end_keyword_loc = zeroLoc,
+    };
+    synthesized.emplace_back(up_cast(def));
+
+    return synthesized;
+}
+
+bool SigsRewriterPrism::maybeRewriteDataDefine(pm_call_node_t *call) {
+    if (call == nullptr) {
+        return false;
+    }
+
+    auto it = dataDefineMembersByNode.find(up_cast(call));
+    if (it == dataDefineMembersByNode.end()) {
+        return false;
+    }
+
+    rewriteArgumentsNode(call->arguments);
+
+    if (blockHasInitialize(down_cast<pm_block_node_t>(call->block))) {
+        rewriteNullableNode(call->block);
+        return true;
+    }
+
+    auto synthesized = synthesizeDataDefineMembers(call, it->second);
+    auto loc = parser.translateLocation(call->base.location);
+
+    if (auto *block = down_cast<pm_block_node_t>(call->block)) {
+        if (block->body == nullptr) {
+            block->body = prism.StatementsNode(loc, absl::MakeSpan(synthesized));
+        } else if (auto *statements = down_cast<pm_statements_node_t>(block->body)) {
+            for (auto *stmt : synthesized) {
+                pm_node_list_append(&statements->body, stmt);
+            }
+        } else {
+            vector<pm_node_t *> body;
+            body.reserve(synthesized.size() + 1);
+            body.emplace_back(block->body);
+            body.insert(body.end(), synthesized.begin(), synthesized.end());
+            block->body = prism.StatementsNode(loc, absl::MakeSpan(body));
+        }
+    } else {
+        call->block = prism.Block(loc, prism.StatementsNode(loc, absl::MakeSpan(synthesized)));
+    }
+
+    rewriteNullableNode(call->block);
+    return true;
+}
+
 void SigsRewriterPrism::rewriteNodes(pm_node_list_t &nodes) {
     for (size_t i = 0; i < nodes.size; i++) {
         nodes.nodes[i] = rewriteBody(nodes.nodes[i]);
@@ -669,6 +837,9 @@ void SigsRewriterPrism::rewriteNode(pm_node_t *node) {
         }
         case PM_CALL_NODE: {
             auto *call = down_cast_nonnull<pm_call_node_t>(node);
+            if (maybeRewriteDataDefine(call)) {
+                break;
+            }
             if (auto *block = call->block) {
                 rewriteNode(block);
             }
@@ -730,7 +901,7 @@ void SigsRewriterPrism::rewriteNode(pm_node_t *node) {
 
 void SigsRewriterPrism::run(pm_node_t *node) {
     // If there are no signature comments to process, we can skip the entire tree walk.
-    if (commentsByNode.empty()) {
+    if (commentsByNode.empty() && dataDefineMembersByNode.empty()) {
         return;
     }
 

--- a/rbs/prism/SigsRewriterPrism.h
+++ b/rbs/prism/SigsRewriterPrism.h
@@ -36,9 +36,12 @@ struct CommentsPrism {
 
 class SigsRewriterPrism {
 public:
-    SigsRewriterPrism(core::MutableContext ctx, parser::Prism::Parser &parser,
-                      UnorderedMap<pm_node_t *, std::vector<rbs::CommentNodePrism>> &commentsByNode)
-        : ctx{ctx}, parser{parser}, prism{parser}, commentsByNode{commentsByNode} {}
+    SigsRewriterPrism(
+        core::MutableContext ctx, parser::Prism::Parser &parser,
+        UnorderedMap<pm_node_t *, std::vector<rbs::CommentNodePrism>> &commentsByNode,
+        UnorderedMap<pm_node_t *, std::vector<rbs::CommentMapPrism::DataDefineMember>> &dataDefineMembersByNode)
+        : ctx{ctx}, parser{parser}, prism{parser}, commentsByNode{commentsByNode},
+          dataDefineMembersByNode{dataDefineMembersByNode} {}
 
     // Rewrite the RBS signatures in the Prism AST, in-place.
     void run(pm_node_t *node);
@@ -47,7 +50,10 @@ private:
     core::MutableContext ctx;
     parser::Prism::Parser &parser;
     parser::Prism::Factory prism;
+    // Non-owning references to CommentMapPrism fields. The CommentMapPrism is owned by
+    // runPrismRBSRewrite and outlives this rewriter.
     UnorderedMap<pm_node_t *, std::vector<rbs::CommentNodePrism>> &commentsByNode;
+    UnorderedMap<pm_node_t *, std::vector<rbs::CommentMapPrism::DataDefineMember>> &dataDefineMembersByNode;
 
     pm_node_t *rewriteBody(pm_node_t *node);
     void rewriteBody(pm_statements_node_t *stmts);
@@ -60,6 +66,10 @@ private:
     CommentsPrism commentsForNode(pm_node_t *node);
     void insertTypeParams(pm_node_t *node, pm_node_t *body);
     void processClassBody(pm_node_t *node, pm_node_t *&body, absl::Span<pm_node_t *const> helpers);
+    bool maybeRewriteDataDefine(pm_call_node_t *call);
+    std::vector<pm_node_t *> synthesizeDataDefineMembers(
+        pm_call_node_t *call, std::vector<rbs::CommentMapPrism::DataDefineMember> &members);
+    bool blockHasInitialize(pm_block_node_t *block);
     pm_node_t *replaceSyntheticTypeAlias(pm_node_t *node);
     pm_node_t *createStatementsWithSignatures(pm_node_t *originalNode,
                                               std::unique_ptr<std::vector<pm_node_t *>> signatures);

--- a/rewriter/Data.cc
+++ b/rewriter/Data.cc
@@ -13,30 +13,124 @@ namespace sorbet::rewriter {
 
 namespace {
 
-bool isMissingInitialize(const core::GlobalState &gs, const ast::Send *send) {
+// Find the `params(...)` Send node inside a sig block.
+// Walks the sig's builder chain (e.g., `self.params(...).void`) to find the params call.
+//
+// Returns a non-owning pointer into the sig's AST. The returned pointer borrows from the
+// ExpressionPtr pointed to by `send`, which is itself a node in the block body. Valid as
+// long as the block body's ExpressionPtr tree is alive (i.e., before it is move()'d).
+const ast::Send *findParams(const ast::ExpressionPtr *send) {
+    if (send == nullptr) {
+        return nullptr;
+    }
+    auto *sig = ASTUtil::castSig(*send);
+    if (sig == nullptr) {
+        return nullptr;
+    }
+
+    auto *block = sig->block();
+    if (block == nullptr) {
+        return nullptr;
+    }
+
+    auto bodyBlock = ast::cast_tree<ast::Send>(block->body);
+
+    while (bodyBlock && bodyBlock->fun != core::Names::params()) {
+        bodyBlock = ast::cast_tree<ast::Send>(bodyBlock->recv);
+    }
+
+    return bodyBlock;
+}
+
+// Information about a user-defined `initialize` found inside a Data.define block.
+//
+// Both pointers are non-owning borrows into the block body of the Data.define Send node.
+// The block body's ExpressionPtr tree owns these nodes and is responsible for their
+// lifetime. They remain valid throughout `Data::run` because we read from them (to
+// extract types and check for bare `super`) before the block body is move()'d into the
+// synthesized class definition.
+struct InitializeInfo {
+    // The initialize method definition. Used to check whether its body is bare `super`,
+    // which is the only case where we can reliably propagate types to attribute readers.
+    const ast::MethodDef *methodDef;
+
+    // The `params(...)` Send node from the sig immediately preceding initialize, or
+    // nullptr if there was no sig. Used to extract member types.
+    const ast::Send *sigParams;
+};
+
+// Search the Data.define block body for a `def initialize` method definition.
+// If found, also looks for a sig immediately preceding it.
+optional<InitializeInfo> getInitialize(const ast::Send *send) {
     if (!send->hasBlock()) {
-        return true;
+        return nullopt;
     }
 
     auto block = send->block();
 
     if (auto insSeq = ast::cast_tree<ast::InsSeq>(block->body)) {
-        auto methodDef = ast::cast_tree<ast::MethodDef>(insSeq->expr);
-
-        if (methodDef && methodDef->name == core::Names::initialize()) {
-            return false;
-        }
-
-        for (auto &&stat : insSeq->stats) {
-            methodDef = ast::cast_tree<ast::MethodDef>(stat);
+        const ast::ExpressionPtr *prevStat = nullptr;
+        for (auto &stat : insSeq->stats) {
+            auto methodDef = ast::cast_tree<ast::MethodDef>(stat);
 
             if (methodDef && methodDef->name == core::Names::initialize()) {
-                return false;
+                return InitializeInfo{methodDef, findParams(prevStat)};
+            }
+
+            prevStat = &stat;
+        }
+
+        // the last expression of the block is stored separately as expr
+        auto methodDef = ast::cast_tree<ast::MethodDef>(insSeq->expr);
+        if (methodDef && methodDef->name == core::Names::initialize()) {
+            return InitializeInfo{methodDef, findParams(prevStat)};
+        }
+    } else if (auto methodDef = ast::cast_tree<ast::MethodDef>(block->body)) {
+        if (methodDef && methodDef->name == core::Names::initialize()) {
+            return InitializeInfo{methodDef, nullptr};
+        }
+    }
+
+    return nullopt;
+}
+
+// Check if the initialize body is exactly bare `super` (i.e., forwards all args).
+// Only when this is true can we reliably propagate sig types to attribute readers.
+// When the user transforms values (e.g., `super(x: x.to_i)`), the sig types describe
+// the initialize params, not necessarily what gets stored — so readers must fall back
+// to T.untyped.
+bool canCreateTypedAccessors(const core::GlobalState &gs, const ast::MethodDef *initialize) {
+    auto send = ast::cast_tree<ast::Send>(initialize->rhs);
+    if (!send)
+        return false;
+    if (send->fun != core::Names::untypedSuper())
+        return false;
+    if (send->numPosArgs() == 1 && ast::isa_tree<ast::ZSuperArgs>(send->getPosArg(0)))
+        return true;
+
+    return false;
+}
+
+// Extract the type for a specific member from the sig's params() call.
+// `params` is a non-owning pointer borrowed from the sig AST (see findParams).
+// Returns a deep copy of the type expression, or T.untyped if the member isn't found.
+ast::ExpressionPtr getMemberType(core::MutableContext ctx, const ast::Send *params, core::NameRef name,
+                                 core::LocOffsets loc) {
+    if (params != nullptr) {
+        for (int i = 0; i < params->numKwArgs(); i++) {
+            auto lit = ast::cast_tree<ast::Literal>(params->getKwKey(i));
+            if (!lit) {
+                continue;
+            }
+            auto key = lit->asName();
+
+            if (key.toString(ctx) == name.toString(ctx)) {
+                return params->getKwValue(i).deepCopy();
             }
         }
     }
 
-    return true;
+    return ast::MK::Untyped(loc);
 }
 
 } // namespace
@@ -66,12 +160,6 @@ vector<ast::ExpressionPtr> Data::run(core::MutableContext ctx, ast::Assign *asgn
         return empty;
     }
 
-    auto loc = asgn->loc;
-
-    ast::MethodDef::PARAMS_store newArgs;
-    ast::Send::ARGS_store sigArgs;
-    ast::ClassDef::RHS_store body;
-
     if (auto dup = ASTUtil::findDuplicateArg(ctx, send)) {
         if (auto e = ctx.beginIndexerError(dup->secondLoc, core::errors::Rewriter::InvalidStructMember)) {
             e.setHeader("Duplicate member `{}` in Data definition", dup->name.show(ctx));
@@ -80,6 +168,28 @@ vector<ast::ExpressionPtr> Data::run(core::MutableContext ctx, ast::Assign *asgn
         }
         return empty;
     }
+
+    // Check for a user-provided initialize with a sig in the block.
+    // `reliableSigParams` is a non-owning pointer into the block body's AST tree.
+    // It borrows from `send->block()->body` and remains valid until the block body
+    // is move()'d into the synthesized class (the "steal" section below).
+    // We only read from it (via getMemberType) before that move happens.
+    auto initialize = getInitialize(send);
+    bool initializeHasSig = false;
+    const ast::Send *reliableSigParams = nullptr;
+    if (initialize.has_value()) {
+        initializeHasSig = !!initialize->sigParams;
+        if (initializeHasSig && canCreateTypedAccessors(ctx, initialize->methodDef)) {
+            reliableSigParams = initialize->sigParams;
+        }
+    }
+
+    auto loc = asgn->loc;
+    ast::Send::ARGS_store newSigArgs;
+    ast::MethodDef::PARAMS_store newArgs;
+    ast::Send::ARGS_store initializeSigArgs;
+    ast::MethodDef::PARAMS_store initializeArgs;
+    ast::ClassDef::RHS_store body;
 
     for (auto &arg : send->posArgs()) {
         auto sym = ast::cast_tree<ast::Literal>(arg);
@@ -99,19 +209,42 @@ vector<ast::ExpressionPtr> Data::run(core::MutableContext ctx, ast::Assign *asgn
             symLoc = ctx.locAt(symLoc).adjust(ctx, 1, 0).offsets();
         }
 
-        sigArgs.emplace_back(ast::MK::Symbol(symLoc, name));
-        sigArgs.emplace_back(ast::MK::Constant(symLoc, core::Symbols::BasicObject()));
+        auto memberType = getMemberType(ctx, reliableSigParams, name, symLoc);
 
-        auto argName = ast::MK::Local(symLoc, name);
-        newArgs.emplace_back(ast::MK::OptionalParam(symLoc, move(argName), ast::MK::Nil(symLoc)));
-
+        // Generate typed reader: sig {returns(Type)} + def member_name; end
+        body.emplace_back(ast::MK::Sig0(symLoc, ASTUtil::dupType(memberType)));
         body.emplace_back(ast::MK::SyntheticMethod0(symLoc, symLoc, name, ast::MK::RaiseUnimplemented(loc)));
+
+        // Build self.new args (only when no user-provided initialize with sig)
+        if (!(initialize.has_value() && initializeHasSig)) {
+            newSigArgs.emplace_back(ast::MK::Symbol(symLoc, name));
+            newSigArgs.emplace_back(ASTUtil::dupType(memberType));
+            auto argName = ast::MK::Local(symLoc, name);
+            newArgs.emplace_back(ast::MK::OptionalParam(symLoc, move(argName), ast::MK::Nil(symLoc)));
+        }
+
+        // Build initialize args (only when user provided initialize)
+        if (initialize.has_value()) {
+            initializeArgs.emplace_back(ast::MK::KeywordArg(symLoc, name));
+            initializeSigArgs.emplace_back(ast::MK::Symbol(symLoc, name));
+            initializeSigArgs.emplace_back(ASTUtil::dupType(memberType));
+        }
     }
 
-    if (isMissingInitialize(ctx, send)) {
-        body.emplace_back(ast::MK::SigVoid(loc, std::move(sigArgs)));
-        body.emplace_back(ast::MK::SyntheticMethod(loc, loc, core::Names::initialize(), std::move(newArgs),
-                                                   ast::MK::RaiseUnimplemented(loc)));
+    // Generate self.new (only when no user-provided initialize with sig)
+    if (newArgs.size() > 0) {
+        body.emplace_back(ast::MK::Sig(loc, move(newSigArgs), ast::MK::AttachedClass(loc)));
+        ast::MethodDef::Flags flags;
+        flags.isSelfMethod = true;
+        body.emplace_back(ast::MK::SyntheticMethod(loc, loc, core::Names::new_(), move(newArgs),
+                                                   ast::MK::RaiseUnimplemented(loc), flags));
+    }
+
+    // Generate initialize (when user provided one or as default)
+    if (initializeArgs.size() > 0) {
+        body.emplace_back(ast::MK::SigVoid(loc, move(initializeSigArgs)));
+        body.emplace_back(ast::MK::SyntheticMethod(loc, loc, core::Names::initialize(), move(initializeArgs),
+                                                    ast::MK::RaiseUnimplemented(loc)));
     }
 
     if (auto *block = send->block()) {

--- a/rewriter/Data.h
+++ b/rewriter/Data.h
@@ -12,13 +12,44 @@ namespace sorbet::rewriter {
  * into
  *
  *   class A < Data
+ *       sig {returns(T.untyped)}
  *       def foo; end
+ *       sig {returns(T.untyped)}
  *       def bar; end
- *       sig {params(foo: BasicObject, bar: BasicObject).returns(A)}
- *       def self.new(foo=nil, bar=nil)
- *           T.cast(nil, A)
- *       end
+ *       sig {params(foo: T.untyped, bar: T.untyped).returns(T.attached_class)}
+ *       def self.new(foo=nil, bar=nil); end
  *   end
+ *
+ * When an initialize method with a sig is provided and calls bare super:
+ *
+ *   A = Data.define(:foo, :bar) do
+ *     extend T::Sig
+ *     sig { params(foo: Integer, bar: String).void }
+ *     def initialize(foo:, bar:) = super
+ *   end
+ *
+ * the typed members are propagated to the attribute readers:
+ *
+ *   class A < Data
+ *       sig {returns(Integer)}
+ *       def foo; end
+ *       sig {returns(String)}
+ *       def bar; end
+ *       sig {params(foo: Integer, bar: String).void}
+ *       def initialize(foo:, bar:); end
+ *   end
+ *
+ * Design notes:
+ *
+ * - Bare super required: Typed readers are only created when the initialize
+ *   body is exactly bare `super`. When the user transforms values (e.g.,
+ *   `super(x: x.to_i)`), the sig types describe the initialize params, not
+ *   necessarily what gets stored — so readers fall back to T.untyped.
+ *
+ * - `self.[]` is intentionally left untyped even when a typed initialize is
+ *   provided. Sorbet cannot overload a method to accept both positional and
+ *   keyword arguments, so typing only the keyword-based `new`/`initialize`
+ *   path is the conservative choice.
  */
 class Data final {
 public:

--- a/test/testdata/rbs/data_define_members.rb
+++ b/test/testdata/rbs/data_define_members.rb
@@ -1,0 +1,177 @@
+# typed: true
+# enable-experimental-rbs-comments: true
+
+# ============================================================================
+# Basic typed members
+# ============================================================================
+
+TypedPoint = Data.define(
+  :x, #: Integer
+  :y, #: Integer
+)
+
+point = TypedPoint.new(x: 1, y: 2)
+T.reveal_type(point.x) # error: Revealed type: `Integer`
+T.reveal_type(point.y) # error: Revealed type: `Integer`
+T.assert_type!(point.x, Integer)
+T.assert_type!(point.y, Integer)
+
+# Wrong type errors
+TypedPoint.new(x: "bad", y: 2) # error: Expected `Integer` but found `String("bad")`
+
+# Missing required keyword argument
+TypedPoint.new(x: 1) # error: Missing required keyword argument `y`
+
+# Extra keyword argument
+TypedPoint.new(x: 1, y: 2, z: 3) # error: Unrecognized keyword argument `z`
+
+# ============================================================================
+# Complex types (RBS syntax)
+# ============================================================================
+
+TypedMoney = Data.define(
+  :amount, #: Numeric
+  :currency, #: String
+)
+
+money = TypedMoney.new(amount: 1.0, currency: "USD")
+T.assert_type!(money.amount, Numeric)
+T.assert_type!(money.currency, String)
+
+# Nilable types
+NilableData = Data.define(
+  :name, #: String?
+  :age, #: Integer?
+)
+
+nilable = NilableData.new(name: nil, age: nil)
+T.reveal_type(nilable.name) # error: Revealed type: `T.nilable(String)`
+T.reveal_type(nilable.age) # error: Revealed type: `T.nilable(Integer)`
+
+# Union types
+UnionData = Data.define(
+  :value, #: Integer | String
+)
+
+union = UnionData.new(value: 42)
+T.reveal_type(union.value) # error: Revealed type: `T.any(Integer, String)`
+
+# Generic collection types
+CollectionData = Data.define(
+  :items, #: Array[String]
+  :lookup, #: Hash[Symbol, Integer]
+)
+
+generic = CollectionData.new(items: ["a"], lookup: {foo: 1})
+T.reveal_type(generic.items) # error: Revealed type: `T::Array[String]`
+T.reveal_type(generic.lookup) # error: Revealed type: `T::Hash[Symbol, Integer]`
+
+# Boolean type
+BoolData = Data.define(
+  :flag, #: bool
+)
+
+bool_data = BoolData.new(flag: true)
+T.reveal_type(bool_data.flag) # error: Revealed type: `T::Boolean`
+
+# ============================================================================
+# Partially typed (y is T.untyped)
+# ============================================================================
+
+PartiallyTyped = Data.define(
+  :x, #: Integer
+  :y,
+)
+
+partial = PartiallyTyped.new(x: 1, y: "anything")
+T.reveal_type(partial.x) # error: Revealed type: `Integer`
+T.reveal_type(partial.y) # error: Revealed type: `T.untyped`
+
+# ============================================================================
+# Block with additional methods
+# ============================================================================
+
+DataWithMethods = Data.define(
+  :name, #: String
+  :age, #: Integer
+) do
+  #: -> String
+  def greeting = "Hello #{name}, age #{age}"
+end
+
+obj = DataWithMethods.new(name: "Alice", age: 30)
+T.assert_type!(obj.name, String)
+T.assert_type!(obj.age, Integer)
+T.reveal_type(obj.greeting) # error: Revealed type: `String`
+
+# ============================================================================
+# Fully qualified ::Data.define
+# ============================================================================
+
+QualifiedData = ::Data.define(
+  :value, #: Float
+)
+
+qd = QualifiedData.new(value: 1.0)
+T.assert_type!(qd.value, Float)
+
+# ============================================================================
+# Single member
+# ============================================================================
+
+SingleMember = Data.define(
+  :id, #: Integer
+)
+
+single = SingleMember.new(id: 42)
+T.assert_type!(single.id, Integer)
+
+# ============================================================================
+# Many members (5+)
+# ============================================================================
+
+ManyMembers = Data.define(
+  :a, #: Integer
+  :b, #: String
+  :c, #: Float
+  :d, #: Symbol
+  :e, #: bool
+)
+
+many = ManyMembers.new(a: 1, b: "hi", c: 1.0, d: :sym, e: true)
+T.assert_type!(many.a, Integer)
+T.assert_type!(many.b, String)
+T.assert_type!(many.c, Float)
+T.assert_type!(many.d, Symbol)
+T.assert_type!(many.e, T::Boolean)
+
+# ============================================================================
+# Nested in modules
+# ============================================================================
+
+module Payments
+  Invoice = Data.define(
+    :id, #: Integer
+    :total, #: Numeric
+  )
+
+  inv = Invoice.new(id: 1, total: 99.99)
+  T.assert_type!(inv.id, Integer)
+  T.assert_type!(inv.total, Numeric)
+
+  Invoice.new(id: "bad", total: 1) # error: Expected `Integer` but found `String("bad")`
+end
+
+# ============================================================================
+# Malformed type comment — falls back to T.untyped without crashing
+# ============================================================================
+
+MalformedType = Data.define(
+  :x, #: !!!  # error: Failed to parse RBS type
+  :y, #: Integer
+)
+
+# x should degrade to T.untyped due to parse failure
+mal = MalformedType.new(x: "anything", y: 42)
+T.reveal_type(mal.x) # error: Revealed type: `T.untyped`
+T.reveal_type(mal.y) # error: Revealed type: `Integer`

--- a/test/testdata/rbs/data_define_members_edge_cases.rb
+++ b/test/testdata/rbs/data_define_members_edge_cases.rb
@@ -1,0 +1,146 @@
+# typed: true
+# enable-experimental-rbs-comments: true
+
+# ============================================================================
+# No typed members — should not add anything extra, members stay untyped
+# ============================================================================
+
+UntypedData = Data.define(:x, :y)
+
+untyped = UntypedData.new(x: 1, y: 2)
+T.reveal_type(untyped.x) # error: Revealed type: `T.untyped`
+T.reveal_type(untyped.y) # error: Revealed type: `T.untyped`
+
+# ============================================================================
+# Explicit initialize with sig in block takes precedence over inline types
+# ============================================================================
+
+MoneyWithDefault = Data.define(
+  :amount, #: Numeric
+  :currency, #: String
+) do
+  #: (amount: Numeric, ?currency: String) -> void
+  def initialize(amount:, currency: "USD") = super
+end
+
+mwd = MoneyWithDefault.new(amount: 10)
+T.assert_type!(mwd.amount, Numeric)
+T.assert_type!(mwd.currency, String)
+
+# ============================================================================
+# Block with methods + inline types (no explicit initialize) — types work
+# ============================================================================
+
+DataWithMethodsAndTypes = Data.define(
+  :x, #: Integer
+  :y, #: String
+) do
+  #: -> String
+  def to_s = "#{x},#{y}"
+end
+
+dmt = DataWithMethodsAndTypes.new(x: 1, y: "hello")
+T.reveal_type(dmt.x) # error: Revealed type: `Integer`
+T.reveal_type(dmt.y) # error: Revealed type: `String`
+
+# ============================================================================
+# Block with methods but no typed members — members stay untyped
+# ============================================================================
+
+DataWithMethodsOnly = Data.define(:x, :y) do
+  #: -> String
+  def to_s = "#{x},#{y}"
+end
+
+dmo = DataWithMethodsOnly.new(x: 1, y: 2)
+T.reveal_type(dmo.x) # error: Revealed type: `T.untyped`
+T.reveal_type(dmo.y) # error: Revealed type: `T.untyped`
+
+# ============================================================================
+# Empty block with typed members
+# ============================================================================
+
+EmptyBlockTyped = Data.define(
+  :x, #: Integer
+) do
+end
+
+ebt = EmptyBlockTyped.new(x: 42)
+T.reveal_type(ebt.x) # error: Revealed type: `Integer`
+
+# ============================================================================
+# Scoped Data class (Foo::Data) — should NOT be rewritten
+# ============================================================================
+
+module Foo
+  class Data
+    def self.define(*args); end
+  end
+end
+
+NotRealData = Foo::Data.define(
+  :x, #: Integer # error: Argument does not have asserted type `Integer`
+)
+
+# ============================================================================
+# Interaction with traditional Sorbet sig annotations
+# ============================================================================
+
+# Traditional sig + bare-super initialize (no inline types) works via Data.cc
+SorbetMoney = Data.define(:amount, :currency) do
+  extend T::Sig
+
+  sig { params(amount: Numeric, currency: String).void }
+  def initialize(amount:, currency:) = super
+end
+
+sm = SorbetMoney.new(amount: 10, currency: "CAD")
+T.assert_type!(sm.amount, Numeric)
+T.assert_type!(sm.currency, String)
+SorbetMoney.new(amount: "bad", currency: "CAD") # error: Expected `Numeric` but found `String("bad")`
+
+# Sorbet sig + initialize WITH inline types — explicit Sorbet sig takes precedence
+BothSigStyles = Data.define(
+  :x, #: Integer
+  :y, #: String
+) do
+  extend T::Sig
+
+  sig { params(x: Numeric, y: String).void }
+  def initialize(x:, y:) = super
+end
+
+# Sorbet sig's Numeric takes precedence over inline #: Integer
+bs = BothSigStyles.new(x: 1, y: "hi")
+T.assert_type!(bs.x, Numeric)
+T.assert_type!(bs.y, String)
+
+# RBS method sig + initialize WITH inline types — explicit RBS sig takes precedence
+RbsBothStyles = Data.define(
+  :x, #: Integer
+  :y, #: String
+) do
+  #: (x: Numeric, y: String) -> void
+  def initialize(x:, y:) = super
+end
+
+# RBS sig's Numeric takes precedence over inline #: Integer
+rbs = RbsBothStyles.new(x: 1, y: "hi")
+T.assert_type!(rbs.x, Numeric)
+T.assert_type!(rbs.y, String)
+
+# Sorbet sig + non-bare-super — readers fall back to untyped even with sig
+CoercedData = Data.define(:amount, :currency) do
+  extend T::Sig
+
+  sig { params(amount: Numeric, currency: String).void }
+  def initialize(amount:, currency:)
+    super(amount: amount.to_i, currency: currency)
+  end
+end
+
+cd = CoercedData.new(amount: 10, currency: "CAD")
+T.reveal_type(cd.amount) # error: Revealed type: `T.untyped`
+T.reveal_type(cd.currency) # error: Revealed type: `T.untyped`
+# The sig still constrains the constructor even though readers are untyped
+CoercedData.new(amount: :bad, currency: "CAD") # error: Expected `Numeric` but found `Symbol(:bad)`


### PR DESCRIPTION
## Summary

Add support for typing `Data.define` members using inline RBS comments on the symbol arguments. This solves the problem that Data.define members are always `T.untyped` with zero runtime cost — the type annotations live in comments that only the static analyzer reads.

```ruby
Point = Data.define(
  :x, #: Integer
  :y, #: String
)

point = Point.new(x: 1, y: "hello")
T.assert_type!(point.x, Integer)    # typed!
T.assert_type!(point.y, String)     # typed!
Point.new(x: "bad", y: "hello")     # error: Expected `Integer`
Point.new(x: 1)                     # error: Missing required keyword argument `y`
```

Based on the typed Data.define approach originally designed by @cbothner in [sorbet/sorbet#8079](https://github.com/sorbet/sorbet/pull/8079). This PR adds the RBS inline syntax (zero runtime cost) and incorporates the conservative bare-super check from @jez's [review feedback](https://github.com/sorbet/sorbet/pull/8079#pullrequestreview-2242849268) on that PR.

Addresses https://github.com/sorbet/sorbet/issues/10055

## Design decisions (informed by [#8079 review](https://github.com/sorbet/sorbet/pull/8079#pullrequestreview-2242849268))

Following @jez's principle that *"the default assumption should be 'Sorbet doesn't do anything' and only if a certain set of very precise constraints are met should Sorbet do something"*:

- **Bare super required**: Typed readers are only created when the `initialize` body is exactly bare `super` (desugars to `send(untypedSuper, [ZSuperArgs])`). When the user transforms values (e.g., `super(x: x.to_i)`), readers conservatively fall back to `T.untyped`. This is the `canCreateTypedAccessors()` check ported from #8079.

- **`self.[]` left untyped**: Sorbet cannot overload a method to accept both positional and keyword arguments, so only `new`/`initialize` gets typed.

- **Explicit initialize takes precedence**: If the user provides both inline `#:` types AND a `def initialize` with a sig in the block, the explicit initialize wins and the inline types are ignored (see "Interaction with Sorbet-style annotations" below).

- **No partial typing surprises**: Un-annotated members get `T.untyped` in the synthesized sig. This enables gradually annotating members while preserving old behavior for unannotated ones.

## Interaction with Sorbet-style annotations

The inline `#:` syntax composes cleanly with all existing annotation styles. The Data.cc type extraction operates on the shared desugared AST, so it works identically regardless of whether the sig came from inline RBS types, an RBS method sig, or a traditional Sorbet `sig { }` block.

**Three ways to type Data.define members** (all produce equivalent type checking when the initialize body is bare `super`):

```ruby
# 1. Inline RBS types on arguments (zero runtime cost — this PR)
TypedPoint = Data.define(
  :x, #: Integer
  :y, #: String
)

# 2. RBS method sig + explicit initialize (zero runtime cost)
TypedPoint = Data.define(:x, :y) do
  #: (x: Integer, y: String) -> void
  def initialize(x:, y:) = super
end

# 3. Traditional Sorbet sig + explicit initialize (small runtime cost)
TypedPoint = Data.define(:x, :y) do
  extend T::Sig
  sig { params(x: Integer, y: String).void }
  def initialize(x:, y:) = super
end
```

**Precedence when styles are mixed:** If inline `#:` types are present AND the block contains an explicit `def initialize` (with either a Sorbet or RBS sig), the explicit initialize takes precedence and the inline types are ignored. This avoids conflicting type information:

```ruby
# The Sorbet sig's Numeric takes precedence over inline #: Integer
BothStyles = Data.define(
  :x, #: Integer        # ← ignored
  :y, #: String         # ← ignored
) do
  extend T::Sig
  sig { params(x: Numeric, y: String).void }
  def initialize(x:, y:) = super
end
T.assert_type!(BothStyles.new(x: 1, y: "hi").x, Numeric)  # Numeric, not Integer
```

**Non-bare-super fallback:** When the initialize body does anything beyond bare `super` (e.g., coercing values), readers fall back to `T.untyped` regardless of annotation style. The sig still constrains the constructor:

```ruby
CoercedData = Data.define(:amount, :currency) do
  extend T::Sig
  sig { params(amount: Numeric, currency: String).void }
  def initialize(amount:, currency:)
    super(amount: amount.to_i, currency: currency)  # not bare super
  end
end
T.reveal_type(CoercedData.new(amount: 10, currency: "CAD").amount)  # T.untyped
CoercedData.new(amount: :bad, currency: "CAD")  # error: Expected Numeric
```

## Approach

**Prism RBS pipeline** (Parse → `CommentsAssociatorPrism` → `SigsRewriterPrism`):

- **`rbs/prism/CommentsAssociatorPrism.cc`**: Detects root `Data.define(...)` / `::Data.define(...)` calls and captures `#:` comments on each symbol argument. Stored in a new `dataDefineMembersForNode` map in `CommentMapPrism` keyed by non-owning Prism call-node pointers.

- **`rbs/prism/SigsRewriterPrism.cc`**: When a `Data.define` has typed members, synthesizes Prism C AST nodes equivalent to `sig { params(x: Integer, y: String).void }` + `def initialize(x:, y:) = super` into the Data.define block body. This creates `pm_def_node_t`, `pm_parameters_node_t`, required keyword parameter nodes, and a forwarding-super node. The bare-super body is critical — it's what `canCreateTypedAccessors()` in Data.cc checks to propagate types.

**Data rewriter** (`rewriter/Data.cc`):

- **`getInitialize()`**: Finds a `def initialize` in the block body and its preceding sig.
- **`canCreateTypedAccessors()`**: Checks the initialize body is exactly bare `super`.
- **`getMemberType()`**: Extracts per-member types from the sig's `params()` call.
- When all conditions are met, generates `sig { returns(Type) }` before each reader method instead of the default `T.untyped`.

## Test coverage

**`test/testdata/rbs/data_define_members.rb`**:
- Basic typed members, wrong type errors, missing kwarg errors, extra kwarg errors
- Complex types: `String?` (nilable), `Integer | String` (union), `Array[String]`, `Hash[Symbol, Integer]`, `bool`
- Partially typed (some members `T.untyped`), `T.assert_type!` validation
- Blocks with additional methods, fully-qualified `::Data.define`
- Single member, many members (5+), nested in modules
- Malformed type comment — graceful degradation to `T.untyped`

**`test/testdata/rbs/data_define_members_edge_cases.rb`**:
- Untyped Data.define (no comments) — unchanged behavior
- Explicit initialize with defaults takes precedence over inline types
- Block with methods + inline types (no explicit initialize) — types propagate
- Block with methods only (no types) — members stay `T.untyped`
- Empty block with typed members
- Scoped `Foo::Data.define` — correctly not rewritten
- Sorbet sig interaction: traditional `sig { }` + bare-super initialize
- Mixed styles: inline `#:` types + explicit Sorbet sig → explicit wins
- Mixed styles: inline `#:` types + explicit RBS sig → explicit wins
- Non-bare-super with sig: readers untyped, constructor still constrained

## Limitations

**Single-line syntax:** The inline `#:` syntax requires spreading `Data.define` across multiple lines — each member must be on its own line to have a trailing `#:` comment. Single-line `Data.define(:x, :y)` cannot have per-member inline comments (Ruby comment syntax extends to end of line). This is inherent to using trailing comments and not something we can change.

**Multiline types:** Multiline RBS continuation (`#|`) is not supported for inline member type annotations. Each member's type must fit on a single line. For complex types that don't fit, users can fall back to the explicit initialize pattern with a full method signature. This limitation is acceptable because Data.define member types are typically simple (class names, nilable wrappers, unions).

**`self.[]` untyped:** The `self.[]` constructor method remains untyped even when members are typed. Sorbet cannot overload a method to accept both positional and keyword arguments, so only the keyword-based `new`/`initialize` path gets type constraints. This matches the behavior proposed in #8079.

Co-authored-by: Cameron Bothner <cbothner@users.noreply.github.com>
Co-authored-by: Claude <noreply@anthropic.com>
