### PR TITLE
Handle top level type aliases in Prism RBS rewriter

### DIFF
--- a/rbs/prism/CommentsAssociatorPrism.cc
+++ b/rbs/prism/CommentsAssociatorPrism.cc
@@ -284,16 +284,17 @@ int CommentsAssociatorPrism::maybeInsertStandalonePlaceholders(pm_node_list_t &n
         auto commentString = it->second.string;
         std::match_results<std::string_view::const_iterator> matches;
         if (std::regex_match(commentString.begin(), commentString.end(), matches, TYPE_ALIAS_PATTERN)) {
-            // Type aliases are only allowed in class/module bodies
+            // Type aliases are only allowed at top level or in class/module bodies
             if (!typeAliasAllowedInContext()) {
                 if (auto e = ctx.beginError(it->second.loc, core::errors::Rewriter::RBSUnusedComment)) {
                     e.setHeader("Unexpected RBS type alias comment");
                     if (!contextAllowingTypeAlias.empty()) {
                         auto loc = contextAllowingTypeAlias.back().second;
-                        e.addErrorLine(ctx.locAt(loc),
-                                       "RBS type aliases are only allowed in class and module bodies. Found in:");
+                        e.addErrorLine(
+                            ctx.locAt(loc),
+                            "RBS type aliases are only allowed at top level or in class and module bodies. Found in:");
                     } else {
-                        e.addErrorNote("RBS type aliases are only allowed in class and module bodies");
+                        e.addErrorNote("RBS type aliases are only allowed at top level or in class and module bodies");
                     }
                 }
 
@@ -375,8 +376,14 @@ void CommentsAssociatorPrism::processTrailingComments(pm_node_t *node, pm_node_l
         return;
     }
 
-    auto loc = translateLocation(node->location);
-    int endLine = core::Loc::pos2Detail(ctx.file.data(ctx), loc.endPos()).line;
+    // The program node location only spans until the last statement end (or (0, 0) for comment-only files)
+    // In order to find all top level RBS type alias comments, we need to scan every line of the program.
+    // As `maybeInsertStandalonePlaceholders()` scans up until the last line (but excluding the last line),
+    // we add 1 line to compensate
+    int endLine = PM_NODE_TYPE_P(node, PM_PROGRAM_NODE)
+                      ? posToLine(static_cast<uint32_t>(ctx.file.data(ctx).source().size())) + 1
+                      : posToLine(translateLocation(node->location).endPos());
+
     maybeInsertStandalonePlaceholders(nodes, nodes.size, lastLine, endLine);
     lastLine = endLine;
 }
@@ -1034,9 +1041,14 @@ void CommentsAssociatorPrism::walkNode(pm_node_t *node) {
         }
         case PM_PROGRAM_NODE: {
             auto *program = down_cast<pm_program_node_t>(node);
-            if (program->statements) {
-                walkStatements(program->statements->body);
-            }
+
+            // A program may contain top level RBS type alias comments
+            auto programLoc = translateLocation(node->location);
+            contextAllowingTypeAlias.push_back(make_pair(true, programLoc));
+
+            program->statements = down_cast<pm_statements_node_t>(walkBody(node, up_cast(program->statements)));
+
+            contextAllowingTypeAlias.pop_back();
             break;
         }
         case PM_STATEMENTS_NODE: {

--- a/test/BUILD
+++ b/test/BUILD
@@ -534,6 +534,10 @@ pipeline_tests(
         # todo(gdritter): fix this!
         exclude = [
             "testdata/packager/directed-*/**/*",
+            
+            # Top level RBS type alias comments are only supported in Prism
+            "testdata/rbs/signatures_type_aliases_top_level.rb",
+            "testdata/rbs/signatures_type_aliases_empty_file.rb",
         ],
     ),
     "LSPTests",
@@ -610,6 +614,10 @@ pipeline_tests(
         exclude = [
             # Specific test that is modified for Prism, contains minor differences in the exp file
             "testdata/rbs/assertions_heredoc_modified.rb",
+
+            # Top level RBS type alias comments are only supported in Prism
+            "testdata/rbs/signatures_type_aliases_top_level.rb",
+            "testdata/rbs/signatures_type_aliases_empty_file.rb",
         ],
     ),
     "PosTests",

--- a/test/testdata/rbs/signatures_type_aliases_empty_file.rb
+++ b/test/testdata/rbs/signatures_type_aliases_empty_file.rb
@@ -1,0 +1,5 @@
+# typed: strict
+# enable-experimental-rbs-comments: true
+
+#: type top_level = Integer
+#: type another = String

--- a/test/testdata/rbs/signatures_type_aliases_empty_file.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_type_aliases_empty_file.rb.rewrite-tree.exp
@@ -1,0 +1,9 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  <emptyTree>::<C type another> = ::<root>::<C T>.type_alias() do ||
+    <emptyTree>::<C String>
+  end
+
+  <emptyTree>::<C type top_level> = ::<root>::<C T>.type_alias() do ||
+    <emptyTree>::<C Integer>
+  end
+end

--- a/test/testdata/rbs/signatures_type_aliases_top_level.rb
+++ b/test/testdata/rbs/signatures_type_aliases_top_level.rb
@@ -1,0 +1,20 @@
+# typed: strict
+# enable-experimental-rbs-comments: true
+
+#: type top_level = Integer
+
+#: -> top_level
+def top_level_type_alias
+  "42"
+# ^^^^ error: Expected `Integer` but found `String("42")` for method result type
+end
+
+#: type another = Integer
+
+#: -> trailing
+def trailing_type_alias
+  42
+# ^^ error: Expected `String` but found `Integer(42)` for method result type
+end
+
+#: type trailing = String

--- a/test/testdata/rbs/signatures_type_aliases_top_level.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_type_aliases_top_level.rb.rewrite-tree.exp
@@ -1,0 +1,33 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  ::T::Sig::WithoutRuntime.sig() do ||
+    <self>.returns(<emptyTree>::<C type top_level>)
+  end
+
+  def top_level_type_alias<<todo method>>(&<blk>)
+    "42"
+  end
+
+  ::T::Sig::WithoutRuntime.sig() do ||
+    <self>.returns(<emptyTree>::<C type trailing>)
+  end
+
+  def trailing_type_alias<<todo method>>(&<blk>)
+    42
+  end
+
+  <emptyTree>::<C type top_level> = ::<root>::<C T>.type_alias() do ||
+    <emptyTree>::<C Integer>
+  end
+
+  <runtime method definition of top_level_type_alias>
+
+  <emptyTree>::<C type another> = ::<root>::<C T>.type_alias() do ||
+    <emptyTree>::<C Integer>
+  end
+
+  <runtime method definition of trailing_type_alias>
+
+  <emptyTree>::<C type trailing> = ::<root>::<C T>.type_alias() do ||
+    <emptyTree>::<C String>
+  end
+end


### PR DESCRIPTION
- closes https://github.com/Shopify/sorbet/issues/804

### Motivation
`T.type_alias` is allowed at top level, so the RBS rewriter can similary support type alias comments

This PR matches the pattern used by class and module nodes to allow type aliases to be associated with standalone placeholders. Since a program node's location range ends after the last statement (or at 0 if the program contains only comments), we scan to the end of the program to catch any trailing comments

This has only been implemented for Prism RBS rewriter, as [the whitequark rewriter has been deprecated](https://github.com/sorbet/sorbet/pull/10069)

### Test plan

Added 2 new test fixtures: `signatures_type_aliases_empty_file` and `signatures_type_aliases_top_level` (which is split out from `signatures_type_aliases` as it needs to be excluded from the whitequark test pipeline)
